### PR TITLE
feat(chemistry): add chemistry actions with suggestion/requirement classification

### DIFF
--- a/custom_components/poolman/domain/chemistry.py
+++ b/custom_components/poolman/domain/chemistry.py
@@ -151,6 +151,70 @@ def compute_tac_adjustment(pool: Pool, reading: PoolReading) -> DosageAdjustment
     return None
 
 
+# CYA dosage: 1g of cyanuric acid per 1 m3 raises CYA by 1 ppm
+CYA_DOSAGE_PER_M3_PER_PPM: float = 1.0
+
+# Hardness dosage: ~1.5g of CaCl2 per 1 m3 raises hardness by 1 ppm
+HARDNESS_DOSAGE_PER_M3_PER_PPM: float = 1.5
+
+
+def compute_cya_adjustment(pool: Pool, reading: PoolReading) -> DosageAdjustment | None:
+    """Compute cyanuric acid (stabilizer) adjustment recommendation.
+
+    Uses 1 g of cyanuric acid per m3 to raise CYA by 1 ppm.
+    Returns None when CYA is within range or above maximum (no chemical fix
+    for excess CYA -- partial drain is the only option).
+
+    Args:
+        pool: Pool physical characteristics.
+        reading: Current sensor readings.
+
+    Returns:
+        DosageAdjustment with product and quantity, or None if CYA is in range
+        or no chemical fix is available.
+    """
+    if reading.cya is None:
+        return None
+
+    if reading.cya < CYA_MIN:
+        delta_ppm = CYA_TARGET - reading.cya
+        quantity = delta_ppm * CYA_DOSAGE_PER_M3_PER_PPM * pool.volume_m3
+        return DosageAdjustment(product=ChemicalProduct.STABILIZER, quantity_g=round(quantity, 0))
+
+    # CYA above max: no chemical product can lower it
+    return None
+
+
+def compute_hardness_adjustment(pool: Pool, reading: PoolReading) -> DosageAdjustment | None:
+    """Compute calcium hardness adjustment recommendation.
+
+    Uses ~1.5 g of CaCl2 per m3 to raise hardness by 1 ppm.
+    Returns None when hardness is within range or above maximum (no chemical
+    fix for excess hardness -- partial drain is the only option).
+
+    Args:
+        pool: Pool physical characteristics.
+        reading: Current sensor readings.
+
+    Returns:
+        DosageAdjustment with product and quantity, or None if hardness is in
+        range or no chemical fix is available.
+    """
+    if reading.hardness is None:
+        return None
+
+    if reading.hardness < HARDNESS_MIN:
+        delta_ppm = HARDNESS_TARGET - reading.hardness
+        quantity = delta_ppm * HARDNESS_DOSAGE_PER_M3_PER_PPM * pool.volume_m3
+        return DosageAdjustment(
+            product=ChemicalProduct.CALCIUM_HARDNESS_INCREASER,
+            quantity_g=round(quantity, 0),
+        )
+
+    # Hardness above max: no chemical product can lower it
+    return None
+
+
 def compute_water_quality_score(reading: PoolReading) -> int | None:
     """Compute an overall water quality score from 0 to 100.
 

--- a/custom_components/poolman/domain/model.py
+++ b/custom_components/poolman/domain/model.py
@@ -103,6 +103,17 @@ class RecommendationType(StrEnum):
     MAINTENANCE = "maintenance"
 
 
+class ActionKind(StrEnum):
+    """Whether a recommendation is a suggestion or a requirement.
+
+    Suggestions are optional improvements; requirements indicate
+    that the pool needs attention to remain safe or functional.
+    """
+
+    SUGGESTION = "suggestion"
+    REQUIREMENT = "requirement"
+
+
 class RecommendationPriority(StrEnum):
     """Priority levels for recommendations."""
 
@@ -190,6 +201,7 @@ class Recommendation(BaseModel):
 
     type: RecommendationType
     priority: RecommendationPriority
+    kind: ActionKind = ActionKind.SUGGESTION
     message: str
     product: str | None = None
     quantity_g: float | None = Field(None, ge=0, description="Quantity in grams")
@@ -254,6 +266,21 @@ class PoolState(BaseModel):
             for r in self.recommendations
             if r.priority in (RecommendationPriority.HIGH, RecommendationPriority.CRITICAL)
         ]
+
+    @property
+    def chemistry_actions(self) -> list[Recommendation]:
+        """Return only chemistry-related recommendations (excludes filtration)."""
+        return [r for r in self.recommendations if r.type != RecommendationType.FILTRATION]
+
+    @property
+    def suggestions(self) -> list[Recommendation]:
+        """Return chemistry actions classified as suggestions."""
+        return [r for r in self.chemistry_actions if r.kind == ActionKind.SUGGESTION]
+
+    @property
+    def requirements(self) -> list[Recommendation]:
+        """Return chemistry actions classified as requirements."""
+        return [r for r in self.chemistry_actions if r.kind == ActionKind.REQUIREMENT]
 
 
 # Chemistry parameter names evaluated for status changes

--- a/custom_components/poolman/domain/rules.py
+++ b/custom_components/poolman/domain/rules.py
@@ -10,6 +10,10 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 
 from .chemistry import (
+    CYA_MAX,
+    CYA_MIN,
+    HARDNESS_MAX,
+    HARDNESS_MIN,
     ORP_MAX,
     ORP_MIN_ACCEPTABLE,
     PH_MAX,
@@ -18,12 +22,15 @@ from .chemistry import (
     PH_TOLERANCE,
     TAC_MAX,
     TAC_MIN,
+    compute_cya_adjustment,
+    compute_hardness_adjustment,
     compute_ph_adjustment,
     compute_sanitizer_status,
     compute_tac_adjustment,
 )
 from .filtration import compute_filtration_duration
 from .model import (
+    ActionKind,
     Pool,
     PoolMode,
     PoolReading,
@@ -102,19 +109,23 @@ class PhRule(Rule):
         if result is None:
             return []
 
-        # Determine priority based on how far from target
+        # Determine priority and kind based on how far from target
         delta = abs(reading.ph - PH_TARGET)
         if reading.ph < PH_MIN or reading.ph > PH_MAX:
             priority = RecommendationPriority.HIGH
+            kind = ActionKind.REQUIREMENT
         elif delta > PH_TOLERANCE * 3:
             priority = RecommendationPriority.MEDIUM
+            kind = ActionKind.SUGGESTION
         else:
             priority = RecommendationPriority.LOW
+            kind = ActionKind.SUGGESTION
 
         return [
             Recommendation(
                 type=RecommendationType.CHEMICAL,
                 priority=priority,
+                kind=kind,
                 message=f"Add {result.quantity_g:.0f}g of {result.product}",
                 product=result.product,
                 quantity_g=result.quantity_g,
@@ -143,18 +154,22 @@ class SanitizerRule(Rule):
 
         if result.severity == Severity.CRITICAL:
             priority = RecommendationPriority.CRITICAL
+            kind = ActionKind.REQUIREMENT
             message = messages["shock"]
         elif reading.orp > ORP_MAX:
             priority = RecommendationPriority.MEDIUM
+            kind = ActionKind.REQUIREMENT
             message = messages["excess"]
         else:
             priority = RecommendationPriority.MEDIUM
+            kind = ActionKind.SUGGESTION
             message = messages["regular"].format(orp_min=ORP_MIN_ACCEPTABLE)
 
         return [
             Recommendation(
                 type=RecommendationType.CHEMICAL,
                 priority=priority,
+                kind=kind,
                 message=message,
                 product=result.product,
             )
@@ -186,6 +201,7 @@ class FiltrationRule(Rule):
             Recommendation(
                 type=RecommendationType.FILTRATION,
                 priority=priority,
+                kind=ActionKind.SUGGESTION,
                 message=f"Run filtration for {hours:.1f} hours today",
             )
         ]
@@ -210,9 +226,11 @@ class TacRule(Rule):
 
         if reading.tac < TAC_MIN:
             priority = RecommendationPriority.MEDIUM
+            kind = ActionKind.REQUIREMENT
             message = f"Add {result.quantity_g:.0f}g of TAC+ (alkalinity too low)"
         elif reading.tac > TAC_MAX:
             priority = RecommendationPriority.LOW
+            kind = ActionKind.SUGGESTION
             message = "Alkalinity too high, pH- treatments will help lower it"
         else:
             return []
@@ -221,6 +239,7 @@ class TacRule(Rule):
             Recommendation(
                 type=RecommendationType.CHEMICAL,
                 priority=priority,
+                kind=kind,
                 message=message,
                 product=result.product,
                 quantity_g=result.quantity_g,
@@ -249,7 +268,102 @@ class AlgaeRiskRule(Rule):
                 Recommendation(
                     type=RecommendationType.ALERT,
                     priority=RecommendationPriority.HIGH,
+                    kind=ActionKind.REQUIREMENT,
                     message="High algae risk (warm water + low ORP)",
+                )
+            ]
+
+        return []
+
+
+class CyaRule(Rule):
+    """Rule for cyanuric acid (stabilizer) level adjustment.
+
+    CYA below minimum requires adding stabilizer (with dosage).
+    CYA above maximum has no chemical fix -- recommends partial drain.
+    """
+
+    def evaluate(
+        self,
+        pool: Pool,
+        reading: PoolReading,
+        mode: PoolMode,
+    ) -> list[Recommendation]:
+        """Evaluate CYA level and recommend adjustments."""
+        if mode == PoolMode.WINTER_PASSIVE or reading.cya is None:
+            return []
+
+        if reading.cya < CYA_MIN:
+            result = compute_cya_adjustment(pool, reading)
+            if result is None:
+                return []
+            return [
+                Recommendation(
+                    type=RecommendationType.CHEMICAL,
+                    priority=RecommendationPriority.MEDIUM,
+                    kind=ActionKind.REQUIREMENT,
+                    message=f"Add {result.quantity_g:.0f}g of stabilizer (CYA too low)",
+                    product=result.product,
+                    quantity_g=result.quantity_g,
+                )
+            ]
+
+        if reading.cya > CYA_MAX:
+            return [
+                Recommendation(
+                    type=RecommendationType.ALERT,
+                    priority=RecommendationPriority.LOW,
+                    kind=ActionKind.REQUIREMENT,
+                    message="CYA too high, consider partial water drain",
+                )
+            ]
+
+        return []
+
+
+class HardnessRule(Rule):
+    """Rule for calcium hardness level adjustment.
+
+    Hardness below minimum requires adding calcium hardness increaser
+    (with dosage). Hardness above maximum has no chemical fix -- recommends
+    partial drain.
+    """
+
+    def evaluate(
+        self,
+        pool: Pool,
+        reading: PoolReading,
+        mode: PoolMode,
+    ) -> list[Recommendation]:
+        """Evaluate calcium hardness and recommend adjustments."""
+        if mode == PoolMode.WINTER_PASSIVE or reading.hardness is None:
+            return []
+
+        if reading.hardness < HARDNESS_MIN:
+            result = compute_hardness_adjustment(pool, reading)
+            if result is None:
+                return []
+            return [
+                Recommendation(
+                    type=RecommendationType.CHEMICAL,
+                    priority=RecommendationPriority.MEDIUM,
+                    kind=ActionKind.REQUIREMENT,
+                    message=(
+                        f"Add {result.quantity_g:.0f}g of calcium hardness"
+                        " increaser (hardness too low)"
+                    ),
+                    product=result.product,
+                    quantity_g=result.quantity_g,
+                )
+            ]
+
+        if reading.hardness > HARDNESS_MAX:
+            return [
+                Recommendation(
+                    type=RecommendationType.ALERT,
+                    priority=RecommendationPriority.LOW,
+                    kind=ActionKind.REQUIREMENT,
+                    message="Calcium hardness too high, consider partial water drain",
                 )
             ]
 
@@ -280,6 +394,8 @@ class RuleEngine:
             FiltrationRule(),
             TacRule(),
             AlgaeRiskRule(),
+            CyaRule(),
+            HardnessRule(),
         ]
 
     def evaluate(

--- a/custom_components/poolman/sensor.py
+++ b/custom_components/poolman/sensor.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.typing import StateType
 
 from . import PoolmanConfigEntry
 from .coordinator import PoolmanCoordinator
-from .domain.model import ChemistryStatus, ParameterReport, PoolState
+from .domain.model import ActionKind, ChemistryStatus, ParameterReport, PoolState
 from .entity import PoolmanEntity
 
 
@@ -107,6 +107,29 @@ SENSOR_DESCRIPTIONS: tuple[PoolmanSensorEntityDescription, ...] = (
         extra_attrs_fn=lambda state: {
             "actions": [str(r) for r in state.recommendations],
             "critical_count": len(state.critical_recommendations),
+        },
+    ),
+    PoolmanSensorEntityDescription(
+        key="chemistry_actions",
+        translation_key="chemistry_actions",
+        icon="mdi:flask-outline",
+        value_fn=lambda state: len(state.chemistry_actions),
+        extra_attrs_fn=lambda state: {
+            "actions": [
+                {
+                    "kind": r.kind,
+                    "message": r.message,
+                    "product": r.product,
+                    "quantity_g": r.quantity_g,
+                }
+                for r in state.chemistry_actions
+            ],
+            "suggestion_count": len(
+                [r for r in state.chemistry_actions if r.kind == ActionKind.SUGGESTION]
+            ),
+            "requirement_count": len(
+                [r for r in state.chemistry_actions if r.kind == ActionKind.REQUIREMENT]
+            ),
         },
     ),
     PoolmanSensorEntityDescription(

--- a/custom_components/poolman/strings.json
+++ b/custom_components/poolman/strings.json
@@ -122,6 +122,9 @@
       "recommendations": {
         "name": "Recommendations"
       },
+      "chemistry_actions": {
+        "name": "Chemistry actions"
+      },
       "ph_status": {
         "name": "pH status",
         "state": {

--- a/custom_components/poolman/translations/en.json
+++ b/custom_components/poolman/translations/en.json
@@ -122,6 +122,9 @@
       "recommendations": {
         "name": "Recommendations"
       },
+      "chemistry_actions": {
+        "name": "Chemistry actions"
+      },
       "ph_status": {
         "name": "pH status",
         "state": {

--- a/custom_components/poolman/translations/fr.json
+++ b/custom_components/poolman/translations/fr.json
@@ -122,6 +122,9 @@
       "recommendations": {
         "name": "Recommendations"
       },
+      "chemistry_actions": {
+        "name": "Actions chimie"
+      },
       "ph_status": {
         "name": "Statut pH",
         "state": {

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -11,7 +11,7 @@ name you set during configuration.
 
 ## Sensors
 
-The integration creates 13 sensor entities:
+The integration creates 14 sensor entities:
 
 ### Reading sensors
 
@@ -32,6 +32,7 @@ These sensors are calculated by Pool Manager from your readings.
 | `sensor.{pool}_filtration_duration` | Recommended filtration | h | Recommended daily filtration hours, computed from water temperature, filter type efficiency, outdoor temperature, and pump capacity. See [Pool Modes](pool-modes.md#filtration) for the full algorithm. |
 | `sensor.{pool}_water_quality_score` | Water quality | % | Overall water quality score from 0 (poor) to 100 (perfect). See [Water Chemistry](water-chemistry.md#water-quality-score) for scoring details. |
 | `sensor.{pool}_recommendations` | Recommendations | -- | Number of active recommendations. See details below. |
+| `sensor.{pool}_chemistry_actions` | Chemistry actions | -- | Number of chemistry-related actions (excludes filtration). See details below. |
 | `sensor.{pool}_active_treatments` | Active treatments | -- | Number of currently active chemical treatments. See [Chemistry Tracking](chemistry-tracking.md) for details. |
 | `sensor.{pool}_safe_at` | Safe to swim at | -- | Timestamp (`timestamp` device class) indicating when the pool will be safe for swimming after treatments. `None` if already safe. |
 
@@ -45,6 +46,22 @@ The `recommendations` sensor exposes additional detail through its state attribu
 | `critical_count` | integer | Number of high or critical priority recommendations |
 
 These attributes can be used in automations, templates, or Lovelace cards to display detailed recommendation information.
+
+### Chemistry actions sensor attributes
+
+The `chemistry_actions` sensor exposes chemistry-related recommendations
+(chemical treatments and alerts, excluding filtration) through its
+state attributes:
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `actions` | list of objects | Each action includes `kind` (suggestion/requirement), `message`, `product`, and `quantity_g` |
+| `suggestion_count` | integer | Number of actions classified as suggestions |
+| `requirement_count` | integer | Number of actions classified as requirements |
+
+Actions are classified as either **suggestions** (optional improvements)
+or **requirements** (needed to keep the pool safe).
+See [Action Kind](rules-and-recommendations.md#action-kind) for details.
 
 ### Chemistry status sensors
 

--- a/docs/rules-and-recommendations.md
+++ b/docs/rules-and-recommendations.md
@@ -23,6 +23,20 @@ Each recommendation has a priority level that determines its urgency and affects
 
 Recommendations are sorted by priority (critical first) when displayed.
 
+## Action Kind
+
+Each recommendation is classified as either a **suggestion** or a **requirement**:
+
+| Kind | Description |
+| --- | --- |
+| Requirement | The pool needs attention to remain safe or functional |
+| Suggestion | An optional improvement that would bring parameters closer to ideal |
+
+The kind is exposed through the
+[chemistry actions sensor](entities.md#chemistry-actions-sensor-attributes)
+and can be used to filter or prioritize actions in automations
+and dashboards.
+
 ## Recommendation Types
 
 | Type | Description |
@@ -39,11 +53,11 @@ Recommendations are sorted by priority (critical first) when displayed.
 Monitors the pH level and recommends adjustments when it deviates from the
 target (7.2).
 
-| Condition | Priority | Recommendation |
-| --- | --- | --- |
-| pH outside acceptable range (< 6.8 or > 7.8) | High | Add pH+ or pH- with calculated dosage |
-| pH deviation > 0.3 from target | Medium | Add pH+ or pH- with calculated dosage |
-| pH deviation > 0.1 from target | Low | Add pH+ or pH- with calculated dosage |
+| Condition | Priority | Kind | Recommendation |
+| --- | --- | --- | --- |
+| pH outside acceptable range (< 6.8 or > 7.8) | High | Requirement | Add pH+ or pH- with calculated dosage |
+| pH deviation > 0.3 from target | Medium | Suggestion | Add pH+ or pH- with calculated dosage |
+| pH deviation > 0.1 from target | Low | Suggestion | Add pH+ or pH- with calculated dosage |
 
 The dosage is calculated based on pool volume.
 See [pH Dosage Calculation](water-chemistry.md#ph-dosage-calculation)
@@ -59,12 +73,12 @@ Evaluates sanitizer effectiveness through ORP (Oxidation-Reduction Potential)
 readings. The recommended products depend on the configured
 [treatment type](getting-started.md#step-2-chemistry).
 
-| ORP Level | Severity | Priority | Action |
-| --- | --- | --- | --- |
-| < 650 mV | Critical | Critical | Shock treatment required |
-| 650--720 mV | Medium | Medium | Add regular sanitizer product |
-| 720--900 mV | -- | -- | No action (acceptable range) |
-| > 900 mV | Medium | Medium | Reduce sanitizer dosage (add neutralizer) |
+| ORP Level | Severity | Priority | Kind | Action |
+| --- | --- | --- | --- | --- |
+| < 650 mV | Critical | Critical | Requirement | Shock treatment required |
+| 650--720 mV | Medium | Medium | Suggestion | Add regular sanitizer product |
+| 720--900 mV | -- | -- | -- | No action (acceptable range) |
+| > 900 mV | Medium | Medium | Requirement | Reduce sanitizer dosage (add neutralizer) |
 
 #### Products by treatment type
 
@@ -93,10 +107,10 @@ Recommends daily filtration duration based on the current [pool mode](pool-modes
 
 Monitors total alkalinity and recommends adjustments.
 
-| Condition | Priority | Recommendation |
-| --- | --- | --- |
-| TAC < 80 ppm | Medium | Add TAC+ with calculated dosage |
-| TAC > 150 ppm | Low | pH- treatments will help lower it |
+| Condition | Priority | Kind | Recommendation |
+| --- | --- | --- | --- |
+| TAC < 80 ppm | Medium | Requirement | Add TAC+ with calculated dosage |
+| TAC > 150 ppm | Low | Suggestion | pH- treatments will help lower it |
 
 See [TAC Dosage Calculation](water-chemistry.md#tac-dosage-calculation) for dosage details.
 
@@ -108,9 +122,39 @@ See [TAC Dosage Calculation](water-chemistry.md#tac-dosage-calculation) for dosa
 
 Detects conditions favorable to algae growth by combining temperature and ORP readings.
 
-| Condition | Priority | Recommendation |
-| --- | --- | --- |
-| Water temperature > 28°C **and** ORP < 720 mV | High | High algae risk alert |
+| Condition | Priority | Kind | Recommendation |
+| --- | --- | --- | --- |
+| Water temperature > 28°C **and** ORP < 720 mV | High | Requirement | High algae risk alert |
 
 Both conditions must be met simultaneously. This rule is disabled in
 [Passive Wintering](pool-modes.md#passive-wintering) mode.
+
+### CYA Rule (Cyanuric Acid)
+
+Monitors cyanuric acid (stabilizer) levels and recommends adjustments.
+
+| Condition | Priority | Kind | Recommendation |
+| --- | --- | --- | --- |
+| CYA < 20 ppm | Medium | Requirement | Add stabilizer with calculated dosage |
+| CYA > 75 ppm | Low | Requirement | Consider partial water drain (no chemical fix) |
+
+See [CYA Dosage Calculation](water-chemistry.md#cya-dosage-calculation) for dosage details.
+
+!!! note
+
+    This rule is disabled in [Passive Wintering](pool-modes.md#passive-wintering) mode.
+
+### Hardness Rule (Calcium Hardness)
+
+Monitors calcium hardness levels and recommends adjustments.
+
+| Condition | Priority | Kind | Recommendation |
+| --- | --- | --- | --- |
+| Hardness < 150 ppm | Medium | Requirement | Add calcium hardness increaser with calculated dosage |
+| Hardness > 400 ppm | Low | Requirement | Consider partial water drain (no chemical fix) |
+
+See [Hardness Dosage Calculation](water-chemistry.md#hardness-dosage-calculation) for dosage details.
+
+!!! note
+
+    This rule is disabled in [Passive Wintering](pool-modes.md#passive-wintering) mode.

--- a/docs/water-chemistry.md
+++ b/docs/water-chemistry.md
@@ -110,6 +110,8 @@ universal.
 | pH- (pH minus) | Lower pH when it is above target |
 | pH+ (pH plus) | Raise pH when it is below target |
 | TAC+ (alkalinity increaser) | Raise total alkalinity when it is below minimum |
+| Stabilizer (CYA) | Raise cyanuric acid when it is below minimum |
+| Calcium hardness increaser | Raise calcium hardness when it is below minimum |
 
 ### Sanitizer products by treatment type
 
@@ -153,3 +155,45 @@ $$
 Where **18 g of sodium bicarbonate per m³** raises TAC by **10 ppm**.
 
 When TAC is above the maximum (150 ppm), pH- treatments are recommended as they indirectly lower alkalinity.
+
+## CYA Dosage Calculation
+
+When CYA (cyanuric acid / stabilizer) falls below the minimum (20 ppm), the
+integration calculates the stabilizer dosage needed to reach the target (40 ppm):
+
+$$
+\text{quantity (g)} = (\text{target} - \text{CYA}) \times 1 \times \text{volume\_m3}
+$$
+
+Where **1 g of cyanuric acid per m³** raises CYA by **1 ppm**.
+
+When CYA is above the maximum (75 ppm), no chemical product can lower it.
+The integration recommends a partial water drain instead.
+
+??? example "CYA dosage example"
+
+    For a 50 m³ pool with CYA at 10 ppm:
+
+    - Delta: 40 - 10 = 30
+    - Quantity: 30 x 1 x 50 = **1500 g of stabilizer**
+
+## Hardness Dosage Calculation
+
+When calcium hardness falls below the minimum (150 ppm), the integration
+calculates the calcium chloride dosage needed to reach the target (250 ppm):
+
+$$
+\text{quantity (g)} = (\text{target} - \text{hardness}) \times 1.5 \times \text{volume\_m3}
+$$
+
+Where **1.5 g of CaCl₂ per m³** raises hardness by **1 ppm**.
+
+When hardness is above the maximum (400 ppm), no chemical product can lower it.
+The integration recommends a partial water drain instead.
+
+??? example "Hardness dosage example"
+
+    For a 50 m³ pool with hardness at 100 ppm:
+
+    - Delta: 250 - 100 = 150
+    - Quantity: 150 x 1.5 x 50 = **11250 g of calcium hardness increaser**

--- a/tests/domain/test_chemistry.py
+++ b/tests/domain/test_chemistry.py
@@ -21,6 +21,8 @@ from custom_components.poolman.domain.chemistry import (
     TAC_MIN,
     TAC_TARGET,
     compute_chemistry_report,
+    compute_cya_adjustment,
+    compute_hardness_adjustment,
     compute_parameter_status,
     compute_ph_adjustment,
     compute_sanitizer_status,
@@ -386,3 +388,111 @@ class TestChemistryReport:
         assert report.ph.minimum == PH_MIN
         assert report.ph.maximum == PH_MAX
         assert report.ph.score == 100
+
+
+class TestCyaAdjustment:
+    """Tests for CYA (cyanuric acid / stabilizer) adjustment calculation."""
+
+    def test_cya_in_range_returns_none(self, pool: Pool) -> None:
+        reading = PoolReading(cya=40.0)
+        assert compute_cya_adjustment(pool, reading) is None
+
+    def test_cya_at_min_returns_none(self, pool: Pool) -> None:
+        reading = PoolReading(cya=CYA_MIN)
+        assert compute_cya_adjustment(pool, reading) is None
+
+    def test_cya_at_max_returns_none(self, pool: Pool) -> None:
+        reading = PoolReading(cya=CYA_MAX)
+        assert compute_cya_adjustment(pool, reading) is None
+
+    def test_cya_none_returns_none(self, pool: Pool) -> None:
+        reading = PoolReading(cya=None)
+        assert compute_cya_adjustment(pool, reading) is None
+
+    def test_cya_too_low_recommends_stabilizer(self, pool: Pool) -> None:
+        reading = PoolReading(cya=10.0)
+        result = compute_cya_adjustment(pool, reading)
+        assert result is not None
+        assert result.product == ChemicalProduct.STABILIZER
+        assert result.quantity_g is not None
+        assert result.quantity_g > 0
+
+    def test_cya_too_low_dosage_formula(self, pool: Pool) -> None:
+        """1g per m3 per ppm: (40 - 10) * 1 * 50 = 1500g."""
+        reading = PoolReading(cya=10.0)
+        result = compute_cya_adjustment(pool, reading)
+        assert result is not None
+        assert result.quantity_g == pytest.approx(1500.0)
+
+    def test_cya_above_max_returns_none(self, pool: Pool) -> None:
+        """No chemical can lower CYA -- returns None (alert handled by rule)."""
+        reading = PoolReading(cya=100.0)
+        assert compute_cya_adjustment(pool, reading) is None
+
+    def test_cya_quantity_scales_with_volume(self) -> None:
+        small_pool = Pool(name="Small", volume_m3=20.0, pump_flow_m3h=5.0)
+        large_pool = Pool(name="Large", volume_m3=100.0, pump_flow_m3h=20.0)
+        reading = PoolReading(cya=10.0)
+
+        small_result = compute_cya_adjustment(small_pool, reading)
+        large_result = compute_cya_adjustment(large_pool, reading)
+
+        assert small_result is not None
+        assert large_result is not None
+        assert large_result.quantity_g is not None
+        assert small_result.quantity_g is not None
+        assert large_result.quantity_g > small_result.quantity_g
+
+
+class TestHardnessAdjustment:
+    """Tests for calcium hardness adjustment calculation."""
+
+    def test_hardness_in_range_returns_none(self, pool: Pool) -> None:
+        reading = PoolReading(hardness=250.0)
+        assert compute_hardness_adjustment(pool, reading) is None
+
+    def test_hardness_at_min_returns_none(self, pool: Pool) -> None:
+        reading = PoolReading(hardness=HARDNESS_MIN)
+        assert compute_hardness_adjustment(pool, reading) is None
+
+    def test_hardness_at_max_returns_none(self, pool: Pool) -> None:
+        reading = PoolReading(hardness=HARDNESS_MAX)
+        assert compute_hardness_adjustment(pool, reading) is None
+
+    def test_hardness_none_returns_none(self, pool: Pool) -> None:
+        reading = PoolReading(hardness=None)
+        assert compute_hardness_adjustment(pool, reading) is None
+
+    def test_hardness_too_low_recommends_increaser(self, pool: Pool) -> None:
+        reading = PoolReading(hardness=100.0)
+        result = compute_hardness_adjustment(pool, reading)
+        assert result is not None
+        assert result.product == ChemicalProduct.CALCIUM_HARDNESS_INCREASER
+        assert result.quantity_g is not None
+        assert result.quantity_g > 0
+
+    def test_hardness_too_low_dosage_formula(self, pool: Pool) -> None:
+        """1.5g per m3 per ppm: (250 - 100) * 1.5 * 50 = 11250g."""
+        reading = PoolReading(hardness=100.0)
+        result = compute_hardness_adjustment(pool, reading)
+        assert result is not None
+        assert result.quantity_g == pytest.approx(11250.0)
+
+    def test_hardness_above_max_returns_none(self, pool: Pool) -> None:
+        """No chemical can lower hardness -- returns None (alert handled by rule)."""
+        reading = PoolReading(hardness=500.0)
+        assert compute_hardness_adjustment(pool, reading) is None
+
+    def test_hardness_quantity_scales_with_volume(self) -> None:
+        small_pool = Pool(name="Small", volume_m3=20.0, pump_flow_m3h=5.0)
+        large_pool = Pool(name="Large", volume_m3=100.0, pump_flow_m3h=20.0)
+        reading = PoolReading(hardness=100.0)
+
+        small_result = compute_hardness_adjustment(small_pool, reading)
+        large_result = compute_hardness_adjustment(large_pool, reading)
+
+        assert small_result is not None
+        assert large_result is not None
+        assert large_result.quantity_g is not None
+        assert small_result.quantity_g is not None
+        assert large_result.quantity_g > small_result.quantity_g

--- a/tests/domain/test_model.py
+++ b/tests/domain/test_model.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from custom_components.poolman.domain.model import (
+    ActionKind,
     ChemistryReport,
     ChemistryStatus,
     ParameterReport,
@@ -289,3 +290,99 @@ class TestPoolStateActionRequired:
         )
         state = PoolState(recommendations=[rec])
         assert state.action_required is True
+
+
+class TestActionKind:
+    """Tests for ActionKind enum and default value."""
+
+    def test_action_kind_values(self) -> None:
+        assert ActionKind.SUGGESTION == "suggestion"
+        assert ActionKind.REQUIREMENT == "requirement"
+
+    def test_recommendation_default_kind_is_suggestion(self) -> None:
+        rec = Recommendation(
+            type=RecommendationType.CHEMICAL,
+            priority=RecommendationPriority.LOW,
+            message="Test",
+        )
+        assert rec.kind == ActionKind.SUGGESTION
+
+    def test_recommendation_explicit_kind(self) -> None:
+        rec = Recommendation(
+            type=RecommendationType.CHEMICAL,
+            priority=RecommendationPriority.HIGH,
+            kind=ActionKind.REQUIREMENT,
+            message="Test",
+        )
+        assert rec.kind == ActionKind.REQUIREMENT
+
+
+class TestPoolStateChemistryActions:
+    """Tests for PoolState.chemistry_actions, suggestions, and requirements."""
+
+    def _make_rec(
+        self,
+        rtype: RecommendationType = RecommendationType.CHEMICAL,
+        kind: ActionKind = ActionKind.SUGGESTION,
+        priority: RecommendationPriority = RecommendationPriority.LOW,
+        message: str = "test",
+    ) -> Recommendation:
+        return Recommendation(type=rtype, priority=priority, kind=kind, message=message)
+
+    def test_chemistry_actions_excludes_filtration(self) -> None:
+        chem = self._make_rec(rtype=RecommendationType.CHEMICAL)
+        filt = self._make_rec(rtype=RecommendationType.FILTRATION)
+        alert = self._make_rec(rtype=RecommendationType.ALERT)
+        state = PoolState(recommendations=[chem, filt, alert])
+
+        assert len(state.chemistry_actions) == 2
+        assert filt not in state.chemistry_actions
+        assert chem in state.chemistry_actions
+        assert alert in state.chemistry_actions
+
+    def test_chemistry_actions_empty(self) -> None:
+        state = PoolState()
+        assert state.chemistry_actions == []
+
+    def test_suggestions_filters_by_kind(self) -> None:
+        sug = self._make_rec(kind=ActionKind.SUGGESTION)
+        req = self._make_rec(kind=ActionKind.REQUIREMENT)
+        state = PoolState(recommendations=[sug, req])
+
+        assert len(state.suggestions) == 1
+        assert state.suggestions[0] is sug
+
+    def test_requirements_filters_by_kind(self) -> None:
+        sug = self._make_rec(kind=ActionKind.SUGGESTION)
+        req = self._make_rec(kind=ActionKind.REQUIREMENT)
+        state = PoolState(recommendations=[sug, req])
+
+        assert len(state.requirements) == 1
+        assert state.requirements[0] is req
+
+    def test_filtration_excluded_from_suggestions_and_requirements(self) -> None:
+        filt = self._make_rec(rtype=RecommendationType.FILTRATION, kind=ActionKind.SUGGESTION)
+        state = PoolState(recommendations=[filt])
+
+        assert state.suggestions == []
+        assert state.requirements == []
+        assert state.chemistry_actions == []
+
+    def test_mixed_recommendations(self) -> None:
+        chem_sug = self._make_rec(
+            rtype=RecommendationType.CHEMICAL, kind=ActionKind.SUGGESTION, message="chem_sug"
+        )
+        chem_req = self._make_rec(
+            rtype=RecommendationType.CHEMICAL, kind=ActionKind.REQUIREMENT, message="chem_req"
+        )
+        alert_req = self._make_rec(
+            rtype=RecommendationType.ALERT, kind=ActionKind.REQUIREMENT, message="alert_req"
+        )
+        filt = self._make_rec(
+            rtype=RecommendationType.FILTRATION, kind=ActionKind.SUGGESTION, message="filt"
+        )
+        state = PoolState(recommendations=[chem_sug, chem_req, alert_req, filt])
+
+        assert len(state.chemistry_actions) == 3
+        assert len(state.suggestions) == 1
+        assert len(state.requirements) == 2

--- a/tests/domain/test_rules.py
+++ b/tests/domain/test_rules.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from custom_components.poolman.domain.model import (
+    ActionKind,
     Pool,
     PoolMode,
     PoolReading,
@@ -14,7 +15,9 @@ from custom_components.poolman.domain.model import (
 )
 from custom_components.poolman.domain.rules import (
     AlgaeRiskRule,
+    CyaRule,
     FiltrationRule,
+    HardnessRule,
     PhRule,
     RuleEngine,
     SanitizerRule,
@@ -36,6 +39,7 @@ class TestPhRule:
         assert len(result) == 1
         assert result[0].product == "ph_minus"
         assert result[0].type == RecommendationType.CHEMICAL
+        assert result[0].kind == ActionKind.SUGGESTION
 
     def test_low_ph_returns_recommendation(self, pool: Pool) -> None:
         reading = PoolReading(ph=6.6)
@@ -43,6 +47,7 @@ class TestPhRule:
         assert len(result) == 1
         assert result[0].product == "ph_plus"
         assert result[0].priority == RecommendationPriority.HIGH
+        assert result[0].kind == ActionKind.REQUIREMENT
 
     def test_winter_passive_skips(self, pool: Pool) -> None:
         reading = PoolReading(ph=8.5)
@@ -72,12 +77,14 @@ class TestSanitizerRule:
         assert len(result) == 1
         assert result[0].priority == RecommendationPriority.CRITICAL
         assert result[0].product == "chlore_choc"
+        assert result[0].kind == ActionKind.REQUIREMENT
 
     def test_chlorine_low_orp_galet(self, pool: Pool) -> None:
         reading = PoolReading(orp=700.0)
         result = SanitizerRule().evaluate(pool, reading, PoolMode.RUNNING)
         assert len(result) == 1
         assert result[0].product == "galet_chlore"
+        assert result[0].kind == ActionKind.SUGGESTION
 
     def test_salt_low_orp_recommends_salt(self) -> None:
         pool = Pool(
@@ -228,6 +235,7 @@ class TestAlgaeRiskRule:
         result = AlgaeRiskRule().evaluate(pool, reading, PoolMode.RUNNING)
         assert len(result) == 1
         assert result[0].priority == RecommendationPriority.HIGH
+        assert result[0].kind == ActionKind.REQUIREMENT
 
     def test_cool_water_no_risk(self, pool: Pool) -> None:
         reading = PoolReading(temp_c=22.0, orp=650.0)
@@ -250,7 +258,7 @@ class TestRuleEngine:
 
     def test_default_rules_loaded(self) -> None:
         engine = RuleEngine()
-        assert len(engine.rules) == 5
+        assert len(engine.rules) == 7
 
     def test_good_readings_produce_filtration_only(
         self, pool: Pool, good_reading: PoolReading
@@ -303,3 +311,103 @@ class TestRuleEngine:
         results = engine.evaluate(pool, reading, PoolMode.RUNNING)
         # Only pH rule should fire, not sanitizer
         assert all(r.product in ("ph_minus", "ph_plus") for r in results)
+
+
+class TestCyaRule:
+    """Tests for CYA (cyanuric acid) rule evaluation."""
+
+    def test_cya_in_range_no_recommendation(self, pool: Pool) -> None:
+        reading = PoolReading(cya=40.0)
+        result = CyaRule().evaluate(pool, reading, PoolMode.RUNNING)
+        assert result == []
+
+    def test_cya_too_low_recommends_stabilizer(self, pool: Pool) -> None:
+        reading = PoolReading(cya=10.0)
+        result = CyaRule().evaluate(pool, reading, PoolMode.RUNNING)
+        assert len(result) == 1
+        assert result[0].product == "stabilizer"
+        assert result[0].type == RecommendationType.CHEMICAL
+        assert result[0].priority == RecommendationPriority.MEDIUM
+        assert result[0].kind == ActionKind.REQUIREMENT
+        assert result[0].quantity_g is not None
+        assert result[0].quantity_g > 0
+
+    def test_cya_too_high_recommends_drain(self, pool: Pool) -> None:
+        reading = PoolReading(cya=100.0)
+        result = CyaRule().evaluate(pool, reading, PoolMode.RUNNING)
+        assert len(result) == 1
+        assert result[0].type == RecommendationType.ALERT
+        assert result[0].priority == RecommendationPriority.LOW
+        assert result[0].kind == ActionKind.REQUIREMENT
+        assert result[0].product is None
+        assert "drain" in result[0].message.lower()
+
+    def test_cya_none_no_recommendation(self, pool: Pool) -> None:
+        reading = PoolReading(cya=None)
+        result = CyaRule().evaluate(pool, reading, PoolMode.RUNNING)
+        assert result == []
+
+    def test_winter_passive_skips(self, pool: Pool) -> None:
+        reading = PoolReading(cya=10.0)
+        result = CyaRule().evaluate(pool, reading, PoolMode.WINTER_PASSIVE)
+        assert result == []
+
+    def test_cya_at_min_no_recommendation(self, pool: Pool) -> None:
+        reading = PoolReading(cya=20.0)
+        result = CyaRule().evaluate(pool, reading, PoolMode.RUNNING)
+        assert result == []
+
+    def test_cya_at_max_no_recommendation(self, pool: Pool) -> None:
+        reading = PoolReading(cya=75.0)
+        result = CyaRule().evaluate(pool, reading, PoolMode.RUNNING)
+        assert result == []
+
+
+class TestHardnessRule:
+    """Tests for calcium hardness rule evaluation."""
+
+    def test_hardness_in_range_no_recommendation(self, pool: Pool) -> None:
+        reading = PoolReading(hardness=250.0)
+        result = HardnessRule().evaluate(pool, reading, PoolMode.RUNNING)
+        assert result == []
+
+    def test_hardness_too_low_recommends_increaser(self, pool: Pool) -> None:
+        reading = PoolReading(hardness=100.0)
+        result = HardnessRule().evaluate(pool, reading, PoolMode.RUNNING)
+        assert len(result) == 1
+        assert result[0].product == "calcium_hardness_increaser"
+        assert result[0].type == RecommendationType.CHEMICAL
+        assert result[0].priority == RecommendationPriority.MEDIUM
+        assert result[0].kind == ActionKind.REQUIREMENT
+        assert result[0].quantity_g is not None
+        assert result[0].quantity_g > 0
+
+    def test_hardness_too_high_recommends_drain(self, pool: Pool) -> None:
+        reading = PoolReading(hardness=500.0)
+        result = HardnessRule().evaluate(pool, reading, PoolMode.RUNNING)
+        assert len(result) == 1
+        assert result[0].type == RecommendationType.ALERT
+        assert result[0].priority == RecommendationPriority.LOW
+        assert result[0].kind == ActionKind.REQUIREMENT
+        assert result[0].product is None
+        assert "drain" in result[0].message.lower()
+
+    def test_hardness_none_no_recommendation(self, pool: Pool) -> None:
+        reading = PoolReading(hardness=None)
+        result = HardnessRule().evaluate(pool, reading, PoolMode.RUNNING)
+        assert result == []
+
+    def test_winter_passive_skips(self, pool: Pool) -> None:
+        reading = PoolReading(hardness=100.0)
+        result = HardnessRule().evaluate(pool, reading, PoolMode.WINTER_PASSIVE)
+        assert result == []
+
+    def test_hardness_at_min_no_recommendation(self, pool: Pool) -> None:
+        reading = PoolReading(hardness=150.0)
+        result = HardnessRule().evaluate(pool, reading, PoolMode.RUNNING)
+        assert result == []
+
+    def test_hardness_at_max_no_recommendation(self, pool: Pool) -> None:
+        reading = PoolReading(hardness=400.0)
+        result = HardnessRule().evaluate(pool, reading, PoolMode.RUNNING)
+        assert result == []


### PR DESCRIPTION
## Summary

- Add `ActionKind` enum (suggestion/requirement) to the `Recommendation` model, classifying every rule output as either a **requirement** (pool needs attention) or a **suggestion** (optional improvement)
- Add `CyaRule` and `HardnessRule` with dosage calculations for cyanuric acid and calcium hardness, including alert-type recommendations when values exceed maximum (partial drain needed)
- Expose a new `chemistry_actions` sensor (count + attributes: actions list, suggestion_count, requirement_count) for use in automations and dashboards

## Details

### Domain model
- `ActionKind` enum with `SUGGESTION` and `REQUIREMENT` values added to `domain/model.py`
- `kind` field added to `Recommendation` dataclass (default: `SUGGESTION`)
- `chemistry_actions`, `suggestions`, `requirements` filtering properties added to `PoolState`

### Chemistry calculations (`domain/chemistry.py`)
- `compute_cya_adjustment()`: 1 g cyanuric acid per m³ raises CYA by 1 ppm
- `compute_hardness_adjustment()`: 1.5 g CaCl₂ per m³ raises hardness by 1 ppm

### Rules (`domain/rules.py`)
- `CyaRule`: requirement when CYA < 20 ppm (chemical), requirement when CYA > 75 ppm (alert/drain)
- `HardnessRule`: requirement when hardness < 150 ppm (chemical), requirement when hardness > 400 ppm (alert/drain)
- All existing rules (pH, Sanitizer, TAC, AlgaeRisk, Filtration) now set `kind` appropriately

### Sensor (`sensor.py`)
- New `chemistry_actions` sensor with state = action count, attributes = actions list + suggestion/requirement counts

### Tests
- 16 tests for CYA/hardness dosage calculations
- 14 tests for CyaRule/HardnessRule
- 9 tests for ActionKind enum and PoolState filtering
- All 347 tests pass, linter clean

### Documentation
- Updated `water-chemistry.md`, `rules-and-recommendations.md`, `entities.md`

Closes #18