### PR TITLE
feat(filtration): add automatic pump scheduling and control (closes #11)

### DIFF
--- a/custom_components/poolman/const.py
+++ b/custom_components/poolman/const.py
@@ -1,11 +1,12 @@
 """Constants for the Pool Manager integration."""
 
+from datetime import time
 from typing import Final
 
 DOMAIN: Final = "poolman"
 EVENT_POOLMAN: Final = "poolman_event"
 
-PLATFORMS: Final = ["sensor", "binary_sensor", "select"]
+PLATFORMS: Final = ["sensor", "binary_sensor", "select", "switch", "time", "number", "event"]
 
 # Config entry keys
 CONF_POOL_NAME: Final = "pool_name"
@@ -66,9 +67,15 @@ MODE_WINTER_ACTIVE: Final = "winter_active"
 MODE_WINTER_PASSIVE: Final = "winter_passive"
 MODES: Final = [MODE_RUNNING, MODE_WINTER_ACTIVE, MODE_WINTER_PASSIVE]
 
+# Filtration control event types
+EVENT_FILTRATION_STARTED: Final = "filtration_started"
+EVENT_FILTRATION_STOPPED: Final = "filtration_stopped"
+
 # Default values
 DEFAULT_VOLUME_M3: Final = 50.0
 DEFAULT_TREATMENT: Final = TREATMENT_CHLORINE
 DEFAULT_FILTRATION_KIND: Final = FILTRATION_KIND_SAND
 DEFAULT_PUMP_FLOW_M3H: Final = 10.0
 DEFAULT_UPDATE_INTERVAL_MINUTES: Final = 5
+DEFAULT_FILTRATION_START_TIME: Final = time(10, 0)
+DEFAULT_FILTRATION_DURATION_HOURS: Final = 8.0

--- a/custom_components/poolman/coordinator.py
+++ b/custom_components/poolman/coordinator.py
@@ -19,6 +19,7 @@ from .const import (
     CONF_ORP_ENTITY,
     CONF_OUTDOOR_TEMPERATURE_ENTITY,
     CONF_PH_ENTITY,
+    CONF_PUMP_ENTITY,
     CONF_PUMP_FLOW_M3H,
     CONF_SHAPE,
     CONF_TAC_ENTITY,
@@ -45,6 +46,7 @@ from .domain.model import (
     compute_status_changes,
 )
 from .domain.rules import RuleEngine
+from .scheduler import FiltrationScheduler
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -72,6 +74,12 @@ class PoolmanCoordinator(DataUpdateCoordinator[PoolState]):
         self.pool = self._build_pool()
         self.engine = RuleEngine()
         self._mode = PoolMode.RUNNING
+
+        # Filtration scheduler: only created when a pump entity is configured
+        pump_entity_id = self._get_config(CONF_PUMP_ENTITY)
+        self.scheduler: FiltrationScheduler | None = (
+            FiltrationScheduler(hass, pump_entity_id) if pump_entity_id else None
+        )
 
     def _get_config(self, key: str, default: Any = None) -> Any:
         """Get a config value, checking options first then data.

--- a/custom_components/poolman/event.py
+++ b/custom_components/poolman/event.py
@@ -1,0 +1,67 @@
+"""Event platform for Pool Manager filtration events."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, ClassVar
+
+from homeassistant.components.event import EventEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import PoolmanConfigEntry
+from .const import EVENT_FILTRATION_STARTED, EVENT_FILTRATION_STOPPED
+from .coordinator import PoolmanCoordinator
+from .entity import PoolmanEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: PoolmanConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Pool Manager event entities."""
+    coordinator: PoolmanCoordinator = entry.runtime_data
+    if coordinator.scheduler is not None:
+        async_add_entities([PoolmanFiltrationEvent(coordinator)])
+
+
+class PoolmanFiltrationEvent(PoolmanEntity, EventEntity):
+    """Event entity that fires when filtration starts or stops.
+
+    Listens to the FiltrationScheduler via its on_event() callback
+    and triggers HA event entity updates with schedule details.
+    """
+
+    _attr_translation_key = "filtration"
+    _attr_icon = "mdi:pump"
+    _attr_event_types: ClassVar[list[str]] = [EVENT_FILTRATION_STARTED, EVENT_FILTRATION_STOPPED]
+
+    def __init__(self, coordinator: PoolmanCoordinator) -> None:
+        """Initialize the filtration event entity."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}_filtration"
+        self._unsub_scheduler: Callable[[], None] | None = None
+
+    async def async_added_to_hass(self) -> None:
+        """Register scheduler event listener when added to HA."""
+        await super().async_added_to_hass()
+        if self.coordinator.scheduler is not None:
+            self._unsub_scheduler = self.coordinator.scheduler.on_event(self._on_scheduler_event)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Unregister scheduler event listener when removed from HA."""
+        if self._unsub_scheduler is not None:
+            self._unsub_scheduler()
+            self._unsub_scheduler = None
+        await super().async_will_remove_from_hass()
+
+    def _on_scheduler_event(self, event_type: str, event_data: dict[str, Any]) -> None:
+        """Handle a scheduler event by triggering the HA event entity.
+
+        Args:
+            event_type: The event type (filtration_started or filtration_stopped).
+            event_data: Schedule details (start_time, duration_hours, end_time).
+        """
+        self._trigger_event(event_type, event_data)
+        self.async_write_ha_state()

--- a/custom_components/poolman/number.py
+++ b/custom_components/poolman/number.py
@@ -1,0 +1,75 @@
+"""Number platform for Pool Manager filtration duration."""
+
+from __future__ import annotations
+
+import contextlib
+
+from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, UnitOfTime
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
+
+from . import PoolmanConfigEntry
+from .const import DEFAULT_FILTRATION_DURATION_HOURS
+from .coordinator import PoolmanCoordinator
+from .entity import PoolmanEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: PoolmanConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Pool Manager number entities."""
+    coordinator: PoolmanCoordinator = entry.runtime_data
+    if coordinator.scheduler is not None:
+        async_add_entities([PoolmanFiltrationDuration(coordinator)])
+
+
+class PoolmanFiltrationDuration(PoolmanEntity, NumberEntity, RestoreEntity):
+    """Number entity for configuring the daily filtration duration in hours.
+
+    The value is persisted across restarts via RestoreEntity. Changes
+    immediately recalculate the scheduler triggers.
+    """
+
+    _attr_translation_key = "filtration_duration_setting"
+    _attr_icon = "mdi:timer-outline"
+    _attr_device_class = NumberDeviceClass.DURATION
+    _attr_native_unit_of_measurement = UnitOfTime.HOURS
+    _attr_native_min_value = 1.0
+    _attr_native_max_value = 24.0
+    _attr_native_step = 0.5
+    _attr_mode = NumberMode.BOX
+
+    def __init__(self, coordinator: PoolmanCoordinator) -> None:
+        """Initialize the filtration duration entity."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}_filtration_duration_setting"
+        self._attr_native_value: float = DEFAULT_FILTRATION_DURATION_HOURS
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the last known duration value."""
+        await super().async_added_to_hass()
+        if (
+            last_state := await self.async_get_last_state()
+        ) is not None and last_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+            with contextlib.suppress(ValueError, TypeError):
+                self._attr_native_value = float(last_state.state)
+        # Sync the scheduler with the restored (or default) value
+        if self.coordinator.scheduler is not None:
+            await self.coordinator.scheduler.async_update_schedule(
+                duration_hours=self._attr_native_value,
+            )
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set a new filtration duration.
+
+        Args:
+            value: The new duration in hours.
+        """
+        self._attr_native_value = value
+        if self.coordinator.scheduler is not None:
+            await self.coordinator.scheduler.async_update_schedule(duration_hours=value)
+        self.async_write_ha_state()

--- a/custom_components/poolman/scheduler.py
+++ b/custom_components/poolman/scheduler.py
@@ -1,0 +1,281 @@
+"""Filtration scheduler for daily pump on/off control.
+
+Manages time-based triggers to automatically turn a pump switch on and off
+according to a user-defined start time and duration.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from collections.abc import Callable
+from datetime import date, datetime, time, timedelta
+
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.helpers.event import async_track_time_change
+from homeassistant.util import dt as dt_util
+
+from .const import (
+    DEFAULT_FILTRATION_DURATION_HOURS,
+    DEFAULT_FILTRATION_START_TIME,
+    EVENT_FILTRATION_STARTED,
+    EVENT_FILTRATION_STOPPED,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+type EventCallback = Callable[[str, dict[str, object]], None]
+
+
+class FiltrationScheduler:
+    """Manages daily filtration pump on/off scheduling.
+
+    Registers time-based triggers with Home Assistant to turn a pump switch
+    on at a configured start time and off after a configured duration.
+    Supports cross-midnight schedules and restart recovery.
+    """
+
+    def __init__(self, hass: HomeAssistant, pump_entity_id: str) -> None:
+        """Initialize the filtration scheduler.
+
+        Args:
+            hass: Home Assistant instance.
+            pump_entity_id: Entity ID of the pump switch to control.
+        """
+        self._hass = hass
+        self._pump_entity_id = pump_entity_id
+        self._enabled = False
+        self._start_time: time = DEFAULT_FILTRATION_START_TIME
+        self._duration_hours: float = DEFAULT_FILTRATION_DURATION_HOURS
+        self._unsub_start: CALLBACK_TYPE | None = None
+        self._unsub_stop: CALLBACK_TYPE | None = None
+        self._listeners: list[EventCallback] = []
+
+    @property
+    def enabled(self) -> bool:
+        """Return whether the scheduler is currently active."""
+        return self._enabled
+
+    @property
+    def start_time(self) -> time:
+        """Return the configured daily start time."""
+        return self._start_time
+
+    @property
+    def duration_hours(self) -> float:
+        """Return the configured filtration duration in hours."""
+        return self._duration_hours
+
+    @property
+    def end_time(self) -> time:
+        """Compute the end time from start time and duration.
+
+        Handles cross-midnight wrap-around naturally via timedelta.
+
+        Returns:
+            The time at which filtration should stop.
+        """
+        start_dt = datetime.combine(date.today(), self._start_time)
+        end_dt = start_dt + timedelta(hours=self._duration_hours)
+        return end_dt.time()
+
+    @property
+    def pump_entity_id(self) -> str:
+        """Return the pump entity ID being controlled."""
+        return self._pump_entity_id
+
+    def is_in_active_window(self, now: datetime | None = None) -> bool:
+        """Check if a given time falls within the active filtration window.
+
+        Handles both same-day (e.g., 10:00-18:00) and cross-midnight
+        (e.g., 22:00-06:00) windows. The start boundary is inclusive,
+        the end boundary is exclusive.
+
+        Args:
+            now: The time to check. Defaults to the current HA-aware time.
+
+        Returns:
+            True if the time is within the active window.
+        """
+        if now is None:
+            now = dt_util.now()
+        now_time = now.time()
+        start = self._start_time
+        end = self.end_time
+
+        if end > start:
+            # Same-day window (e.g., 10:00-18:00)
+            return start <= now_time < end
+        # Cross-midnight window (e.g., 22:00-06:00)
+        return now_time >= start or now_time < end
+
+    def on_event(self, callback_fn: EventCallback) -> Callable[[], None]:
+        """Register a listener for scheduler events.
+
+        Args:
+            callback_fn: Called with (event_type, event_data) when events occur.
+
+        Returns:
+            An unsubscribe function to remove the listener.
+        """
+        self._listeners.append(callback_fn)
+
+        def _unsubscribe() -> None:
+            self._listeners.remove(callback_fn)
+
+        return _unsubscribe
+
+    def _event_data(self) -> dict[str, object]:
+        """Build the event data payload with current schedule details.
+
+        Returns:
+            Dictionary with start_time, duration_hours, and end_time.
+        """
+        return {
+            "start_time": self._start_time.isoformat(),
+            "duration_hours": self._duration_hours,
+            "end_time": self.end_time.isoformat(),
+        }
+
+    @callback
+    def _notify(self, event_type: str) -> None:
+        """Notify all registered listeners of a scheduler event.
+
+        Args:
+            event_type: The event type (e.g., filtration_started).
+        """
+        data = self._event_data()
+        for listener in self._listeners:
+            listener(event_type, data)
+
+    async def async_enable(self) -> None:
+        """Enable the filtration schedule.
+
+        Sets up daily time triggers for pump start and stop. If the current
+        time falls within the active window, the pump is turned on immediately.
+        """
+        self._enabled = True
+        self._setup_triggers()
+
+        if self.is_in_active_window():
+            await self._async_start_pump()
+        _LOGGER.debug(
+            "Filtration control enabled: %s for %.1fh (pump: %s)",
+            self._start_time,
+            self._duration_hours,
+            self._pump_entity_id,
+        )
+
+    async def async_disable(self) -> None:
+        """Disable the filtration schedule and turn off the pump.
+
+        Cancels all time triggers and immediately turns the pump off.
+        """
+        self._enabled = False
+        self._cancel_triggers()
+        await self._async_stop_pump()
+        _LOGGER.debug("Filtration control disabled (pump: %s)", self._pump_entity_id)
+
+    async def async_update_schedule(
+        self,
+        start_time: time | None = None,
+        duration_hours: float | None = None,
+    ) -> None:
+        """Update schedule parameters and recalculate triggers.
+
+        If the scheduler is enabled, triggers are re-registered and the
+        pump state is immediately adjusted based on the new active window.
+
+        Args:
+            start_time: New start time, or None to keep current.
+            duration_hours: New duration in hours, or None to keep current.
+        """
+        if start_time is not None:
+            self._start_time = start_time
+        if duration_hours is not None:
+            self._duration_hours = duration_hours
+
+        if not self._enabled:
+            return
+
+        self._cancel_triggers()
+        self._setup_triggers()
+
+        # Immediately adjust pump state to the new window
+        if self.is_in_active_window():
+            await self._async_start_pump()
+        else:
+            await self._async_stop_pump()
+
+        _LOGGER.debug(
+            "Filtration schedule updated: %s for %.1fh",
+            self._start_time,
+            self._duration_hours,
+        )
+
+    def _setup_triggers(self) -> None:
+        """Register time-based triggers for pump start and stop."""
+        end = self.end_time
+
+        self._unsub_start = async_track_time_change(
+            self._hass,
+            self._on_start_time,
+            hour=self._start_time.hour,
+            minute=self._start_time.minute,
+            second=0,
+        )
+        self._unsub_stop = async_track_time_change(
+            self._hass,
+            self._on_stop_time,
+            hour=end.hour,
+            minute=end.minute,
+            second=0,
+        )
+
+    def _cancel_triggers(self) -> None:
+        """Cancel all registered time triggers."""
+        if self._unsub_start is not None:
+            self._unsub_start()
+            self._unsub_start = None
+        if self._unsub_stop is not None:
+            self._unsub_stop()
+            self._unsub_stop = None
+
+    async def _on_start_time(self, _now: datetime) -> None:
+        """Handle the daily start time trigger."""
+        if self._enabled:
+            await self._async_start_pump()
+
+    async def _on_stop_time(self, _now: datetime) -> None:
+        """Handle the daily stop time trigger."""
+        if self._enabled:
+            await self._async_stop_pump()
+
+    async def _async_start_pump(self) -> None:
+        """Turn on the pump switch and notify listeners."""
+        _LOGGER.info("Starting filtration pump: %s", self._pump_entity_id)
+        await self._hass.services.async_call(
+            "switch",
+            "turn_on",
+            {"entity_id": self._pump_entity_id},
+        )
+        self._notify(EVENT_FILTRATION_STARTED)
+
+    async def _async_stop_pump(self) -> None:
+        """Turn off the pump switch and notify listeners."""
+        _LOGGER.info("Stopping filtration pump: %s", self._pump_entity_id)
+        await self._hass.services.async_call(
+            "switch",
+            "turn_off",
+            {"entity_id": self._pump_entity_id},
+        )
+        self._notify(EVENT_FILTRATION_STOPPED)
+
+    @callback
+    def async_cancel(self) -> None:
+        """Cancel all triggers and clear listeners.
+
+        Called during integration unload to clean up resources.
+        """
+        self._cancel_triggers()
+        self._listeners.clear()

--- a/custom_components/poolman/strings.json
+++ b/custom_components/poolman/strings.json
@@ -180,6 +180,34 @@
           "winter_passive": "Passive wintering"
         }
       }
+    },
+    "switch": {
+      "filtration_control": {
+        "name": "Filtration control"
+      }
+    },
+    "time": {
+      "filtration_start_time": {
+        "name": "Filtration start time"
+      }
+    },
+    "number": {
+      "filtration_duration_setting": {
+        "name": "Filtration duration"
+      }
+    },
+    "event": {
+      "filtration": {
+        "name": "Filtration",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "filtration_started": "Filtration started",
+              "filtration_stopped": "Filtration stopped"
+            }
+          }
+        }
+      }
     }
   },
   "selector": {

--- a/custom_components/poolman/switch.py
+++ b/custom_components/poolman/switch.py
@@ -1,0 +1,66 @@
+"""Switch platform for Pool Manager filtration control."""
+
+from __future__ import annotations
+
+from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
+from homeassistant.const import STATE_ON
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
+
+from . import PoolmanConfigEntry
+from .coordinator import PoolmanCoordinator
+from .entity import PoolmanEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: PoolmanConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Pool Manager switch entities."""
+    coordinator: PoolmanCoordinator = entry.runtime_data
+    if coordinator.scheduler is not None:
+        async_add_entities([PoolmanFiltrationControlSwitch(coordinator)])
+
+
+class PoolmanFiltrationControlSwitch(PoolmanEntity, SwitchEntity, RestoreEntity):
+    """Switch entity to enable or disable automatic filtration scheduling.
+
+    When turned on, the scheduler will turn the configured pump switch on
+    at the scheduled start time and off after the configured duration,
+    every day. When turned off, the pump is turned off immediately and
+    all scheduled triggers are cancelled.
+    """
+
+    _attr_device_class = SwitchDeviceClass.SWITCH
+    _attr_translation_key = "filtration_control"
+    _attr_icon = "mdi:pump"
+
+    def __init__(self, coordinator: PoolmanCoordinator) -> None:
+        """Initialize the filtration control switch."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}_filtration_control"
+        self._attr_is_on = False
+
+    async def async_added_to_hass(self) -> None:
+        """Restore last known state and re-enable scheduling if needed."""
+        await super().async_added_to_hass()
+        if (last_state := await self.async_get_last_state()) is not None:
+            self._attr_is_on = last_state.state == STATE_ON
+            if self._attr_is_on and self.coordinator.scheduler is not None:
+                await self.coordinator.scheduler.async_enable()
+
+    async def async_turn_on(self, **kwargs: object) -> None:
+        """Enable automatic filtration scheduling."""
+        self._attr_is_on = True
+        if self.coordinator.scheduler is not None:
+            await self.coordinator.scheduler.async_enable()
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs: object) -> None:
+        """Disable automatic filtration scheduling and turn off the pump."""
+        self._attr_is_on = False
+        if self.coordinator.scheduler is not None:
+            await self.coordinator.scheduler.async_disable()
+        self.async_write_ha_state()

--- a/custom_components/poolman/time.py
+++ b/custom_components/poolman/time.py
@@ -1,0 +1,71 @@
+"""Time platform for Pool Manager filtration start time."""
+
+from __future__ import annotations
+
+from datetime import time
+
+from homeassistant.components.time import TimeEntity
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.util import dt as dt_util
+
+from . import PoolmanConfigEntry
+from .const import DEFAULT_FILTRATION_START_TIME
+from .coordinator import PoolmanCoordinator
+from .entity import PoolmanEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: PoolmanConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Pool Manager time entities."""
+    coordinator: PoolmanCoordinator = entry.runtime_data
+    if coordinator.scheduler is not None:
+        async_add_entities([PoolmanFiltrationStartTime(coordinator)])
+
+
+class PoolmanFiltrationStartTime(PoolmanEntity, TimeEntity, RestoreEntity):
+    """Time entity for configuring the daily filtration start time.
+
+    The value is persisted across restarts via RestoreEntity. Changes
+    immediately recalculate the scheduler triggers.
+    """
+
+    _attr_translation_key = "filtration_start_time"
+    _attr_icon = "mdi:clock-start"
+
+    def __init__(self, coordinator: PoolmanCoordinator) -> None:
+        """Initialize the filtration start time entity."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}_filtration_start_time"
+        self._attr_native_value: time = DEFAULT_FILTRATION_START_TIME
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the last known start time value."""
+        await super().async_added_to_hass()
+        if (
+            last_state := await self.async_get_last_state()
+        ) is not None and last_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+            restored = dt_util.parse_time(last_state.state)
+            if restored is not None:
+                self._attr_native_value = restored
+        # Sync the scheduler with the restored (or default) value
+        if self.coordinator.scheduler is not None:
+            await self.coordinator.scheduler.async_update_schedule(
+                start_time=self._attr_native_value,
+            )
+
+    async def async_set_value(self, value: time) -> None:
+        """Set a new filtration start time.
+
+        Args:
+            value: The new start time.
+        """
+        self._attr_native_value = value
+        if self.coordinator.scheduler is not None:
+            await self.coordinator.scheduler.async_update_schedule(start_time=value)
+        self.async_write_ha_state()

--- a/custom_components/poolman/translations/en.json
+++ b/custom_components/poolman/translations/en.json
@@ -180,6 +180,34 @@
           "winter_passive": "Passive wintering"
         }
       }
+    },
+    "switch": {
+      "filtration_control": {
+        "name": "Filtration control"
+      }
+    },
+    "time": {
+      "filtration_start_time": {
+        "name": "Filtration start time"
+      }
+    },
+    "number": {
+      "filtration_duration_setting": {
+        "name": "Filtration duration"
+      }
+    },
+    "event": {
+      "filtration": {
+        "name": "Filtration",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "filtration_started": "Filtration started",
+              "filtration_stopped": "Filtration stopped"
+            }
+          }
+        }
+      }
     }
   },
   "selector": {

--- a/custom_components/poolman/translations/fr.json
+++ b/custom_components/poolman/translations/fr.json
@@ -180,6 +180,34 @@
           "winter_passive": "Hivernage passif"
         }
       }
+    },
+    "switch": {
+      "filtration_control": {
+        "name": "Contr\u00f4le de la filtration"
+      }
+    },
+    "time": {
+      "filtration_start_time": {
+        "name": "Heure de d\u00e9but de filtration"
+      }
+    },
+    "number": {
+      "filtration_duration_setting": {
+        "name": "Dur\u00e9e de filtration"
+      }
+    },
+    "event": {
+      "filtration": {
+        "name": "Filtration",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "filtration_started": "Filtration d\u00e9marr\u00e9e",
+              "filtration_stopped": "Filtration arr\u00eat\u00e9e"
+            }
+          }
+        }
+      }
     }
   },
   "selector": {

--- a/demo/fake_pool_sensor/const.py
+++ b/demo/fake_pool_sensor/const.py
@@ -7,7 +7,7 @@ from typing import Final
 
 DOMAIN: Final = "fake_pool_sensor"
 
-PLATFORMS: Final = ["sensor", "number"]
+PLATFORMS: Final = ["sensor", "number", "switch"]
 
 CONF_DEVICE_NAME: Final = "device_name"
 

--- a/demo/fake_pool_sensor/switch.py
+++ b/demo/fake_pool_sensor/switch.py
@@ -1,0 +1,60 @@
+"""Switch platform for Fake Pool Sensor (pool pump simulator)."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import FakePoolSensorConfigEntry
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: FakePoolSensorConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the fake pool pump switch."""
+    async_add_entities([FakePoolPumpSwitch(entry)])
+
+
+class FakePoolPumpSwitch(SwitchEntity):
+    """Simulated pool pump switch for demo and testing.
+
+    A simple on/off switch that represents a pool pump. No actual
+    hardware is controlled.
+    """
+
+    _attr_has_entity_name = True
+    _attr_name = "Pump"
+    _attr_device_class = SwitchDeviceClass.SWITCH
+    _attr_icon = "mdi:pump"
+
+    def __init__(self, entry: FakePoolSensorConfigEntry) -> None:
+        """Initialize the fake pump switch."""
+        self._attr_unique_id = f"{entry.entry_id}_pump"
+        self._attr_is_on = False
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.entry_id)},
+            name=entry.title,
+            manufacturer="Fake Pool Sensor",
+            model="Simulator",
+        )
+
+    async def async_turn_on(self, **kwargs: object) -> None:
+        """Turn the pump on."""
+        self._attr_is_on = True
+        self.async_write_ha_state()
+        _LOGGER.debug("Fake pool pump turned ON")
+
+    async def async_turn_off(self, **kwargs: object) -> None:
+        """Turn the pump off."""
+        self._attr_is_on = False
+        self.async_write_ha_state()
+        _LOGGER.debug("Fake pool pump turned OFF")

--- a/demo/setup.py
+++ b/demo/setup.py
@@ -350,6 +350,7 @@ def main() -> None:
 
     # Wait for fake sensor entities to appear
     wait_for_entities(token, "sensor.fake_pool_sensor_", expected_count=7)
+    wait_for_entities(token, "switch.fake_pool_sensor_", expected_count=1)
 
     # Set up Pool Manager (three-step flow: pool basics, chemistry, filtration)
     if has_integration(entries, "poolman"):
@@ -375,6 +376,7 @@ def main() -> None:
                 {
                     "filtration_kind": "sand",
                     "pump_flow_m3h": 10.0,
+                    "pump_entity": "switch.fake_pool_sensor_pump",
                     **FAKE_FILTRATION_SENSORS,
                 },
             ],

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -97,6 +97,39 @@ The integration creates 1 select entity to control the operational mode:
 
 Changing the mode immediately triggers a data refresh and recalculation of all computed values.
 
+## Filtration Control Entities
+
+When a **pump switch entity** is configured in the integration, additional
+entities are created for automatic pump scheduling. These entities are
+**conditional** -- they only appear when a pump entity is set.
+
+See [Filtration Control](filtration-control.md) for full details on
+scheduling behavior, cross-midnight support, and automation examples.
+
+### Switch
+
+| Entity | Name | Description |
+| --- | --- | --- |
+| `switch.{pool}_filtration_control` | Filtration control | Enables or disables automatic daily pump scheduling. Turning off immediately stops the pump. |
+
+### Time
+
+| Entity | Name | Default | Description |
+| --- | --- | --- | --- |
+| `time.{pool}_filtration_start_time` | Filtration start time | 10:00 | Daily start time for the filtration cycle |
+
+### Number
+
+| Entity | Name | Default | Range | Description |
+| --- | --- | --- | --- | --- |
+| `number.{pool}_filtration_duration_setting` | Filtration duration | 8 h | 1--24 h (step 0.5) | Duration of each daily filtration cycle |
+
+### Event
+
+| Entity | Name | Event types | Description |
+| --- | --- | --- | --- |
+| `event.{pool}_filtration` | Filtration | `filtration_started`, `filtration_stopped` | Fires when the pump is turned on or off by the scheduler |
+
 ## Events
 
 Pool Manager fires `poolman_event` events on the Home Assistant event bus

--- a/docs/filtration-control.md
+++ b/docs/filtration-control.md
@@ -1,0 +1,165 @@
+---
+icon: lucide/pump
+---
+
+# Filtration Control
+
+When a **pump switch entity** is configured in the integration, Pool Manager
+can automatically control your pool pump on a daily schedule. This feature
+creates additional entities that let you enable scheduling, set a start time,
+and configure a duration -- the pump then turns on and off automatically
+every day.
+
+## Prerequisites
+
+Filtration control requires a **switch entity** that controls your pool pump.
+This can be:
+
+- A smart plug or relay connected via any integration (Shelly, Sonoff, Tasmota, etc.)
+- An ESPHome GPIO switch
+- A virtual switch for testing
+
+Configure the pump entity in the integration's filtration settings step
+(or update it later via **Settings > Devices & Services > Pool Manager > Configure**).
+
+!!! note
+    All filtration control entities are **conditional**: they are only created
+    when a pump entity is configured. If you remove the pump entity from the
+    configuration, these entities will no longer appear.
+
+## Entities
+
+When a pump entity is configured, the following entities are added to your
+Pool Manager device:
+
+### Switch
+
+| Entity | Name | Description |
+| --- | --- | --- |
+| `switch.{pool}_filtration_control` | Filtration control | Enables or disables automatic daily pump scheduling |
+
+When turned **on**, the scheduler activates and the pump follows the configured
+schedule. When turned **off**, the pump is turned off **immediately** and all
+scheduled triggers are cancelled.
+
+### Time
+
+| Entity | Name | Default | Description |
+| --- | --- | --- | --- |
+| `time.{pool}_filtration_start_time` | Filtration start time | 10:00 | Daily start time for the filtration cycle |
+
+### Number
+
+| Entity | Name | Default | Range | Step | Description |
+| --- | --- | --- | --- | --- | --- |
+| `number.{pool}_filtration_duration_setting` | Filtration duration | 8 h | 1--24 h | 0.5 h | Duration of each daily filtration cycle |
+
+### Event
+
+| Entity | Name | Event types | Description |
+| --- | --- | --- | --- |
+| `event.{pool}_filtration` | Filtration | `filtration_started`, `filtration_stopped` | Fires when the pump is turned on or off by the scheduler |
+
+Each event carries the following attributes:
+
+| Attribute | Type | Example | Description |
+| --- | --- | --- | --- |
+| `start_time` | string (ISO time) | `"10:00:00"` | Configured start time |
+| `duration_hours` | float | `8.0` | Configured duration in hours |
+| `end_time` | string (ISO time) | `"18:00:00"` | Computed end time |
+
+## Scheduling Behavior
+
+### Daily cycle
+
+The scheduler registers time-based triggers for the start and end of each
+daily filtration window. At the configured start time, the pump turns on.
+After the configured duration elapses, the pump turns off.
+
+### Cross-midnight schedules
+
+Schedules that cross midnight are fully supported. For example, a start time
+of **22:00** with a duration of **8 hours** creates a window from 22:00 to
+06:00 the next day.
+
+### Restart recovery
+
+Both the filtration control switch state and the time/duration settings are
+persisted across Home Assistant restarts using `RestoreEntity`. On restart:
+
+1. The switch restores its last known on/off state
+2. The time and duration entities restore their last values
+3. If the switch was on, the scheduler re-enables and checks whether the
+   current time falls within the active window -- if so, the pump is turned
+   on immediately
+
+### Mid-cycle changes
+
+Changing the start time or duration while the scheduler is enabled takes
+effect **immediately**:
+
+- Triggers are recalculated for the new schedule
+- The pump state is adjusted right away: if the current time is now inside
+  the new window the pump turns on; if outside, it turns off
+
+### Disabling filtration control
+
+Turning off the filtration control switch:
+
+1. Cancels all scheduled triggers
+2. Turns the pump **off immediately**
+
+## Automation Examples
+
+### Notify when filtration starts
+
+```yaml
+automation:
+  - alias: "Notify filtration started"
+    trigger:
+      - platform: state
+        entity_id: event.demo_pool_filtration
+        attribute: event_type
+        to: "filtration_started"
+    action:
+      - action: notify.notify
+        data:
+          title: "Pool"
+          message: "Filtration pump started"
+```
+
+### Adjust duration based on recommended filtration
+
+You can use the recommended filtration sensor to automatically adjust
+the filtration duration setting:
+
+```yaml
+automation:
+  - alias: "Sync filtration duration with recommendation"
+    trigger:
+      - platform: state
+        entity_id: sensor.demo_pool_filtration_duration
+    condition:
+      - condition: not
+        conditions:
+          - condition: state
+            entity_id: sensor.demo_pool_filtration_duration
+            state: "unavailable"
+    action:
+      - action: number.set_value
+        target:
+          entity_id: number.demo_pool_filtration_duration_setting
+        data:
+          value: "{{ states('sensor.demo_pool_filtration_duration') | float }}"
+```
+
+## Relationship to the Recommended Filtration Sensor
+
+The `sensor.{pool}_filtration_duration` entity is an **advisory** value
+computed from water temperature, filter type, outdoor temperature, and pump
+capacity (see [Pool Modes](pool-modes.md#filtration) for the algorithm).
+
+The filtration control feature provides **active control**: it actually
+turns the pump on and off. The two work independently -- the recommended
+duration does not automatically set the control duration. You can connect
+them via automation (see example above) or set the duration manually.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,7 +34,7 @@ These sensors enable additional recommendations and improve the water quality sc
 
 | Entity | Type | Description |
 | --- | --- | --- |
-| Pump switch | switch | Pump on/off entity (reserved for future use) |
+| Pump switch | switch | Pump on/off entity. Enables [filtration control](filtration-control.md) (automatic daily pump scheduling). |
 
 ### Compatible sensor sources
 
@@ -132,7 +132,7 @@ The third step configures your filtration system.
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| Pump entity | entity (switch) | Pump switch (reserved for future use) |
+| Pump entity | entity (switch) | Pump switch for [filtration control](filtration-control.md) (automatic daily scheduling) |
 | Outdoor temperature entity | entity (sensor) | Outdoor / air temperature sensor for heat stress adjustment |
 | Weather entity | entity (weather) | Weather integration entity (used as fallback for outdoor temperature) |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,8 @@ with no cloud service or specific hardware required.
 - **Filtration configuration** -- Support for different filtration
   types (sand, cartridge, diatomaceous earth, glass) with dedicated
   pump and temperature sensor settings
+- **Automatic pump control** -- Daily pump scheduling with configurable
+  start time and duration when a pump switch entity is configured
 - **3 operational modes** -- Running, Active Wintering, and Passive
   Wintering, each with adapted filtration logic and rule behavior
 - **Hardware agnostic** -- Works with any sensor source: dedicated pool
@@ -53,7 +55,8 @@ All computations happen locally. No cloud API, no account, no internet connectio
 ## Quick Links
 
 - [Getting Started](getting-started.md) -- Prerequisites, installation, and configuration
-- [Entities](entities.md) -- Sensors, binary sensors, and select entities created by the integration
+- [Entities](entities.md) -- Sensors, binary sensors, select, and filtration control entities
+- [Filtration Control](filtration-control.md) -- Automatic pump scheduling, events, and automation examples
 - [Pool Modes](pool-modes.md) -- Running, Active Wintering, and Passive Wintering explained
 - [Water Chemistry](water-chemistry.md) -- Target ranges, scoring, and parameter details
 - [Rules & Recommendations](rules-and-recommendations.md) -- The rule engine, priority system, and chemical dosages

--- a/docs/pool-modes.md
+++ b/docs/pool-modes.md
@@ -91,6 +91,14 @@ duration and the turnover time.
 
 The result is bounded between **2 hours minimum** and **24 hours maximum**.
 
+!!! info "Advisory vs Active Control"
+
+    The recommended filtration duration computed here is an **advisory** value
+    exposed as a sensor entity. It does not directly control your pump.
+    If you have a pump switch configured, you can use
+    [Filtration Control](filtration-control.md) for automatic daily pump
+    scheduling, and optionally sync the duration via automation.
+
 ??? example "Calculation examples"
 
     **Example 1 --- Standard conditions**

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,335 @@
+"""Tests for the FiltrationScheduler."""
+
+from __future__ import annotations
+
+from datetime import datetime, time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.poolman.const import (
+    DEFAULT_FILTRATION_DURATION_HOURS,
+    DEFAULT_FILTRATION_START_TIME,
+    EVENT_FILTRATION_STARTED,
+    EVENT_FILTRATION_STOPPED,
+)
+from custom_components.poolman.scheduler import FiltrationScheduler
+
+
+@pytest.fixture
+def hass() -> MagicMock:
+    """Return a mock Home Assistant instance."""
+    mock_hass = MagicMock()
+    mock_hass.services.async_call = AsyncMock()
+    return mock_hass
+
+
+@pytest.fixture
+def scheduler(hass: MagicMock) -> FiltrationScheduler:
+    """Return a FiltrationScheduler with default settings."""
+    return FiltrationScheduler(hass, "switch.pool_pump")
+
+
+class TestIsInActiveWindow:
+    """Tests for is_in_active_window with same-day and cross-midnight windows."""
+
+    def test_same_day_inside_window(self, scheduler: FiltrationScheduler) -> None:
+        """Time within a same-day window should return True."""
+        # Default: 10:00 start, 8h duration -> 10:00-18:00
+        now = datetime(2025, 7, 15, 14, 0, 0)
+        assert scheduler.is_in_active_window(now) is True
+
+    def test_same_day_before_window(self, scheduler: FiltrationScheduler) -> None:
+        """Time before a same-day window should return False."""
+        now = datetime(2025, 7, 15, 9, 0, 0)
+        assert scheduler.is_in_active_window(now) is False
+
+    def test_same_day_after_window(self, scheduler: FiltrationScheduler) -> None:
+        """Time after a same-day window should return False."""
+        now = datetime(2025, 7, 15, 19, 0, 0)
+        assert scheduler.is_in_active_window(now) is False
+
+    def test_same_day_at_start_boundary(self, scheduler: FiltrationScheduler) -> None:
+        """Start time boundary is inclusive."""
+        now = datetime(2025, 7, 15, 10, 0, 0)
+        assert scheduler.is_in_active_window(now) is True
+
+    def test_same_day_at_end_boundary(self, scheduler: FiltrationScheduler) -> None:
+        """End time boundary is exclusive."""
+        now = datetime(2025, 7, 15, 18, 0, 0)
+        assert scheduler.is_in_active_window(now) is False
+
+    def test_cross_midnight_evening_side(
+        self, scheduler: FiltrationScheduler, hass: MagicMock
+    ) -> None:
+        """Time in the evening part of a cross-midnight window should return True."""
+        scheduler = FiltrationScheduler(hass, "switch.pool_pump")
+        scheduler._start_time = time(22, 0)
+        scheduler._duration_hours = 8.0  # 22:00-06:00
+        now = datetime(2025, 7, 15, 23, 30, 0)
+        assert scheduler.is_in_active_window(now) is True
+
+    def test_cross_midnight_morning_side(
+        self, scheduler: FiltrationScheduler, hass: MagicMock
+    ) -> None:
+        """Time in the morning part of a cross-midnight window should return True."""
+        scheduler = FiltrationScheduler(hass, "switch.pool_pump")
+        scheduler._start_time = time(22, 0)
+        scheduler._duration_hours = 8.0  # 22:00-06:00
+        now = datetime(2025, 7, 16, 4, 0, 0)
+        assert scheduler.is_in_active_window(now) is True
+
+    def test_cross_midnight_outside_window(
+        self, scheduler: FiltrationScheduler, hass: MagicMock
+    ) -> None:
+        """Time outside a cross-midnight window should return False."""
+        scheduler = FiltrationScheduler(hass, "switch.pool_pump")
+        scheduler._start_time = time(22, 0)
+        scheduler._duration_hours = 8.0  # 22:00-06:00
+        now = datetime(2025, 7, 16, 12, 0, 0)
+        assert scheduler.is_in_active_window(now) is False
+
+
+class TestEndTime:
+    """Tests for end_time computation."""
+
+    def test_same_day_end_time(self, scheduler: FiltrationScheduler) -> None:
+        """10:00 + 8h = 18:00."""
+        assert scheduler.end_time == time(18, 0)
+
+    def test_cross_midnight_end_time(self, hass: MagicMock) -> None:
+        """22:00 + 8h = 06:00 next day."""
+        scheduler = FiltrationScheduler(hass, "switch.pool_pump")
+        scheduler._start_time = time(22, 0)
+        scheduler._duration_hours = 8.0
+        assert scheduler.end_time == time(6, 0)
+
+    def test_half_hour_duration(self, hass: MagicMock) -> None:
+        """10:00 + 4.5h = 14:30."""
+        scheduler = FiltrationScheduler(hass, "switch.pool_pump")
+        scheduler._start_time = time(10, 0)
+        scheduler._duration_hours = 4.5
+        assert scheduler.end_time == time(14, 30)
+
+
+class TestEnableDisable:
+    """Tests for enable/disable scheduling behavior."""
+
+    @pytest.mark.asyncio
+    async def test_enable_sets_enabled_flag(self, scheduler: FiltrationScheduler) -> None:
+        """Enabling the scheduler should set the enabled property."""
+        with patch.object(scheduler, "_setup_triggers"):
+            await scheduler.async_enable()
+        assert scheduler.enabled is True
+
+    @pytest.mark.asyncio
+    async def test_disable_clears_enabled_flag(self, scheduler: FiltrationScheduler) -> None:
+        """Disabling the scheduler should clear the enabled property."""
+        with patch.object(scheduler, "_setup_triggers"):
+            await scheduler.async_enable()
+        await scheduler.async_disable()
+        assert scheduler.enabled is False
+
+    @pytest.mark.asyncio
+    async def test_enable_starts_pump_when_in_window(
+        self, scheduler: FiltrationScheduler, hass: MagicMock
+    ) -> None:
+        """Pump should turn on immediately if enabled during the active window."""
+        with (
+            patch.object(scheduler, "_setup_triggers"),
+            patch.object(scheduler, "is_in_active_window", return_value=True),
+        ):
+            await scheduler.async_enable()
+        hass.services.async_call.assert_called_once_with(
+            "switch", "turn_on", {"entity_id": "switch.pool_pump"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_enable_does_not_start_pump_outside_window(
+        self, scheduler: FiltrationScheduler, hass: MagicMock
+    ) -> None:
+        """Pump should NOT turn on if enabled outside the active window."""
+        with (
+            patch.object(scheduler, "_setup_triggers"),
+            patch.object(scheduler, "is_in_active_window", return_value=False),
+        ):
+            await scheduler.async_enable()
+        hass.services.async_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_disable_turns_off_pump(
+        self, scheduler: FiltrationScheduler, hass: MagicMock
+    ) -> None:
+        """Disabling should always turn the pump off."""
+        with patch.object(scheduler, "_setup_triggers"):
+            await scheduler.async_enable()
+        hass.services.async_call.reset_mock()
+        await scheduler.async_disable()
+        hass.services.async_call.assert_called_once_with(
+            "switch", "turn_off", {"entity_id": "switch.pool_pump"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_disable_cancels_triggers(self, scheduler: FiltrationScheduler) -> None:
+        """Disabling should cancel any registered time triggers."""
+        unsub_start = MagicMock()
+        unsub_stop = MagicMock()
+        scheduler._unsub_start = unsub_start
+        scheduler._unsub_stop = unsub_stop
+        await scheduler.async_disable()
+        unsub_start.assert_called_once()
+        unsub_stop.assert_called_once()
+        assert scheduler._unsub_start is None
+        assert scheduler._unsub_stop is None
+
+
+class TestUpdateSchedule:
+    """Tests for async_update_schedule mid-cycle recalculation."""
+
+    @pytest.mark.asyncio
+    async def test_update_start_time(self, scheduler: FiltrationScheduler) -> None:
+        """Updating start_time should store the new value."""
+        await scheduler.async_update_schedule(start_time=time(14, 0))
+        assert scheduler.start_time == time(14, 0)
+
+    @pytest.mark.asyncio
+    async def test_update_duration(self, scheduler: FiltrationScheduler) -> None:
+        """Updating duration_hours should store the new value."""
+        await scheduler.async_update_schedule(duration_hours=12.0)
+        assert scheduler.duration_hours == 12.0
+
+    @pytest.mark.asyncio
+    async def test_update_when_disabled_does_not_touch_pump(
+        self, scheduler: FiltrationScheduler, hass: MagicMock
+    ) -> None:
+        """Updating schedule when disabled should not call any services."""
+        await scheduler.async_update_schedule(start_time=time(14, 0))
+        hass.services.async_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_when_enabled_recalculates(
+        self, scheduler: FiltrationScheduler, hass: MagicMock
+    ) -> None:
+        """Updating schedule when enabled should recalculate pump state."""
+        scheduler._enabled = True
+        with patch.object(scheduler, "is_in_active_window", return_value=True):
+            await scheduler.async_update_schedule(start_time=time(14, 0))
+        hass.services.async_call.assert_called_once_with(
+            "switch", "turn_on", {"entity_id": "switch.pool_pump"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_when_enabled_outside_window_stops_pump(
+        self, scheduler: FiltrationScheduler, hass: MagicMock
+    ) -> None:
+        """Updating schedule when enabled but outside window should stop pump."""
+        scheduler._enabled = True
+        with patch.object(scheduler, "is_in_active_window", return_value=False):
+            await scheduler.async_update_schedule(duration_hours=2.0)
+        hass.services.async_call.assert_called_once_with(
+            "switch", "turn_off", {"entity_id": "switch.pool_pump"}
+        )
+
+
+class TestEventListeners:
+    """Tests for the event listener registry."""
+
+    def test_on_event_registers_listener(self, scheduler: FiltrationScheduler) -> None:
+        """on_event() should add a listener."""
+        listener = MagicMock()
+        scheduler.on_event(listener)
+        assert listener in scheduler._listeners
+
+    def test_unsubscribe_removes_listener(self, scheduler: FiltrationScheduler) -> None:
+        """Calling the unsubscribe function should remove the listener."""
+        listener = MagicMock()
+        unsub = scheduler.on_event(listener)
+        unsub()
+        assert listener not in scheduler._listeners
+
+    @pytest.mark.asyncio
+    async def test_start_pump_notifies_listeners(self, scheduler: FiltrationScheduler) -> None:
+        """Starting the pump should notify all registered listeners."""
+        listener = MagicMock()
+        scheduler.on_event(listener)
+        await scheduler._async_start_pump()
+        listener.assert_called_once()
+        event_type, event_data = listener.call_args[0]
+        assert event_type == EVENT_FILTRATION_STARTED
+        assert "start_time" in event_data
+        assert "duration_hours" in event_data
+        assert "end_time" in event_data
+
+    @pytest.mark.asyncio
+    async def test_stop_pump_notifies_listeners(self, scheduler: FiltrationScheduler) -> None:
+        """Stopping the pump should notify all registered listeners."""
+        listener = MagicMock()
+        scheduler.on_event(listener)
+        await scheduler._async_stop_pump()
+        listener.assert_called_once()
+        event_type, event_data = listener.call_args[0]
+        assert event_type == EVENT_FILTRATION_STOPPED
+        assert "start_time" in event_data
+        assert "duration_hours" in event_data
+        assert "end_time" in event_data
+
+
+class TestEventData:
+    """Tests for event data payload."""
+
+    def test_event_data_contains_schedule_details(self, scheduler: FiltrationScheduler) -> None:
+        """Event data should contain start_time, duration_hours, and end_time."""
+        data = scheduler._event_data()
+        assert data["start_time"] == DEFAULT_FILTRATION_START_TIME.isoformat()
+        assert data["duration_hours"] == DEFAULT_FILTRATION_DURATION_HOURS
+        assert data["end_time"] == time(18, 0).isoformat()
+
+    def test_event_data_reflects_updated_schedule(self, scheduler: FiltrationScheduler) -> None:
+        """Event data should reflect schedule changes."""
+        scheduler._start_time = time(22, 0)
+        scheduler._duration_hours = 10.0
+        data = scheduler._event_data()
+        assert data["start_time"] == "22:00:00"
+        assert data["duration_hours"] == 10.0
+        assert data["end_time"] == "08:00:00"
+
+
+class TestAsyncCancel:
+    """Tests for cleanup via async_cancel."""
+
+    def test_cancel_clears_listeners(self, scheduler: FiltrationScheduler) -> None:
+        """async_cancel should clear all listeners."""
+        scheduler.on_event(MagicMock())
+        scheduler.on_event(MagicMock())
+        scheduler.async_cancel()
+        assert len(scheduler._listeners) == 0
+
+    def test_cancel_cancels_triggers(self, scheduler: FiltrationScheduler) -> None:
+        """async_cancel should cancel any active triggers."""
+        unsub_start = MagicMock()
+        unsub_stop = MagicMock()
+        scheduler._unsub_start = unsub_start
+        scheduler._unsub_stop = unsub_stop
+        scheduler.async_cancel()
+        unsub_start.assert_called_once()
+        unsub_stop.assert_called_once()
+
+
+class TestDefaults:
+    """Tests for default scheduler configuration."""
+
+    def test_default_start_time(self, scheduler: FiltrationScheduler) -> None:
+        """Default start time should be 10:00."""
+        assert scheduler.start_time == time(10, 0)
+
+    def test_default_duration(self, scheduler: FiltrationScheduler) -> None:
+        """Default duration should be 8 hours."""
+        assert scheduler.duration_hours == 8.0
+
+    def test_default_not_enabled(self, scheduler: FiltrationScheduler) -> None:
+        """Scheduler should be disabled by default."""
+        assert scheduler.enabled is False
+
+    def test_pump_entity_id(self, scheduler: FiltrationScheduler) -> None:
+        """Pump entity ID should match the one provided."""
+        assert scheduler.pump_entity_id == "switch.pool_pump"

--- a/zensical.toml
+++ b/zensical.toml
@@ -55,6 +55,7 @@ nav = [
   { "Getting Started" = "getting-started.md" },
   { "Entities" = "entities.md" },
   { "Pool Modes" = "pool-modes.md" },
+  { "Filtration Control" = "filtration-control.md" },
   { "Water Chemistry" = "water-chemistry.md" },
   { "Rules & Recommendations" = "rules-and-recommendations.md" },
   { "Contributing" = "contributing.md" },


### PR DESCRIPTION
Implement daily filtration pump control when a pump switch entity is configured. The scheduler turns the pump on/off based on a user-defined start time and duration, with cross-midnight and restart recovery support.

- Add FiltrationScheduler with time-based triggers and event listener registry
- Add switch, time, number, and event entity platforms (conditional on pump_entity)
- Add EN/FR translations for all new entities and event types
- Add dedicated filtration-control.md docs page with automation examples
- Update entities.md, getting-started.md, index.md, pool-modes.md, and nav
- Add fake pump switch to demo and configure pump_entity in demo setup
- Add 34 tests covering active window logic, scheduling, and event listeners

Closes #11