### PR TITLE
feat(chemistry): add chemistry status sensors and status change events (closes #17)

### DIFF
--- a/custom_components/poolman/const.py
+++ b/custom_components/poolman/const.py
@@ -3,6 +3,7 @@
 from typing import Final
 
 DOMAIN: Final = "poolman"
+EVENT_POOLMAN: Final = "poolman_event"
 
 PLATFORMS: Final = ["sensor", "binary_sensor", "select"]
 

--- a/custom_components/poolman/coordinator.py
+++ b/custom_components/poolman/coordinator.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
@@ -29,8 +30,9 @@ from .const import (
     DEFAULT_TREATMENT,
     DEFAULT_UPDATE_INTERVAL_MINUTES,
     DOMAIN,
+    EVENT_POOLMAN,
 )
-from .domain.chemistry import compute_water_quality_score
+from .domain.chemistry import compute_chemistry_report, compute_water_quality_score
 from .domain.filtration import compute_filtration_duration
 from .domain.model import (
     FiltrationKind,
@@ -40,6 +42,7 @@ from .domain.model import (
     PoolShape,
     PoolState,
     TreatmentType,
+    compute_status_changes,
 )
 from .domain.rules import RuleEngine
 
@@ -182,14 +185,64 @@ class PoolmanCoordinator(DataUpdateCoordinator[PoolState]):
         recommendations = self.engine.evaluate(self.pool, reading, self._mode)
         filtration_hours = compute_filtration_duration(self.pool, reading, self._mode)
         water_quality_score = compute_water_quality_score(reading)
+        chemistry_report = compute_chemistry_report(reading)
 
-        return PoolState(
+        new_state = PoolState(
             mode=self._mode,
             reading=reading,
             recommendations=recommendations,
             filtration_hours=filtration_hours,
             water_quality_score=water_quality_score,
+            chemistry_report=chemistry_report,
         )
+
+        self._fire_status_change_events(new_state)
+
+        return new_state
+
+    def _fire_status_change_events(self, new_state: PoolState) -> None:
+        """Fire bus events for any status changes compared to the previous state.
+
+        Compares the new state against the previously stored state
+        (``self.data``) and fires a ``poolman_event`` for each detected
+        status transition. Skipped on the first update when no previous
+        state exists.
+
+        Args:
+            new_state: The newly computed pool state.
+        """
+        previous = self.data
+        if previous is None:
+            return
+
+        changes = compute_status_changes(previous, new_state)
+        if not changes:
+            return
+
+        device_id = self._get_device_id()
+        for change in changes:
+            self.hass.bus.async_fire(
+                EVENT_POOLMAN,
+                {
+                    "device_id": device_id,
+                    "type": change.type,
+                    "parameter": change.parameter,
+                    "previous_status": change.previous_status,
+                    "status": change.status,
+                },
+            )
+
+    def _get_device_id(self) -> str | None:
+        """Look up the device registry ID for this pool.
+
+        Returns:
+            The device ID string or None if the device is not yet registered.
+        """
+        device_registry = dr.async_get(self.hass)
+        device = device_registry.async_get_device(
+            identifiers={(DOMAIN, self.config_entry.entry_id)}
+        )
+        return device.id if device else None
 
     def get_entity_id(self, key: str) -> str | None:
         """Get configured entity ID for a sensor key.

--- a/custom_components/poolman/domain/chemistry.py
+++ b/custom_components/poolman/domain/chemistry.py
@@ -8,7 +8,10 @@ from __future__ import annotations
 
 from .model import (
     ChemicalProduct,
+    ChemistryReport,
+    ChemistryStatus,
     DosageAdjustment,
+    ParameterReport,
     Pool,
     PoolReading,
     SanitizerStatus,
@@ -205,3 +208,86 @@ def _score_range(value: float, minimum: float, target: float, maximum: float) ->
         return 100.0 * (value - minimum) / (target - minimum) if target != minimum else 100.0
 
     return 100.0 * (maximum - value) / (maximum - target) if maximum != target else 100.0
+
+
+# Threshold for good vs warning status (score out of 100)
+_STATUS_GOOD_THRESHOLD: float = 50.0
+
+
+def compute_parameter_status(
+    value: float, minimum: float, target: float, maximum: float
+) -> ParameterReport:
+    """Compute chemistry status for a single parameter value.
+
+    Classification logic:
+        - **good**: score >= 50 (inner half of acceptable range, closer to target)
+        - **warning**: 0 < score < 50, or value at boundary (outer half, near boundary)
+        - **bad**: value outside the acceptable min--max range
+
+    Args:
+        value: The measured value.
+        minimum: Lower bound of acceptable range.
+        target: Ideal value.
+        maximum: Upper bound of acceptable range.
+
+    Returns:
+        ParameterReport with status, value, range, and score.
+    """
+    score = _score_range(value, minimum, target, maximum)
+
+    if value < minimum or value > maximum:
+        status = ChemistryStatus.BAD
+    elif score >= _STATUS_GOOD_THRESHOLD:
+        status = ChemistryStatus.GOOD
+    else:
+        status = ChemistryStatus.WARNING
+
+    return ParameterReport(
+        status=status,
+        value=value,
+        target=target,
+        minimum=minimum,
+        maximum=maximum,
+        score=round(score),
+    )
+
+
+def compute_chemistry_report(reading: PoolReading) -> ChemistryReport:
+    """Compute chemistry status report for all available parameters.
+
+    Only parameters with a valid reading are evaluated. Parameters without
+    a sensor reading are left as None.
+
+    Args:
+        reading: Current sensor readings.
+
+    Returns:
+        ChemistryReport with per-parameter status reports.
+    """
+    return ChemistryReport(
+        ph=(
+            compute_parameter_status(reading.ph, PH_MIN, PH_TARGET, PH_MAX)
+            if reading.ph is not None
+            else None
+        ),
+        orp=(
+            compute_parameter_status(reading.orp, ORP_MIN_CRITICAL, ORP_TARGET, ORP_MAX)
+            if reading.orp is not None
+            else None
+        ),
+        tac=(
+            compute_parameter_status(reading.tac, TAC_MIN, TAC_TARGET, TAC_MAX)
+            if reading.tac is not None
+            else None
+        ),
+        cya=(
+            compute_parameter_status(reading.cya, CYA_MIN, CYA_TARGET, CYA_MAX)
+            if reading.cya is not None
+            else None
+        ),
+        hardness=(
+            compute_parameter_status(reading.hardness, HARDNESS_MIN, HARDNESS_TARGET, HARDNESS_MAX)
+            if reading.hardness is not None
+            else None
+        ),
+    )

--- a/custom_components/poolman/domain/model.py
+++ b/custom_components/poolman/domain/model.py
@@ -60,6 +60,14 @@ class ChemicalProduct(StrEnum):
     ACTIVE_OXYGEN_ACTIVATOR = "active_oxygen_activator"
 
 
+class ChemistryStatus(StrEnum):
+    """Status levels for individual chemistry parameters."""
+
+    GOOD = "good"
+    WARNING = "warning"
+    BAD = "bad"
+
+
 class Severity(StrEnum):
     """Severity levels for chemistry status."""
 
@@ -97,6 +105,34 @@ class SanitizerStatus(BaseModel, frozen=True):
 
     product: ChemicalProduct
     severity: Severity
+
+
+class ParameterReport(BaseModel, frozen=True):
+    """Status report for a single chemistry parameter.
+
+    Bundles the evaluated status with the reading value, target range,
+    and individual quality score for rich dashboard display.
+    """
+
+    status: ChemistryStatus
+    value: float
+    target: float
+    minimum: float
+    maximum: float
+    score: int = Field(ge=0, le=100, description="Quality score from 0 to 100")
+
+
+class ChemistryReport(BaseModel, frozen=True):
+    """Chemistry status report for all available parameters.
+
+    Each field is None when the corresponding sensor reading is unavailable.
+    """
+
+    ph: ParameterReport | None = None
+    orp: ParameterReport | None = None
+    tac: ParameterReport | None = None
+    cya: ParameterReport | None = None
+    hardness: ParameterReport | None = None
 
 
 class Pool(BaseModel):
@@ -154,6 +190,7 @@ class PoolState(BaseModel):
     recommendations: list[Recommendation] = Field(default_factory=list)
     filtration_hours: float | None = None
     water_quality_score: int | None = Field(None, ge=0, le=100)
+    chemistry_report: ChemistryReport = Field(default_factory=ChemistryReport)
 
     @property
     def water_ok(self) -> bool:
@@ -173,3 +210,75 @@ class PoolState(BaseModel):
             for r in self.recommendations
             if r.priority in (RecommendationPriority.HIGH, RecommendationPriority.CRITICAL)
         ]
+
+
+# Chemistry parameter names evaluated for status changes
+_CHEMISTRY_PARAMS: tuple[str, ...] = ("ph", "orp", "tac", "cya", "hardness")
+
+
+class StatusChange(BaseModel, frozen=True):
+    """A detected status transition between two consecutive pool state updates.
+
+    Attributes:
+        type: Event type identifier (``water_status_changed`` or
+            ``chemistry_status_changed``).
+        parameter: Which parameter changed (``water``, ``ph``, ``orp``,
+            ``tac``, ``cya``, or ``hardness``).
+        previous_status: Status before the change, or None if the parameter
+            was previously unavailable.
+        status: Status after the change, or None if the parameter became
+            unavailable.
+    """
+
+    type: str
+    parameter: str
+    previous_status: str | None
+    status: str | None
+
+
+def compute_status_changes(previous: PoolState, current: PoolState) -> list[StatusChange]:
+    """Detect status changes between two consecutive pool states.
+
+    Detects transitions in:
+        - Overall ``water_ok`` status (ok / not_ok)
+        - Individual chemistry parameter statuses (good / warning / bad)
+
+    Args:
+        previous: The previous pool state.
+        current: The current pool state.
+
+    Returns:
+        List of detected status changes. Empty if nothing changed.
+    """
+    changes: list[StatusChange] = []
+
+    # Check overall water_ok status
+    if previous.water_ok != current.water_ok:
+        changes.append(
+            StatusChange(
+                type="water_status_changed",
+                parameter="water",
+                previous_status="ok" if previous.water_ok else "not_ok",
+                status="ok" if current.water_ok else "not_ok",
+            )
+        )
+
+    # Check individual chemistry parameter statuses
+    for param in _CHEMISTRY_PARAMS:
+        prev_report: ParameterReport | None = getattr(previous.chemistry_report, param)
+        new_report: ParameterReport | None = getattr(current.chemistry_report, param)
+
+        prev_status = prev_report.status if prev_report else None
+        new_status = new_report.status if new_report else None
+
+        if prev_status != new_status:
+            changes.append(
+                StatusChange(
+                    type="chemistry_status_changed",
+                    parameter=param,
+                    previous_status=prev_status,
+                    status=new_status,
+                )
+            )
+
+    return changes

--- a/custom_components/poolman/sensor.py
+++ b/custom_components/poolman/sensor.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.typing import StateType
 
 from . import PoolmanConfigEntry
 from .coordinator import PoolmanCoordinator
-from .domain.model import PoolState
+from .domain.model import ChemistryStatus, ParameterReport, PoolState
 from .entity import PoolmanEntity
 
 
@@ -29,6 +29,29 @@ class PoolmanSensorEntityDescription(SensorEntityDescription):
 
     value_fn: Callable[[PoolState], StateType]
     extra_attrs_fn: Callable[[PoolState], dict[str, Any]] | None = None
+
+
+def _parameter_report_attrs(report: ParameterReport | None) -> dict[str, Any]:
+    """Extract extra state attributes from a parameter report.
+
+    Args:
+        report: The parameter report, or None if the reading is unavailable.
+
+    Returns:
+        Dictionary with value, target, range, and score; empty if report is None.
+    """
+    if report is None:
+        return {}
+    return {
+        "value": report.value,
+        "target": report.target,
+        "minimum": report.minimum,
+        "maximum": report.maximum,
+        "score": report.score,
+    }
+
+
+_CHEMISTRY_STATUS_OPTIONS: list[str] = list(ChemistryStatus)
 
 
 SENSOR_DESCRIPTIONS: tuple[PoolmanSensorEntityDescription, ...] = (
@@ -84,6 +107,61 @@ SENSOR_DESCRIPTIONS: tuple[PoolmanSensorEntityDescription, ...] = (
             "actions": [str(r) for r in state.recommendations],
             "critical_count": len(state.critical_recommendations),
         },
+    ),
+    PoolmanSensorEntityDescription(
+        key="ph_status",
+        translation_key="ph_status",
+        device_class=SensorDeviceClass.ENUM,
+        options=_CHEMISTRY_STATUS_OPTIONS,
+        icon="mdi:ph",
+        value_fn=lambda state: (
+            state.chemistry_report.ph.status if state.chemistry_report.ph else None
+        ),
+        extra_attrs_fn=lambda state: _parameter_report_attrs(state.chemistry_report.ph),
+    ),
+    PoolmanSensorEntityDescription(
+        key="orp_status",
+        translation_key="orp_status",
+        device_class=SensorDeviceClass.ENUM,
+        options=_CHEMISTRY_STATUS_OPTIONS,
+        icon="mdi:flash-triangle-outline",
+        value_fn=lambda state: (
+            state.chemistry_report.orp.status if state.chemistry_report.orp else None
+        ),
+        extra_attrs_fn=lambda state: _parameter_report_attrs(state.chemistry_report.orp),
+    ),
+    PoolmanSensorEntityDescription(
+        key="tac_status",
+        translation_key="tac_status",
+        device_class=SensorDeviceClass.ENUM,
+        options=_CHEMISTRY_STATUS_OPTIONS,
+        icon="mdi:water-opacity",
+        value_fn=lambda state: (
+            state.chemistry_report.tac.status if state.chemistry_report.tac else None
+        ),
+        extra_attrs_fn=lambda state: _parameter_report_attrs(state.chemistry_report.tac),
+    ),
+    PoolmanSensorEntityDescription(
+        key="cya_status",
+        translation_key="cya_status",
+        device_class=SensorDeviceClass.ENUM,
+        options=_CHEMISTRY_STATUS_OPTIONS,
+        icon="mdi:shield-sun-outline",
+        value_fn=lambda state: (
+            state.chemistry_report.cya.status if state.chemistry_report.cya else None
+        ),
+        extra_attrs_fn=lambda state: _parameter_report_attrs(state.chemistry_report.cya),
+    ),
+    PoolmanSensorEntityDescription(
+        key="hardness_status",
+        translation_key="hardness_status",
+        device_class=SensorDeviceClass.ENUM,
+        options=_CHEMISTRY_STATUS_OPTIONS,
+        icon="mdi:water-percent",
+        value_fn=lambda state: (
+            state.chemistry_report.hardness.status if state.chemistry_report.hardness else None
+        ),
+        extra_attrs_fn=lambda state: _parameter_report_attrs(state.chemistry_report.hardness),
     ),
 )
 

--- a/custom_components/poolman/strings.json
+++ b/custom_components/poolman/strings.json
@@ -121,6 +121,46 @@
       },
       "recommendations": {
         "name": "Recommendations"
+      },
+      "ph_status": {
+        "name": "pH status",
+        "state": {
+          "good": "Good",
+          "warning": "Warning",
+          "bad": "Bad"
+        }
+      },
+      "orp_status": {
+        "name": "ORP status",
+        "state": {
+          "good": "Good",
+          "warning": "Warning",
+          "bad": "Bad"
+        }
+      },
+      "tac_status": {
+        "name": "TAC status",
+        "state": {
+          "good": "Good",
+          "warning": "Warning",
+          "bad": "Bad"
+        }
+      },
+      "cya_status": {
+        "name": "CYA status",
+        "state": {
+          "good": "Good",
+          "warning": "Warning",
+          "bad": "Bad"
+        }
+      },
+      "hardness_status": {
+        "name": "Hardness status",
+        "state": {
+          "good": "Good",
+          "warning": "Warning",
+          "bad": "Bad"
+        }
       }
     },
     "binary_sensor": {

--- a/custom_components/poolman/translations/en.json
+++ b/custom_components/poolman/translations/en.json
@@ -121,6 +121,46 @@
       },
       "recommendations": {
         "name": "Recommendations"
+      },
+      "ph_status": {
+        "name": "pH status",
+        "state": {
+          "good": "Good",
+          "warning": "Warning",
+          "bad": "Bad"
+        }
+      },
+      "orp_status": {
+        "name": "ORP status",
+        "state": {
+          "good": "Good",
+          "warning": "Warning",
+          "bad": "Bad"
+        }
+      },
+      "tac_status": {
+        "name": "TAC status",
+        "state": {
+          "good": "Good",
+          "warning": "Warning",
+          "bad": "Bad"
+        }
+      },
+      "cya_status": {
+        "name": "CYA status",
+        "state": {
+          "good": "Good",
+          "warning": "Warning",
+          "bad": "Bad"
+        }
+      },
+      "hardness_status": {
+        "name": "Hardness status",
+        "state": {
+          "good": "Good",
+          "warning": "Warning",
+          "bad": "Bad"
+        }
       }
     },
     "binary_sensor": {

--- a/custom_components/poolman/translations/fr.json
+++ b/custom_components/poolman/translations/fr.json
@@ -121,6 +121,46 @@
       },
       "recommendations": {
         "name": "Recommendations"
+      },
+      "ph_status": {
+        "name": "Statut pH",
+        "state": {
+          "good": "Bon",
+          "warning": "Attention",
+          "bad": "Mauvais"
+        }
+      },
+      "orp_status": {
+        "name": "Statut ORP",
+        "state": {
+          "good": "Bon",
+          "warning": "Attention",
+          "bad": "Mauvais"
+        }
+      },
+      "tac_status": {
+        "name": "Statut TAC",
+        "state": {
+          "good": "Bon",
+          "warning": "Attention",
+          "bad": "Mauvais"
+        }
+      },
+      "cya_status": {
+        "name": "Statut CYA",
+        "state": {
+          "good": "Bon",
+          "warning": "Attention",
+          "bad": "Mauvais"
+        }
+      },
+      "hardness_status": {
+        "name": "Statut duret\u00e9",
+        "state": {
+          "good": "Bon",
+          "warning": "Attention",
+          "bad": "Mauvais"
+        }
       }
     },
     "binary_sensor": {

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -11,7 +11,7 @@ name you set during configuration.
 
 ## Sensors
 
-The integration creates 6 sensor entities:
+The integration creates 11 sensor entities:
 
 ### Reading sensors
 
@@ -44,6 +44,36 @@ The `recommendations` sensor exposes additional detail through its state attribu
 
 These attributes can be used in automations, templates, or Lovelace cards to display detailed recommendation information.
 
+### Chemistry status sensors
+
+These sensors provide a quick **good / warning / bad** status for each chemistry
+parameter. See [Water Chemistry -- Chemistry Status](water-chemistry.md#chemistry-status)
+for how the status is determined.
+
+| Entity | Name | Options | Description |
+| --- | --- | --- | --- |
+| `sensor.{pool}_ph_status` | pH status | `good`, `warning`, `bad` | pH level status |
+| `sensor.{pool}_orp_status` | ORP status | `good`, `warning`, `bad` | Oxidation-Reduction Potential status |
+| `sensor.{pool}_tac_status` | TAC status | `good`, `warning`, `bad` | Total alkalinity status |
+| `sensor.{pool}_cya_status` | CYA status | `good`, `warning`, `bad` | Cyanuric acid (stabilizer) status |
+| `sensor.{pool}_hardness_status` | Hardness status | `good`, `warning`, `bad` | Calcium hardness status |
+
+Each status sensor exposes additional detail through its state attributes:
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `value` | float | Current reading for this parameter |
+| `target` | float | Ideal target value |
+| `minimum` | float | Lower bound of the acceptable range |
+| `maximum` | float | Upper bound of the acceptable range |
+| `score` | integer | Individual quality score from 0 (poor) to 100 (perfect) |
+
+!!! tip "Dashboard ideas"
+
+    Use the status sensors to build a chemistry dashboard card that shows
+    at a glance which parameters need attention. Combine with the extra
+    attributes to display the actual reading alongside its target range.
+
 ## Binary Sensors
 
 The integration creates 2 binary sensor entities for quick status checks:
@@ -66,3 +96,60 @@ The integration creates 1 select entity to control the operational mode:
 | `select.{pool}_mode` | Pool mode | `running`, `winter_active`, `winter_passive` | Controls the current operational mode. See [Pool Modes](pool-modes.md) for details on each mode. |
 
 Changing the mode immediately triggers a data refresh and recalculation of all computed values.
+
+## Events
+
+Pool Manager fires `poolman_event` events on the Home Assistant event bus
+whenever a status transition is detected between two consecutive data updates.
+These events can be used to trigger automations (e.g. send a notification when
+pH becomes bad).
+
+!!! note
+
+    Events are **not** fired on the first data update after Home Assistant
+    starts, since there is no previous state to compare against.
+
+### Chemistry status changed
+
+Fired when an individual chemistry parameter transitions between `good`,
+`warning`, and `bad`, or becomes available/unavailable.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `device_id` | string | Device registry ID of the pool device |
+| `type` | string | `chemistry_status_changed` |
+| `parameter` | string | `ph`, `orp`, `tac`, `cya`, or `hardness` |
+| `previous_status` | string \| null | Previous status (`good`, `warning`, `bad`), or null if the parameter was unavailable |
+| `status` | string \| null | New status (`good`, `warning`, `bad`), or null if the parameter became unavailable |
+
+### Water status changed
+
+Fired when the overall water quality flips between OK and not OK (based on
+whether high/critical recommendations exist).
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `device_id` | string | Device registry ID of the pool device |
+| `type` | string | `water_status_changed` |
+| `parameter` | string | `water` |
+| `previous_status` | string | `ok` or `not_ok` |
+| `status` | string | `ok` or `not_ok` |
+
+!!! tip "Automation example"
+
+    ```yaml
+    automation:
+      - alias: "Notify when pH goes bad"
+        trigger:
+          - platform: event
+            event_type: poolman_event
+            event_data:
+              type: chemistry_status_changed
+              parameter: ph
+              status: bad
+        action:
+          - service: notify.mobile_app
+            data:
+              title: "Pool Alert"
+              message: "pH has gone out of range!"
+    ```

--- a/docs/water-chemistry.md
+++ b/docs/water-chemistry.md
@@ -21,6 +21,41 @@ and dosage calculations.
 Values within the minimum--maximum range are considered acceptable. The target
 value represents the ideal level for each parameter.
 
+## Chemistry Status
+
+Each parameter is evaluated individually and assigned one of three statuses:
+**good**, **warning**, or **bad**. These are exposed as
+[enum sensors](entities.md#chemistry-status-sensors) for use in dashboards and
+automations.
+
+### How the status is determined
+
+The status is derived from the parameter's individual quality score (the same
+score used in the [water quality score](#water-quality-score) calculation):
+
+| Status | Condition | Meaning |
+| --- | --- | --- |
+| **Good** | Score >= 50 (inner half of acceptable range) | Parameter is close to target, no attention needed |
+| **Warning** | Score < 50 but value within min--max range | Parameter is drifting towards boundary, should be monitored |
+| **Bad** | Value outside the acceptable min--max range | Parameter is out of range, action required |
+
+??? example "pH status example"
+
+    For pH with range 6.8--7.8 and target 7.2:
+
+    | pH reading | Score | Status |
+    | --- | --- | --- |
+    | 7.2 | 100 | Good (at target) |
+    | 7.0 | 50 | Good (midpoint, inner half) |
+    | 6.9 | 25 | Warning (outer half, nearing boundary) |
+    | 6.8 | 0 | Warning (at boundary, still in range) |
+    | 6.5 | 0 | Bad (below range) |
+    | 8.0 | 0 | Bad (above range) |
+
+When a parameter's status changes between updates, a `poolman_event` is fired
+on the Home Assistant event bus so you can trigger automations. See
+[Events](entities.md#events) for the full event schema.
+
 ## Water Quality Score
 
 The **water quality score** is a 0--100% value displayed by the

--- a/tests/domain/test_chemistry.py
+++ b/tests/domain/test_chemistry.py
@@ -5,7 +5,23 @@ from __future__ import annotations
 import pytest
 
 from custom_components.poolman.domain.chemistry import (
+    CYA_MAX,
+    CYA_MIN,
+    CYA_TARGET,
+    HARDNESS_MAX,
+    HARDNESS_MIN,
+    HARDNESS_TARGET,
+    ORP_MAX,
+    ORP_MIN_CRITICAL,
+    ORP_TARGET,
+    PH_MAX,
+    PH_MIN,
     PH_TARGET,
+    TAC_MAX,
+    TAC_MIN,
+    TAC_TARGET,
+    compute_chemistry_report,
+    compute_parameter_status,
     compute_ph_adjustment,
     compute_sanitizer_status,
     compute_tac_adjustment,
@@ -13,6 +29,7 @@ from custom_components.poolman.domain.chemistry import (
 )
 from custom_components.poolman.domain.model import (
     ChemicalProduct,
+    ChemistryStatus,
     Pool,
     PoolReading,
     Severity,
@@ -233,3 +250,139 @@ class TestWaterQualityScore:
         score = compute_water_quality_score(reading)
         assert score is not None
         assert expected_min <= score <= expected_max
+
+
+class TestParameterStatus:
+    """Tests for individual parameter status computation."""
+
+    def test_at_target_returns_good(self) -> None:
+        report = compute_parameter_status(PH_TARGET, PH_MIN, PH_TARGET, PH_MAX)
+        assert report.status == ChemistryStatus.GOOD
+        assert report.score == 100
+
+    def test_inner_half_returns_good(self) -> None:
+        # pH 7.0 is midpoint between min (6.8) and target (7.2) -> score = 50
+        report = compute_parameter_status(7.0, PH_MIN, PH_TARGET, PH_MAX)
+        assert report.status == ChemistryStatus.GOOD
+        assert report.score >= 50
+
+    def test_outer_half_returns_warning(self) -> None:
+        # pH 6.9 is in range but closer to boundary than target
+        report = compute_parameter_status(6.9, PH_MIN, PH_TARGET, PH_MAX)
+        assert report.status == ChemistryStatus.WARNING
+        assert 0 < report.score < 50
+
+    def test_at_min_boundary_returns_warning(self) -> None:
+        # At exact minimum, score is 0 but still within range
+        report = compute_parameter_status(PH_MIN, PH_MIN, PH_TARGET, PH_MAX)
+        assert report.status == ChemistryStatus.WARNING
+        assert report.score == 0
+
+    def test_at_max_boundary_returns_warning(self) -> None:
+        # At exact maximum, score is 0 but still within range
+        report = compute_parameter_status(PH_MAX, PH_MIN, PH_TARGET, PH_MAX)
+        assert report.status == ChemistryStatus.WARNING
+        assert report.score == 0
+
+    def test_below_min_returns_bad(self) -> None:
+        report = compute_parameter_status(6.5, PH_MIN, PH_TARGET, PH_MAX)
+        assert report.status == ChemistryStatus.BAD
+        assert report.score == 0
+
+    def test_above_max_returns_bad(self) -> None:
+        report = compute_parameter_status(8.5, PH_MIN, PH_TARGET, PH_MAX)
+        assert report.status == ChemistryStatus.BAD
+        assert report.score == 0
+
+    def test_report_contains_range_info(self) -> None:
+        report = compute_parameter_status(7.2, PH_MIN, PH_TARGET, PH_MAX)
+        assert report.value == 7.2
+        assert report.target == PH_TARGET
+        assert report.minimum == PH_MIN
+        assert report.maximum == PH_MAX
+
+    @pytest.mark.parametrize(
+        ("value", "minimum", "target", "maximum", "expected_status"),
+        [
+            # ORP ranges
+            (ORP_TARGET, ORP_MIN_CRITICAL, ORP_TARGET, ORP_MAX, ChemistryStatus.GOOD),
+            (600, ORP_MIN_CRITICAL, ORP_TARGET, ORP_MAX, ChemistryStatus.BAD),
+            (950, ORP_MIN_CRITICAL, ORP_TARGET, ORP_MAX, ChemistryStatus.BAD),
+            # TAC ranges
+            (TAC_TARGET, TAC_MIN, TAC_TARGET, TAC_MAX, ChemistryStatus.GOOD),
+            (60, TAC_MIN, TAC_TARGET, TAC_MAX, ChemistryStatus.BAD),
+            # CYA ranges
+            (CYA_TARGET, CYA_MIN, CYA_TARGET, CYA_MAX, ChemistryStatus.GOOD),
+            (10, CYA_MIN, CYA_TARGET, CYA_MAX, ChemistryStatus.BAD),
+            # Hardness ranges
+            (HARDNESS_TARGET, HARDNESS_MIN, HARDNESS_TARGET, HARDNESS_MAX, ChemistryStatus.GOOD),
+            (100, HARDNESS_MIN, HARDNESS_TARGET, HARDNESS_MAX, ChemistryStatus.BAD),
+        ],
+    )
+    def test_status_across_parameters(
+        self,
+        value: float,
+        minimum: float,
+        target: float,
+        maximum: float,
+        expected_status: ChemistryStatus,
+    ) -> None:
+        report = compute_parameter_status(value, minimum, target, maximum)
+        assert report.status == expected_status
+
+
+class TestChemistryReport:
+    """Tests for the full chemistry status report."""
+
+    def test_good_reading_all_good(self, good_reading: PoolReading) -> None:
+        report = compute_chemistry_report(good_reading)
+        assert report.ph is not None
+        assert report.ph.status == ChemistryStatus.GOOD
+        assert report.orp is not None
+        assert report.orp.status == ChemistryStatus.GOOD
+        assert report.tac is not None
+        assert report.tac.status == ChemistryStatus.GOOD
+        assert report.cya is not None
+        assert report.cya.status == ChemistryStatus.GOOD
+        assert report.hardness is not None
+        assert report.hardness.status == ChemistryStatus.GOOD
+
+    def test_bad_reading_all_bad(self, bad_reading: PoolReading) -> None:
+        report = compute_chemistry_report(bad_reading)
+        assert report.ph is not None
+        assert report.ph.status == ChemistryStatus.BAD
+        assert report.orp is not None
+        assert report.orp.status == ChemistryStatus.BAD
+        assert report.tac is not None
+        assert report.tac.status == ChemistryStatus.BAD
+        assert report.hardness is not None
+        assert report.hardness.status == ChemistryStatus.BAD
+
+    def test_empty_reading_all_none(self, empty_reading: PoolReading) -> None:
+        report = compute_chemistry_report(empty_reading)
+        assert report.ph is None
+        assert report.orp is None
+        assert report.tac is None
+        assert report.cya is None
+        assert report.hardness is None
+
+    def test_partial_reading(self) -> None:
+        reading = PoolReading(ph=7.2, orp=750.0)
+        report = compute_chemistry_report(reading)
+        assert report.ph is not None
+        assert report.ph.status == ChemistryStatus.GOOD
+        assert report.orp is not None
+        assert report.orp.status == ChemistryStatus.GOOD
+        assert report.tac is None
+        assert report.cya is None
+        assert report.hardness is None
+
+    def test_report_contains_range_attributes(self) -> None:
+        reading = PoolReading(ph=7.2)
+        report = compute_chemistry_report(reading)
+        assert report.ph is not None
+        assert report.ph.value == 7.2
+        assert report.ph.target == PH_TARGET
+        assert report.ph.minimum == PH_MIN
+        assert report.ph.maximum == PH_MAX
+        assert report.ph.score == 100

--- a/tests/domain/test_model.py
+++ b/tests/domain/test_model.py
@@ -1,0 +1,224 @@
+"""Tests for pool domain model status change detection."""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.poolman.domain.model import (
+    ChemistryReport,
+    ChemistryStatus,
+    ParameterReport,
+    PoolState,
+    Recommendation,
+    RecommendationPriority,
+    RecommendationType,
+    StatusChange,
+    compute_status_changes,
+)
+
+
+def _make_report(
+    status: ChemistryStatus,
+    value: float = 7.2,
+    target: float = 7.2,
+    minimum: float = 6.8,
+    maximum: float = 7.8,
+    score: int = 100,
+) -> ParameterReport:
+    """Build a ParameterReport with the given status and sensible defaults."""
+    return ParameterReport(
+        status=status,
+        value=value,
+        target=target,
+        minimum=minimum,
+        maximum=maximum,
+        score=score,
+    )
+
+
+def _make_state(
+    *,
+    ph_status: ChemistryStatus | None = None,
+    orp_status: ChemistryStatus | None = None,
+    tac_status: ChemistryStatus | None = None,
+    cya_status: ChemistryStatus | None = None,
+    hardness_status: ChemistryStatus | None = None,
+    recommendations: list[Recommendation] | None = None,
+) -> PoolState:
+    """Build a PoolState with the given chemistry statuses."""
+    return PoolState(
+        chemistry_report=ChemistryReport(
+            ph=_make_report(ph_status) if ph_status else None,
+            orp=_make_report(orp_status) if orp_status else None,
+            tac=_make_report(tac_status) if tac_status else None,
+            cya=_make_report(cya_status) if cya_status else None,
+            hardness=_make_report(hardness_status) if hardness_status else None,
+        ),
+        recommendations=recommendations or [],
+    )
+
+
+class TestComputeStatusChanges:
+    """Tests for compute_status_changes."""
+
+    def test_no_changes_returns_empty(self) -> None:
+        state = _make_state(ph_status=ChemistryStatus.GOOD)
+        assert compute_status_changes(state, state) == []
+
+    def test_identical_states_returns_empty(self) -> None:
+        state1 = _make_state(
+            ph_status=ChemistryStatus.GOOD,
+            orp_status=ChemistryStatus.WARNING,
+        )
+        state2 = _make_state(
+            ph_status=ChemistryStatus.GOOD,
+            orp_status=ChemistryStatus.WARNING,
+        )
+        assert compute_status_changes(state1, state2) == []
+
+    def test_ph_good_to_warning(self) -> None:
+        prev = _make_state(ph_status=ChemistryStatus.GOOD)
+        curr = _make_state(ph_status=ChemistryStatus.WARNING)
+        changes = compute_status_changes(prev, curr)
+
+        assert len(changes) == 1
+        assert changes[0] == StatusChange(
+            type="chemistry_status_changed",
+            parameter="ph",
+            previous_status="good",
+            status="warning",
+        )
+
+    def test_ph_warning_to_bad(self) -> None:
+        prev = _make_state(ph_status=ChemistryStatus.WARNING)
+        curr = _make_state(ph_status=ChemistryStatus.BAD)
+        changes = compute_status_changes(prev, curr)
+
+        assert len(changes) == 1
+        assert changes[0].parameter == "ph"
+        assert changes[0].previous_status == "warning"
+        assert changes[0].status == "bad"
+
+    def test_ph_bad_to_good(self) -> None:
+        prev = _make_state(ph_status=ChemistryStatus.BAD)
+        curr = _make_state(ph_status=ChemistryStatus.GOOD)
+        changes = compute_status_changes(prev, curr)
+
+        assert len(changes) == 1
+        assert changes[0].previous_status == "bad"
+        assert changes[0].status == "good"
+
+    def test_parameter_becomes_available(self) -> None:
+        prev = _make_state()
+        curr = _make_state(ph_status=ChemistryStatus.GOOD)
+        changes = compute_status_changes(prev, curr)
+
+        assert len(changes) == 1
+        assert changes[0].parameter == "ph"
+        assert changes[0].previous_status is None
+        assert changes[0].status == "good"
+
+    def test_parameter_becomes_unavailable(self) -> None:
+        prev = _make_state(ph_status=ChemistryStatus.GOOD)
+        curr = _make_state()
+        changes = compute_status_changes(prev, curr)
+
+        assert len(changes) == 1
+        assert changes[0].parameter == "ph"
+        assert changes[0].previous_status == "good"
+        assert changes[0].status is None
+
+    def test_multiple_parameters_change(self) -> None:
+        prev = _make_state(
+            ph_status=ChemistryStatus.GOOD,
+            orp_status=ChemistryStatus.GOOD,
+            tac_status=ChemistryStatus.WARNING,
+        )
+        curr = _make_state(
+            ph_status=ChemistryStatus.WARNING,
+            orp_status=ChemistryStatus.BAD,
+            tac_status=ChemistryStatus.WARNING,
+        )
+        changes = compute_status_changes(prev, curr)
+
+        # pH and ORP changed, TAC unchanged
+        assert len(changes) == 2
+        params = {c.parameter for c in changes}
+        assert params == {"ph", "orp"}
+
+    def test_water_ok_to_not_ok(self) -> None:
+        prev = _make_state()  # No recommendations -> water_ok=True
+        critical_rec = Recommendation(
+            type=RecommendationType.CHEMICAL,
+            priority=RecommendationPriority.HIGH,
+            message="pH too high",
+        )
+        curr = _make_state(recommendations=[critical_rec])
+        changes = compute_status_changes(prev, curr)
+
+        water_changes = [c for c in changes if c.type == "water_status_changed"]
+        assert len(water_changes) == 1
+        assert water_changes[0].parameter == "water"
+        assert water_changes[0].previous_status == "ok"
+        assert water_changes[0].status == "not_ok"
+
+    def test_water_not_ok_to_ok(self) -> None:
+        critical_rec = Recommendation(
+            type=RecommendationType.CHEMICAL,
+            priority=RecommendationPriority.HIGH,
+            message="pH too high",
+        )
+        prev = _make_state(recommendations=[critical_rec])
+        curr = _make_state()
+        changes = compute_status_changes(prev, curr)
+
+        water_changes = [c for c in changes if c.type == "water_status_changed"]
+        assert len(water_changes) == 1
+        assert water_changes[0].previous_status == "not_ok"
+        assert water_changes[0].status == "ok"
+
+    def test_water_ok_unchanged_no_event(self) -> None:
+        state = _make_state()  # water_ok=True
+        changes = compute_status_changes(state, state)
+        water_changes = [c for c in changes if c.type == "water_status_changed"]
+        assert water_changes == []
+
+    def test_water_and_chemistry_change_together(self) -> None:
+        critical_rec = Recommendation(
+            type=RecommendationType.CHEMICAL,
+            priority=RecommendationPriority.HIGH,
+            message="pH too high",
+        )
+        prev = _make_state(ph_status=ChemistryStatus.GOOD)
+        curr = _make_state(
+            ph_status=ChemistryStatus.BAD,
+            recommendations=[critical_rec],
+        )
+        changes = compute_status_changes(prev, curr)
+
+        types = {c.type for c in changes}
+        assert types == {"water_status_changed", "chemistry_status_changed"}
+
+    @pytest.mark.parametrize("param", ["ph", "orp", "tac", "cya", "hardness"])
+    def test_all_chemistry_params_detected(self, param: str) -> None:
+        good_report = _make_report(ChemistryStatus.GOOD)
+        bad_report = _make_report(ChemistryStatus.BAD)
+        prev = PoolState(
+            chemistry_report=ChemistryReport(**{param: good_report}),
+        )
+        curr = PoolState(
+            chemistry_report=ChemistryReport(**{param: bad_report}),
+        )
+        changes = compute_status_changes(prev, curr)
+
+        chem_changes = [c for c in changes if c.type == "chemistry_status_changed"]
+        assert len(chem_changes) == 1
+        assert chem_changes[0].parameter == param
+
+    def test_both_none_no_change(self) -> None:
+        prev = _make_state()  # All chemistry params None
+        curr = _make_state()
+        changes = compute_status_changes(prev, curr)
+
+        chem_changes = [c for c in changes if c.type == "chemistry_status_changed"]
+        assert chem_changes == []


### PR DESCRIPTION
Add per-parameter chemistry status (good/warning/bad) as enum sensors with rich extra attributes (value, target, min, max, score), and fire poolman_event bus events on status transitions for use in automations.

- Add ChemistryStatus, ParameterReport, ChemistryReport, StatusChange models and compute_status_changes() to domain layer
- Add compute_parameter_status() and compute_chemistry_report() to chemistry module with score-based classification
- Add 5 enum sensor descriptions (ph/orp/tac/cya/hardness status) with _parameter_report_attrs helper
- Wire chemistry report computation and event firing in coordinator
- Add EVENT_POOLMAN constant and device registry lookup
- Update strings.json and translations (en, fr)
- Add tests for parameter status, chemistry report, and status changes
- Document status sensors, events, and classification logic in docs

Closes #17 