### PR TITLE
feat(filtration): add manual filtration boost

### DIFF
--- a/custom_components/poolman/__init__.py
+++ b/custom_components/poolman/__init__.py
@@ -18,6 +18,7 @@ from .const import (
     DOMAIN,
     PLATFORMS,
     SERVICE_ADD_TREATMENT,
+    SERVICE_BOOST_FILTRATION,
     SERVICE_RECORD_MEASURE,
 )
 from .coordinator import PoolmanCoordinator
@@ -45,6 +46,13 @@ SERVICE_RECORD_MEASURE_SCHEMA = vol.Schema(
     }
 )
 
+SERVICE_BOOST_FILTRATION_SCHEMA = vol.Schema(
+    {
+        vol.Required("device_id"): str,
+        vol.Required("hours"): vol.All(vol.Coerce(float), vol.Range(min=0, max=48)),
+    }
+)
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: PoolmanConfigEntry) -> bool:
     """Set up Pool Manager from a config entry."""
@@ -66,6 +74,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: PoolmanConfigEntry) -> 
     if not any(e.entry_id != entry.entry_id for e in entries):
         hass.services.async_remove(DOMAIN, SERVICE_ADD_TREATMENT)
         hass.services.async_remove(DOMAIN, SERVICE_RECORD_MEASURE)
+        hass.services.async_remove(DOMAIN, SERVICE_BOOST_FILTRATION)
 
     return result
 
@@ -159,4 +168,35 @@ def _async_register_services(hass: HomeAssistant) -> None:
         SERVICE_RECORD_MEASURE,
         async_handle_record_measure,
         schema=SERVICE_RECORD_MEASURE_SCHEMA,
+    )
+
+    async def async_handle_boost_filtration(call: ServiceCall) -> None:
+        """Handle the boost_filtration service call.
+
+        Resolves the target device to find the corresponding coordinator,
+        then activates or cancels a filtration boost.
+        """
+        hours: float = call.data["hours"]
+        device_id: str = call.data["device_id"]
+
+        device_reg = dr.async_get(hass)
+        device = device_reg.async_get(device_id)
+        if device is None:
+            _LOGGER.warning("Device %s not found", device_id)
+            return
+
+        for entry_id in device.config_entries:
+            entry = hass.config_entries.async_get_entry(entry_id)
+            if entry and entry.domain == DOMAIN:
+                coordinator: PoolmanCoordinator = entry.runtime_data
+                if hours <= 0:
+                    await coordinator.async_cancel_boost()
+                else:
+                    await coordinator.async_boost_filtration(hours)
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_BOOST_FILTRATION,
+        async_handle_boost_filtration,
+        schema=SERVICE_BOOST_FILTRATION_SCHEMA,
     )

--- a/custom_components/poolman/const.py
+++ b/custom_components/poolman/const.py
@@ -83,6 +83,15 @@ FILTRATION_DURATION_MODES: Final = [
 EVENT_FILTRATION_STARTED: Final = "filtration_started"
 EVENT_FILTRATION_STOPPED: Final = "filtration_stopped"
 
+# Boost event types
+EVENT_BOOST_STARTED: Final = "boost_started"
+EVENT_BOOST_CONSUMED: Final = "boost_consumed"
+EVENT_BOOST_CANCELLED: Final = "boost_cancelled"
+
+# Boost presets (hours) exposed by the select entity
+BOOST_PRESET_NONE: Final = "none"
+BOOST_PRESETS: Final = [BOOST_PRESET_NONE, "2", "4", "8", "24"]
+
 # Default values
 DEFAULT_VOLUME_M3: Final = 50.0
 DEFAULT_TREATMENT: Final = TREATMENT_CHLORINE
@@ -99,3 +108,4 @@ DEFAULT_MIN_DYNAMIC_DURATION_HOURS: Final = 0.0
 # Service names
 SERVICE_ADD_TREATMENT: Final = "add_treatment"
 SERVICE_RECORD_MEASURE: Final = "record_measure"
+SERVICE_BOOST_FILTRATION: Final = "boost_filtration"

--- a/custom_components/poolman/coordinator.py
+++ b/custom_components/poolman/coordinator.py
@@ -175,6 +175,27 @@ class PoolmanCoordinator(DataUpdateCoordinator[PoolState]):
         if self.scheduler is not None:
             self.hass.async_create_task(self.scheduler.async_set_split(value.is_split))
 
+    async def async_boost_filtration(self, hours: float) -> None:
+        """Activate a filtration boost for the given number of extra hours.
+
+        Delegates to the scheduler.  Has no effect if no pump is configured.
+
+        Args:
+            hours: Extra filtration hours to add.
+        """
+        if self.scheduler is not None:
+            await self.scheduler.async_boost(hours)
+            await self.async_request_refresh()
+
+    async def async_cancel_boost(self) -> None:
+        """Cancel any active filtration boost.
+
+        Delegates to the scheduler.  Has no effect if no pump is configured.
+        """
+        if self.scheduler is not None:
+            await self.scheduler.async_cancel_boost()
+            await self.async_request_refresh()
+
     def register_treatment_entity(
         self,
         product: ChemicalProduct,
@@ -511,6 +532,7 @@ class PoolmanCoordinator(DataUpdateCoordinator[PoolState]):
             safe_at=safe_at,
             manual_measures=manual_measures,
             reading_sources=reading_sources,
+            boost_remaining=(self.scheduler.boost_remaining if self.scheduler is not None else 0.0),
         )
 
         self._fire_status_change_events(new_state)

--- a/custom_components/poolman/domain/model.py
+++ b/custom_components/poolman/domain/model.py
@@ -287,6 +287,7 @@ class PoolState(BaseModel):
     safe_at: datetime | None = None
     manual_measures: dict[MeasureParameter, ManualMeasure] = Field(default_factory=dict)
     reading_sources: dict[str, str] = Field(default_factory=dict)
+    boost_remaining: float = Field(0.0, ge=0, description="Remaining boost filtration hours")
 
     @property
     def water_ok(self) -> bool:

--- a/custom_components/poolman/event.py
+++ b/custom_components/poolman/event.py
@@ -21,7 +21,13 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import PoolmanConfigEntry
-from .const import EVENT_FILTRATION_STARTED, EVENT_FILTRATION_STOPPED
+from .const import (
+    EVENT_BOOST_CANCELLED,
+    EVENT_BOOST_CONSUMED,
+    EVENT_BOOST_STARTED,
+    EVENT_FILTRATION_STARTED,
+    EVENT_FILTRATION_STOPPED,
+)
 from .coordinator import PoolmanCoordinator
 from .domain.model import ChemicalProduct, MeasureParameter, TreatmentType
 from .entity import PoolmanEntity
@@ -272,7 +278,13 @@ class PoolmanFiltrationEvent(PoolmanEntity, EventEntity):
 
     _attr_translation_key = "filtration"
     _attr_icon = "mdi:pump"
-    _attr_event_types: ClassVar[list[str]] = [EVENT_FILTRATION_STARTED, EVENT_FILTRATION_STOPPED]
+    _attr_event_types: ClassVar[list[str]] = [
+        EVENT_FILTRATION_STARTED,
+        EVENT_FILTRATION_STOPPED,
+        EVENT_BOOST_STARTED,
+        EVENT_BOOST_CONSUMED,
+        EVENT_BOOST_CANCELLED,
+    ]
 
     def __init__(self, coordinator: PoolmanCoordinator) -> None:
         """Initialize the filtration event entity."""

--- a/custom_components/poolman/scheduler.py
+++ b/custom_components/poolman/scheduler.py
@@ -2,7 +2,8 @@
 
 Manages time-based triggers to automatically turn a pump switch on and off
 according to one or more filtration periods, each defined by a start time
-and duration.
+and duration.  Supports a manual *boost* that extends filtration beyond the
+normal schedule.
 """
 
 from __future__ import annotations
@@ -15,7 +16,7 @@ from datetime import date, datetime, time, timedelta
 from typing import Any
 
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
-from homeassistant.helpers.event import async_track_time_change
+from homeassistant.helpers.event import async_track_point_in_time, async_track_time_change
 from homeassistant.util import dt as dt_util
 
 from .const import (
@@ -23,6 +24,9 @@ from .const import (
     DEFAULT_FILTRATION_DURATION_HOURS_2,
     DEFAULT_FILTRATION_START_TIME,
     DEFAULT_FILTRATION_START_TIME_2,
+    EVENT_BOOST_CANCELLED,
+    EVENT_BOOST_CONSUMED,
+    EVENT_BOOST_STARTED,
     EVENT_FILTRATION_STARTED,
     EVENT_FILTRATION_STOPPED,
 )
@@ -83,7 +87,8 @@ class FiltrationScheduler:
 
     Registers time-based triggers with Home Assistant to turn a pump switch
     on at configured start times and off after configured durations.
-    Supports multiple periods, cross-midnight schedules, and restart recovery.
+    Supports multiple periods, cross-midnight schedules, restart recovery,
+    and manual boost extensions.
     """
 
     def __init__(self, hass: HomeAssistant, pump_entity_id: str) -> None:
@@ -99,6 +104,13 @@ class FiltrationScheduler:
         self._periods: list[FiltrationPeriod] = [FiltrationPeriod()]
         self._unsub_triggers: list[CALLBACK_TYPE] = []
         self._listeners: list[EventCallback] = []
+
+        # Boost state
+        self._boost_hours: float = 0.0
+        self._boost_end: datetime | None = None
+        self._unsub_boost_stop: CALLBACK_TYPE | None = None
+
+    # ── Properties ──────────────────────────────────────────────
 
     @property
     def enabled(self) -> bool:
@@ -144,6 +156,41 @@ class FiltrationScheduler:
         """Return the pump entity ID being controlled."""
         return self._pump_entity_id
 
+    @property
+    def boost_active(self) -> bool:
+        """Return whether a filtration boost is currently active."""
+        return self._boost_hours > 0
+
+    @property
+    def boost_end(self) -> datetime | None:
+        """Return the datetime when the current boost expires.
+
+        None if no boost is active or the boost has not yet started
+        being consumed (pump is still within a scheduled period).
+        """
+        return self._boost_end
+
+    @property
+    def boost_remaining(self) -> float:
+        """Return remaining boost hours.
+
+        If the boost end time has been set (consumption started),
+        the remaining time is computed from *now*. Otherwise the
+        full requested boost hours are returned.
+
+        Returns:
+            Remaining boost hours, 0.0 if no boost is active.
+        """
+        if self._boost_hours <= 0:
+            return 0.0
+        if self._boost_end is None:
+            # Boost requested but not yet consuming (pump still in-window)
+            return self._boost_hours
+        remaining = (self._boost_end - dt_util.now()).total_seconds() / 3600
+        return max(0.0, remaining)
+
+    # ── Active window ───────────────────────────────────────────
+
     def is_in_active_window(self, now: datetime | None = None) -> bool:
         """Check if a given time falls within any active filtration period.
 
@@ -160,6 +207,8 @@ class FiltrationScheduler:
             now = dt_util.now()
         now_time = now.time()
         return any(period.contains(now_time) for period in self._periods)
+
+    # ── Event listeners ─────────────────────────────────────────
 
     def on_event(self, callback_fn: EventCallback) -> Callable[[], None]:
         """Register a listener for scheduler events.
@@ -195,6 +244,17 @@ class FiltrationScheduler:
             "period_index": period_index,
         }
 
+    def _boost_event_data(self) -> dict[str, object]:
+        """Build the event data payload for a boost event.
+
+        Returns:
+            Dictionary with boost_hours and boost_end (if set).
+        """
+        data: dict[str, object] = {"boost_hours": self._boost_hours}
+        if self._boost_end is not None:
+            data["boost_end"] = self._boost_end.isoformat()
+        return data
+
     @callback
     def _notify(self, event_type: str, period_index: int = 0) -> None:
         """Notify all registered listeners of a scheduler event.
@@ -206,6 +266,19 @@ class FiltrationScheduler:
         data = self._event_data(period_index)
         for listener in self._listeners:
             listener(event_type, data)
+
+    @callback
+    def _notify_boost(self, event_type: str) -> None:
+        """Notify all registered listeners of a boost event.
+
+        Args:
+            event_type: The boost event type (e.g., boost_started).
+        """
+        data = self._boost_event_data()
+        for listener in self._listeners:
+            listener(event_type, data)
+
+    # ── Enable / Disable ────────────────────────────────────────
 
     async def async_enable(self) -> None:
         """Enable the filtration schedule.
@@ -228,12 +301,16 @@ class FiltrationScheduler:
     async def async_disable(self) -> None:
         """Disable the filtration schedule and turn off the pump.
 
-        Cancels all time triggers and immediately turns the pump off.
+        Cancels all time triggers, any active boost, and immediately
+        turns the pump off.
         """
         self._enabled = False
         self._cancel_triggers()
+        self._clear_boost()
         await self._async_stop_pump()
         _LOGGER.debug("Filtration control disabled (pump: %s)", self._pump_entity_id)
+
+    # ── Schedule management ─────────────────────────────────────
 
     async def async_update_schedule(
         self,
@@ -272,7 +349,7 @@ class FiltrationScheduler:
         self._setup_triggers()
 
         # Immediately adjust pump state to the new windows
-        if self.is_in_active_window():
+        if self.is_in_active_window() or self.boost_active:
             await self._async_start_pump()
         else:
             await self._async_stop_pump()
@@ -319,7 +396,7 @@ class FiltrationScheduler:
         self._setup_triggers()
 
         # Immediately adjust pump state to the new windows
-        if self.is_in_active_window():
+        if self.is_in_active_window() or self.boost_active:
             await self._async_start_pump()
         else:
             await self._async_stop_pump()
@@ -329,6 +406,148 @@ class FiltrationScheduler:
             "enabled" if enabled else "disabled",
             len(self._periods),
         )
+
+    # ── Boost ───────────────────────────────────────────────────
+
+    async def async_boost(self, hours: float) -> None:
+        """Activate a filtration boost.
+
+        Adds extra continuous filtration time on top of the normal
+        schedule.  If the pump is currently running (inside a scheduled
+        window), the boost extends past the next natural stop.  If the
+        pump is idle (outside any window), the pump starts immediately
+        and a one-shot stop is scheduled after *hours*.
+
+        A new boost replaces any previously active boost.
+
+        Args:
+            hours: Number of extra filtration hours (must be > 0).
+        """
+        if hours <= 0:
+            await self.async_cancel_boost()
+            return
+
+        # Clear any previous boost timer
+        self._cancel_boost_timer()
+
+        self._boost_hours = hours
+
+        if self.is_in_active_window():
+            # Pump is already running; boost extends past the next stop.
+            # _boost_end will be set when the first stop fires.
+            self._boost_end = None
+            _LOGGER.info(
+                "Filtration boost activated: +%.1fh (extends current period)",
+                hours,
+            )
+        else:
+            # Pump is idle; start immediately and schedule one-shot stop.
+            now = dt_util.now()
+            self._boost_end = now + timedelta(hours=hours)
+            await self._async_start_pump()
+            self._schedule_boost_stop()
+            _LOGGER.info(
+                "Filtration boost activated: +%.1fh (pump started, ends %s)",
+                hours,
+                self._boost_end.isoformat(),
+            )
+
+        self._notify_boost(EVENT_BOOST_STARTED)
+
+    async def async_cancel_boost(self) -> None:
+        """Cancel any active filtration boost.
+
+        If the pump is running outside the normal schedule window
+        (i.e. only because of the boost), it is turned off.
+        """
+        if not self.boost_active:
+            return
+
+        _LOGGER.info("Filtration boost cancelled")
+        self._clear_boost()
+        self._notify_boost(EVENT_BOOST_CANCELLED)
+
+        # Stop the pump if we're outside the normal schedule
+        if not self.is_in_active_window():
+            await self._async_stop_pump()
+
+    async def async_restore_boost(self, boost_end: datetime) -> None:
+        """Restore a boost from a persisted end time (e.g. after HA restart).
+
+        If the boost end is still in the future, the boost is reactivated
+        with the remaining time.  Otherwise the boost is silently discarded.
+
+        Args:
+            boost_end: The persisted boost expiry datetime.
+        """
+        now = dt_util.now()
+        remaining_seconds = (boost_end - now).total_seconds()
+        if remaining_seconds <= 0:
+            return
+
+        remaining_hours = remaining_seconds / 3600
+        self._boost_hours = remaining_hours
+        self._boost_end = boost_end
+
+        # If pump is outside a scheduled window, start it and schedule stop
+        if not self.is_in_active_window():
+            await self._async_start_pump()
+
+        self._schedule_boost_stop()
+        _LOGGER.info(
+            "Filtration boost restored: %.1fh remaining (ends %s)",
+            remaining_hours,
+            boost_end.isoformat(),
+        )
+
+    def _schedule_boost_stop(self) -> None:
+        """Register a one-shot timer to stop the pump when the boost expires."""
+        if self._boost_end is None:
+            return
+
+        self._cancel_boost_timer()
+
+        @callback
+        def _on_boost_end(_now: datetime) -> None:
+            """Handle boost expiry."""
+            self._hass.async_create_task(self._async_on_boost_consumed())
+
+        self._unsub_boost_stop = async_track_point_in_time(
+            self._hass,
+            _on_boost_end,
+            self._boost_end,
+        )
+
+    async def _async_on_boost_consumed(self) -> None:
+        """Handle natural boost expiry.
+
+        Stops the pump (if outside the normal schedule), clears boost
+        state, and notifies listeners.
+        """
+        _LOGGER.info("Filtration boost consumed")
+        self._boost_hours = 0.0
+        self._boost_end = None
+        self._unsub_boost_stop = None
+
+        self._notify_boost(EVENT_BOOST_CONSUMED)
+
+        # Only stop if we're outside a normal window
+        if not self.is_in_active_window():
+            await self._async_stop_pump()
+
+    def _clear_boost(self) -> None:
+        """Reset boost state and cancel any pending boost timer."""
+        self._boost_hours = 0.0
+        self._boost_end = None
+        self._cancel_boost_timer()
+
+    def _cancel_boost_timer(self) -> None:
+        """Cancel the one-shot boost stop timer if registered."""
+        if self._unsub_boost_stop is not None:
+            self._unsub_boost_stop()
+            self._unsub_boost_stop = None
+
+    # ── Time triggers ───────────────────────────────────────────
 
     def _setup_triggers(self) -> None:
         """Register time-based triggers for pump start and stop for all periods."""
@@ -380,6 +599,10 @@ class FiltrationScheduler:
     ) -> Callable[[datetime], Coroutine[Any, Any, None]]:
         """Create a stop-time callback for a specific period.
 
+        When a boost is active, the stop is suppressed. On the first
+        suppressed stop, the boost end time is calculated and a
+        one-shot timer is scheduled.
+
         Args:
             period_index: Index of the period this callback belongs to.
 
@@ -387,11 +610,33 @@ class FiltrationScheduler:
             An async callback for the time trigger.
         """
 
-        async def _on_stop_time(_now: datetime) -> None:
-            if self._enabled:
-                await self._async_stop_pump(period_index)
+        async def _on_stop_time(now: datetime) -> None:
+            if not self._enabled:
+                return
+
+            if self.boost_active:
+                # Suppress the normal stop; the boost keeps the pump running
+                if self._boost_end is None:
+                    # First suppressed stop: calculate boost end from now
+                    self._boost_end = now + timedelta(hours=self._boost_hours)
+                    self._schedule_boost_stop()
+                    _LOGGER.debug(
+                        "Period %d stop suppressed by boost (ends %s)",
+                        period_index,
+                        self._boost_end.isoformat(),
+                    )
+                else:
+                    _LOGGER.debug(
+                        "Period %d stop suppressed by boost (already consuming)",
+                        period_index,
+                    )
+                return
+
+            await self._async_stop_pump(period_index)
 
         return _on_stop_time
+
+    # ── Pump control ────────────────────────────────────────────
 
     async def _async_start_pump(self, period_index: int = 0) -> None:
         """Turn on the pump switch and notify listeners.
@@ -421,6 +666,8 @@ class FiltrationScheduler:
         )
         self._notify(EVENT_FILTRATION_STOPPED, period_index)
 
+    # ── Cleanup ─────────────────────────────────────────────────
+
     @callback
     def async_cancel(self) -> None:
         """Cancel all triggers and clear listeners.
@@ -428,4 +675,5 @@ class FiltrationScheduler:
         Called during integration unload to clean up resources.
         """
         self._cancel_triggers()
+        self._clear_boost()
         self._listeners.clear()

--- a/custom_components/poolman/select.py
+++ b/custom_components/poolman/select.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
@@ -9,7 +11,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from . import PoolmanConfigEntry
-from .const import DEFAULT_FILTRATION_DURATION_MODE
+from .const import BOOST_PRESET_NONE, BOOST_PRESETS, DEFAULT_FILTRATION_DURATION_MODE
 from .coordinator import PoolmanCoordinator
 from .domain.model import FiltrationDurationMode, PoolMode
 from .entity import PoolmanEntity
@@ -28,6 +30,13 @@ FILTRATION_DURATION_MODE_DESCRIPTION = SelectEntityDescription(
     options=[mode.value for mode in FiltrationDurationMode],
 )
 
+FILTRATION_BOOST_DESCRIPTION = SelectEntityDescription(
+    key="filtration_boost",
+    translation_key="filtration_boost",
+    icon="mdi:pump-off",
+    options=BOOST_PRESETS,
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -39,6 +48,7 @@ async def async_setup_entry(
     entities: list[SelectEntity] = [PoolmanModeSelect(coordinator)]
     if coordinator.scheduler is not None:
         entities.append(PoolmanFiltrationDurationModeSelect(coordinator))
+        entities.append(PoolmanFiltrationBoostSelect(coordinator))
     async_add_entities(entities)
 
 
@@ -104,3 +114,86 @@ class PoolmanFiltrationDurationModeSelect(PoolmanEntity, SelectEntity, RestoreEn
         """Change the filtration duration mode."""
         self.coordinator.filtration_duration_mode = FiltrationDurationMode(option)
         await self.coordinator.async_request_refresh()
+
+
+class PoolmanFiltrationBoostSelect(PoolmanEntity, SelectEntity, RestoreEntity):
+    """Select entity for filtration boost presets.
+
+    Allows triggering a manual filtration boost by selecting a preset
+    duration (+2h, +4h, +8h, +24h) or cancelling an active boost
+    by selecting "none".
+
+    The boost end time is persisted via extra state attributes so that
+    it can be restored after a Home Assistant restart.
+    """
+
+    entity_description: SelectEntityDescription
+
+    def __init__(self, coordinator: PoolmanCoordinator) -> None:
+        """Initialize the filtration boost select."""
+        super().__init__(coordinator)
+        self.entity_description = FILTRATION_BOOST_DESCRIPTION
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}_filtration_boost"
+        self._attr_current_option = BOOST_PRESET_NONE
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str | None]:
+        """Return extra state attributes for persistence.
+
+        Stores the boost end datetime so it can be restored after
+        a Home Assistant restart.
+
+        Returns:
+            Dictionary with ``boost_end`` ISO-format string, or None.
+        """
+        scheduler = self.coordinator.scheduler
+        boost_end = scheduler.boost_end if scheduler is not None else None
+        return {
+            "boost_end": boost_end.isoformat() if boost_end is not None else None,
+        }
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the boost from persisted state after HA restart."""
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state is None or last_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+            return
+
+        # Restore boost from the persisted boost_end attribute
+        boost_end_str = last_state.attributes.get("boost_end")
+        if boost_end_str is not None and self.coordinator.scheduler is not None:
+            try:
+                boost_end = datetime.fromisoformat(boost_end_str)
+                await self.coordinator.scheduler.async_restore_boost(boost_end)
+                # Set the select to a non-"none" value while boost is active
+                if self.coordinator.scheduler.boost_active:
+                    self._attr_current_option = last_state.state
+            except (ValueError, TypeError):
+                pass
+
+    def _handle_coordinator_update(self) -> None:
+        """Auto-reset select to "none" when boost expires naturally.
+
+        Called by the coordinator after each data refresh.
+        """
+        super()._handle_coordinator_update()
+        scheduler = self.coordinator.scheduler
+        if scheduler is not None and not scheduler.boost_active:
+            self._attr_current_option = BOOST_PRESET_NONE
+
+    async def async_select_option(self, option: str) -> None:
+        """Handle a boost preset selection.
+
+        Selecting "none" cancels any active boost.  Selecting a numeric
+        preset activates a boost for that many hours.
+
+        Args:
+            option: The selected preset ("none", "2", "4", "8", or "24").
+        """
+        self._attr_current_option = option
+        if option == BOOST_PRESET_NONE:
+            await self.coordinator.async_cancel_boost()
+        else:
+            hours = float(option)
+            await self.coordinator.async_boost_filtration(hours)
+        self.async_write_ha_state()

--- a/custom_components/poolman/sensor.py
+++ b/custom_components/poolman/sensor.py
@@ -255,6 +255,18 @@ SENSOR_DESCRIPTIONS: tuple[PoolmanSensorEntityDescription, ...] = (
     ),
 )
 
+FILTRATION_SENSOR_DESCRIPTIONS: tuple[PoolmanSensorEntityDescription, ...] = (
+    PoolmanSensorEntityDescription(
+        key="filtration_boost_remaining",
+        translation_key="filtration_boost_remaining",
+        native_unit_of_measurement=UnitOfTime.HOURS,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+        icon="mdi:pump",
+        value_fn=lambda state: state.boost_remaining,
+    ),
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -263,9 +275,10 @@ async def async_setup_entry(
 ) -> None:
     """Set up Pool Manager sensors."""
     coordinator: PoolmanCoordinator = entry.runtime_data
-    async_add_entities(
-        PoolmanSensor(coordinator, description) for description in SENSOR_DESCRIPTIONS
-    )
+    descriptions = list(SENSOR_DESCRIPTIONS)
+    if coordinator.scheduler is not None:
+        descriptions.extend(FILTRATION_SENSOR_DESCRIPTIONS)
+    async_add_entities(PoolmanSensor(coordinator, description) for description in descriptions)
 
 
 class PoolmanSensor(PoolmanEntity, SensorEntity):

--- a/custom_components/poolman/services.yaml
+++ b/custom_components/poolman/services.yaml
@@ -87,3 +87,26 @@ record_measure:
       description: Optional notes about the measurement.
       selector:
         text:
+
+boost_filtration:
+  name: Boost filtration
+  description: Activate a manual filtration boost for extra continuous pump time.
+  fields:
+    device_id:
+      name: Pool device
+      description: The pool to boost filtration for.
+      required: true
+      selector:
+        device:
+          integration: poolman
+    hours:
+      name: Duration (hours)
+      description: Number of extra filtration hours to add. Set to 0 to cancel an active boost.
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 48
+          step: 0.5
+          unit_of_measurement: h
+          mode: box

--- a/custom_components/poolman/strings.json
+++ b/custom_components/poolman/strings.json
@@ -170,6 +170,9 @@
       },
       "safe_at": {
         "name": "Safe to swim at"
+      },
+      "filtration_boost_remaining": {
+        "name": "Filtration boost remaining"
       }
     },
     "binary_sensor": {
@@ -370,7 +373,10 @@
           "event_type": {
             "state": {
               "filtration_started": "Filtration started",
-              "filtration_stopped": "Filtration stopped"
+              "filtration_stopped": "Filtration stopped",
+              "boost_started": "Boost started",
+              "boost_consumed": "Boost consumed",
+              "boost_cancelled": "Boost cancelled"
             }
           }
         }
@@ -452,6 +458,16 @@
           "dynamic": "Dynamic",
           "split_static": "Split (static)",
           "split_dynamic": "Split (dynamic)"
+        }
+      },
+      "filtration_boost": {
+        "name": "Filtration boost",
+        "state": {
+          "none": "None",
+          "2": "+2 hours",
+          "4": "+4 hours",
+          "8": "+8 hours",
+          "24": "+24 hours"
         }
       }
     },
@@ -576,6 +592,20 @@
         "notes": {
           "name": "Notes",
           "description": "Optional notes about the measurement."
+        }
+      }
+    },
+    "boost_filtration": {
+      "name": "Boost filtration",
+      "description": "Activate a manual filtration boost for extra continuous pump time.",
+      "fields": {
+        "device_id": {
+          "name": "Pool device",
+          "description": "The pool to boost filtration for."
+        },
+        "hours": {
+          "name": "Duration (hours)",
+          "description": "Number of extra filtration hours to add. Set to 0 to cancel an active boost."
         }
       }
     }

--- a/custom_components/poolman/translations/en.json
+++ b/custom_components/poolman/translations/en.json
@@ -170,6 +170,9 @@
       },
       "safe_at": {
         "name": "Safe to swim at"
+      },
+      "filtration_boost_remaining": {
+        "name": "Filtration boost remaining"
       }
     },
     "binary_sensor": {
@@ -370,7 +373,10 @@
           "event_type": {
             "state": {
               "filtration_started": "Filtration started",
-              "filtration_stopped": "Filtration stopped"
+              "filtration_stopped": "Filtration stopped",
+              "boost_started": "Boost started",
+              "boost_consumed": "Boost consumed",
+              "boost_cancelled": "Boost cancelled"
             }
           }
         }
@@ -452,6 +458,16 @@
           "dynamic": "Dynamic",
           "split_static": "Split (static)",
           "split_dynamic": "Split (dynamic)"
+        }
+      },
+      "filtration_boost": {
+        "name": "Filtration boost",
+        "state": {
+          "none": "None",
+          "2": "+2 hours",
+          "4": "+4 hours",
+          "8": "+8 hours",
+          "24": "+24 hours"
         }
       }
     },
@@ -576,6 +592,20 @@
         "notes": {
           "name": "Notes",
           "description": "Optional notes about the measurement."
+        }
+      }
+    },
+    "boost_filtration": {
+      "name": "Boost filtration",
+      "description": "Activate a manual filtration boost for extra continuous pump runtime.",
+      "fields": {
+        "device_id": {
+          "name": "Pool device",
+          "description": "The pool to boost filtration for."
+        },
+        "hours": {
+          "name": "Hours",
+          "description": "Number of extra filtration hours (0 to cancel)."
         }
       }
     }

--- a/custom_components/poolman/translations/fr.json
+++ b/custom_components/poolman/translations/fr.json
@@ -170,6 +170,9 @@
       },
       "safe_at": {
         "name": "Baignade sûre à"
+      },
+      "filtration_boost_remaining": {
+        "name": "Boost de filtration restant"
       }
     },
     "binary_sensor": {
@@ -370,7 +373,10 @@
           "event_type": {
             "state": {
               "filtration_started": "Filtration démarrée",
-              "filtration_stopped": "Filtration arrêtée"
+              "filtration_stopped": "Filtration arrêtée",
+              "boost_started": "Boost démarré",
+              "boost_consumed": "Boost consommé",
+              "boost_cancelled": "Boost annulé"
             }
           }
         }
@@ -452,6 +458,16 @@
           "dynamic": "Dynamique",
           "split_static": "Répartie (statique)",
           "split_dynamic": "Répartie (dynamique)"
+        }
+      },
+      "filtration_boost": {
+        "name": "Boost de filtration",
+        "state": {
+          "none": "Aucun",
+          "2": "+2 heures",
+          "4": "+4 heures",
+          "8": "+8 heures",
+          "24": "+24 heures"
         }
       }
     },
@@ -576,6 +592,20 @@
         "notes": {
           "name": "Notes",
           "description": "Notes optionnelles sur la mesure."
+        }
+      }
+    },
+    "boost_filtration": {
+      "name": "Boost de filtration",
+      "description": "Activer un boost de filtration manuel pour un temps de pompe continu suppl\u00e9mentaire.",
+      "fields": {
+        "device_id": {
+          "name": "Appareil piscine",
+          "description": "La piscine pour laquelle booster la filtration."
+        },
+        "hours": {
+          "name": "Heures",
+          "description": "Nombre d'heures de filtration suppl\u00e9mentaires (0 pour annuler)."
         }
       }
     }

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -176,7 +176,17 @@ scheduling behavior, cross-midnight support, and automation examples.
 
 | Entity | Name | Event types | Description |
 | --- | --- | --- | --- |
-| `event.{pool}_filtration` | Filtration | `filtration_started`, `filtration_stopped` | Fires when the pump is turned on or off by the scheduler |
+| `event.{pool}_filtration` | Filtration | `filtration_started`, `filtration_stopped`, `boost_started`, `boost_consumed`, `boost_cancelled` | Fires when the pump is turned on or off by the scheduler, or when a boost is activated, consumed, or cancelled |
+
+### Filtration Boost
+
+| Entity | Name | Type | Options / Unit | Description |
+| --- | --- | --- | --- | --- |
+| `select.{pool}_filtration_boost` | Filtration boost | Select | `none`, `+2h`, `+4h`, `+8h`, `+24h` | Activate a preset boost or cancel the current boost |
+| `sensor.{pool}_filtration_boost_remaining` | Filtration boost remaining | Sensor | hours | Remaining boost hours (0 when no boost is active) |
+
+See [Filtration Control -- Filtration Boost](filtration-control.md#filtration-boost)
+for full details on boost behavior, persistence, and automation examples.
 
 ## Events
 

--- a/docs/filtration-control.md
+++ b/docs/filtration-control.md
@@ -269,3 +269,118 @@ turns the pump on and off.
 - In **split (dynamic) mode**, the recommendation drives the second
   period's duration: the remaining hours after subtracting period 1's
   duration are assigned to period 2.
+
+## Filtration Boost
+
+The **filtration boost** lets you manually trigger extra continuous
+filtration time on top of the daily schedule. This is useful when you
+need additional circulation -- for example, after adding chemicals, after
+a pool party, or during a heat wave.
+
+### How it works
+
+- **Inside a scheduled window**: the boost extends the pump run past
+  the next natural stop. The pump continues running without
+  interruption until the boost expires.
+- **Outside a scheduled window**: the pump starts **immediately** and
+  runs for the boost duration.
+- **Split mode**: while a boost is active the pump does **not** stop
+  between periods. The boost keeps the pump running continuously until
+  it expires.
+- A new boost **replaces** any previously active boost.
+
+### Boost entities
+
+| Entity | Name | Type | Options | Description |
+| --- | --- | --- | --- | --- |
+| `select.{pool}_filtration_boost` | Filtration boost | Select | `none`, `+2h`, `+4h`, `+8h`, `+24h` | Activate a preset boost duration or cancel the current boost |
+| `sensor.{pool}_filtration_boost_remaining` | Filtration boost remaining | Sensor (hours) | -- | Remaining boost hours (0 when no boost is active) |
+
+The filtration event entity (`event.{pool}_filtration`) also fires boost
+events:
+
+| Event type | Description |
+| --- | --- |
+| `boost_started` | A boost has been activated |
+| `boost_consumed` | The boost has expired naturally |
+| `boost_cancelled` | The boost was cancelled by the user |
+
+Boost events include the following attributes:
+
+| Attribute | Type | Example | Description |
+| --- | --- | --- | --- |
+| `boost_hours` | float | `4.0` | Requested boost duration in hours |
+| `boost_end` | string (ISO datetime) | `"2025-07-15T22:00:00"` | When the boost expires (only present once consumption has started) |
+
+### Service
+
+You can also activate a boost with a custom duration using the
+`poolman.boost_filtration` service:
+
+```yaml
+service: poolman.boost_filtration
+data:
+  device_id: "your_pool_device_id"
+  hours: 6.0
+```
+
+Set `hours` to `0` to cancel an active boost.
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `device_id` | string | yes | The pool device to boost |
+| `hours` | float | yes | Extra filtration hours (0 to cancel, max 48) |
+
+### Persistence
+
+The boost end time is persisted via the select entity's extra state
+attributes. After a Home Assistant restart, the integration restores
+any active boost and resumes the countdown. If the boost has already
+expired during the downtime, it is silently discarded.
+
+### Cancellation
+
+A boost can be cancelled by:
+
+- Selecting **None** in the boost select entity
+- Calling `poolman.boost_filtration` with `hours: 0`
+- Disabling the filtration control switch (which also stops the pump)
+
+If the pump was only running because of the boost (outside the normal
+schedule), it is turned off upon cancellation.
+
+### Automation examples
+
+#### Boost filtration after a treatment
+
+```yaml
+automation:
+  - alias: "Boost after shock chlorine"
+    trigger:
+      - platform: state
+        entity_id: event.demo_pool_chlore_choc
+        attribute: event_type
+        to: "applied"
+    action:
+      - action: poolman.boost_filtration
+        data:
+          device_id: "your_pool_device_id"
+          hours: 8.0
+```
+
+#### Notify when boost expires
+
+```yaml
+automation:
+  - alias: "Notify boost consumed"
+    trigger:
+      - platform: state
+        entity_id: event.demo_pool_filtration
+        attribute: event_type
+        to: "boost_consumed"
+    action:
+      - action: notify.notify
+        data:
+          title: "Pool"
+          message: "Filtration boost has finished"
+```

--- a/tests/test_coordinator_filtration.py
+++ b/tests/test_coordinator_filtration.py
@@ -440,3 +440,77 @@ class TestSplitModeTransitions:
             duration_hours=4.0,
             period_index=1,
         )
+
+
+class TestBoostRemainingInPoolState:
+    """Tests for boost_remaining integration in PoolState."""
+
+    @pytest.mark.asyncio
+    async def test_pool_state_includes_boost_remaining(
+        self, coordinator: PoolmanCoordinator, mock_scheduler: MagicMock
+    ) -> None:
+        """PoolState should include boost_remaining from the scheduler."""
+        mock_scheduler.boost_remaining = 4.0
+
+        state = await coordinator._async_update_data()
+        assert state.boost_remaining == 4.0
+
+    @pytest.mark.asyncio
+    async def test_pool_state_boost_remaining_zero_when_no_boost(
+        self, coordinator: PoolmanCoordinator, mock_scheduler: MagicMock
+    ) -> None:
+        """PoolState boost_remaining should be 0 when no boost is active."""
+        mock_scheduler.boost_remaining = 0.0
+
+        state = await coordinator._async_update_data()
+        assert state.boost_remaining == 0.0
+
+    @pytest.mark.asyncio
+    async def test_pool_state_boost_remaining_zero_without_scheduler(
+        self, coordinator_no_pump: PoolmanCoordinator
+    ) -> None:
+        """PoolState boost_remaining should be 0 when no scheduler is configured."""
+        state = await coordinator_no_pump._async_update_data()
+        assert state.boost_remaining == 0.0
+
+
+class TestBoostCoordinatorBridge:
+    """Tests for coordinator boost bridge methods."""
+
+    @pytest.mark.asyncio
+    async def test_async_boost_filtration_delegates_to_scheduler(
+        self, coordinator: PoolmanCoordinator, mock_scheduler: MagicMock
+    ) -> None:
+        """async_boost_filtration should delegate to scheduler.async_boost."""
+        mock_scheduler.async_boost = AsyncMock()
+
+        with patch.object(coordinator, "async_request_refresh", new_callable=AsyncMock):
+            await coordinator.async_boost_filtration(4.0)
+        mock_scheduler.async_boost.assert_called_once_with(4.0)
+
+    @pytest.mark.asyncio
+    async def test_async_cancel_boost_delegates_to_scheduler(
+        self, coordinator: PoolmanCoordinator, mock_scheduler: MagicMock
+    ) -> None:
+        """async_cancel_boost should delegate to scheduler.async_cancel_boost."""
+        mock_scheduler.async_cancel_boost = AsyncMock()
+
+        with patch.object(coordinator, "async_request_refresh", new_callable=AsyncMock):
+            await coordinator.async_cancel_boost()
+        mock_scheduler.async_cancel_boost.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_async_boost_filtration_noop_without_scheduler(
+        self, coordinator_no_pump: PoolmanCoordinator
+    ) -> None:
+        """async_boost_filtration should be a no-op without a scheduler."""
+        # Should not raise
+        await coordinator_no_pump.async_boost_filtration(4.0)
+
+    @pytest.mark.asyncio
+    async def test_async_cancel_boost_noop_without_scheduler(
+        self, coordinator_no_pump: PoolmanCoordinator
+    ) -> None:
+        """async_cancel_boost should be a no-op without a scheduler."""
+        # Should not raise
+        await coordinator_no_pump.async_cancel_boost()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -12,6 +12,7 @@ from custom_components.poolman.const import (
     DEFAULT_TREATMENT,
     DOMAIN,
     SERVICE_ADD_TREATMENT,
+    SERVICE_BOOST_FILTRATION,
     SERVICE_RECORD_MEASURE,
 )
 from custom_components.poolman.coordinator import PoolmanCoordinator
@@ -44,6 +45,17 @@ class TestSetupEntry:
         assert hass.services.has_service(DOMAIN, SERVICE_ADD_TREATMENT)
         assert hass.services.has_service(DOMAIN, SERVICE_RECORD_MEASURE)
 
+    async def test_setup_registers_boost_service(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Setting up should register the boost_filtration service."""
+        mock_config_entry.add_to_hass(hass)
+        setup_mock_states(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert hass.services.has_service(DOMAIN, SERVICE_BOOST_FILTRATION)
+
     async def test_service_registration_idempotent(
         self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
     ) -> None:
@@ -57,7 +69,7 @@ class TestSetupEntry:
 
         assert hass.services.has_service(DOMAIN, SERVICE_ADD_TREATMENT)
 
-        # Call again — should be a no-op, not raise
+        # Call again -- should be a no-op, not raise
         _async_register_services(hass)
         assert hass.services.has_service(DOMAIN, SERVICE_ADD_TREATMENT)
 
@@ -94,6 +106,22 @@ class TestUnloadEntry:
 
         assert not hass.services.has_service(DOMAIN, SERVICE_ADD_TREATMENT)
         assert not hass.services.has_service(DOMAIN, SERVICE_RECORD_MEASURE)
+
+    async def test_unload_last_entry_removes_boost_service(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Unloading the last entry should remove the boost service."""
+        mock_config_entry.add_to_hass(hass)
+        setup_mock_states(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert hass.services.has_service(DOMAIN, SERVICE_BOOST_FILTRATION)
+
+        await hass.config_entries.async_unload(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert not hass.services.has_service(DOMAIN, SERVICE_BOOST_FILTRATION)
 
 
 class TestMigrateEntry:
@@ -358,6 +386,103 @@ class TestRecordMeasureServiceHandler:
                 "device_id": "nonexistent_device_id",
                 "parameter": "ph",
                 "value": 7.0,
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+
+class TestBoostServiceHandler:
+    """Tests for the boost_filtration service handler."""
+
+    async def test_boost_service_with_valid_device(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Service call with a valid device should activate boost on the coordinator."""
+        mock_config_entry.add_to_hass(hass)
+        setup_mock_states(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        from homeassistant.helpers import device_registry as dr
+
+        device_registry = dr.async_get(hass)
+        device = device_registry.async_get_device(
+            identifiers={(DOMAIN, mock_config_entry.entry_id)}
+        )
+        assert device is not None
+
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_BOOST_FILTRATION,
+            {
+                "device_id": device.id,
+                "hours": 4.0,
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+        coordinator: PoolmanCoordinator = mock_config_entry.runtime_data
+        assert coordinator.scheduler is not None
+        assert coordinator.scheduler.boost_active is True
+
+    async def test_boost_service_zero_hours_cancels(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Service call with hours=0 should cancel any active boost."""
+        mock_config_entry.add_to_hass(hass)
+        setup_mock_states(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        from homeassistant.helpers import device_registry as dr
+
+        device_registry = dr.async_get(hass)
+        device = device_registry.async_get_device(
+            identifiers={(DOMAIN, mock_config_entry.entry_id)}
+        )
+        assert device is not None
+
+        # Activate a boost first
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_BOOST_FILTRATION,
+            {"device_id": device.id, "hours": 4.0},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+        coordinator: PoolmanCoordinator = mock_config_entry.runtime_data
+        assert coordinator.scheduler is not None
+        assert coordinator.scheduler.boost_active is True
+
+        # Cancel with hours=0
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_BOOST_FILTRATION,
+            {"device_id": device.id, "hours": 0},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+        assert coordinator.scheduler.boost_active is False
+
+    async def test_boost_service_with_unknown_device(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Service call with unknown device_id should log warning and not crash."""
+        mock_config_entry.add_to_hass(hass)
+        setup_mock_states(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_BOOST_FILTRATION,
+            {
+                "device_id": "nonexistent_device_id",
+                "hours": 4.0,
             },
             blocking=True,
         )

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -12,6 +12,9 @@ from custom_components.poolman.const import (
     DEFAULT_FILTRATION_DURATION_HOURS_2,
     DEFAULT_FILTRATION_START_TIME,
     DEFAULT_FILTRATION_START_TIME_2,
+    EVENT_BOOST_CANCELLED,
+    EVENT_BOOST_CONSUMED,
+    EVENT_BOOST_STARTED,
     EVENT_FILTRATION_STARTED,
     EVENT_FILTRATION_STOPPED,
 )
@@ -650,3 +653,407 @@ class TestMultiPeriodEvents:
         event_type, event_data = listener.call_args[0]
         assert event_type == EVENT_FILTRATION_STOPPED
         assert event_data["period_index"] == 0
+
+
+# ---------- Boost tests ----------
+
+
+class TestBoostDefaults:
+    """Tests for default boost state."""
+
+    def test_boost_not_active_by_default(self, scheduler: FiltrationScheduler) -> None:
+        """Boost should be inactive by default."""
+        assert scheduler.boost_active is False
+
+    def test_boost_remaining_zero_by_default(self, scheduler: FiltrationScheduler) -> None:
+        """Boost remaining should be 0 by default."""
+        assert scheduler.boost_remaining == 0.0
+
+    def test_boost_end_none_by_default(self, scheduler: FiltrationScheduler) -> None:
+        """Boost end should be None by default."""
+        assert scheduler.boost_end is None
+
+
+class TestBoostActivation:
+    """Tests for activating a filtration boost."""
+
+    @pytest.mark.asyncio
+    async def test_boost_outside_window_starts_pump(
+        self, scheduler: FiltrationScheduler, hass: MagicMock
+    ) -> None:
+        """Boost outside schedule window should start the pump immediately."""
+        with patch.object(scheduler, "is_in_active_window", return_value=False):
+            await scheduler.async_boost(4.0)
+        hass.services.async_call.assert_called_once_with(
+            "switch", "turn_on", {"entity_id": "switch.pool_pump"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_boost_outside_window_sets_boost_end(
+        self, scheduler: FiltrationScheduler
+    ) -> None:
+        """Boost outside window should set boost_end immediately."""
+        with (
+            patch.object(scheduler, "is_in_active_window", return_value=False),
+            patch("custom_components.poolman.scheduler.async_track_point_in_time") as mock_track,
+        ):
+            mock_track.return_value = MagicMock()
+            await scheduler.async_boost(4.0)
+        assert scheduler.boost_active is True
+        assert scheduler.boost_end is not None
+
+    @pytest.mark.asyncio
+    async def test_boost_inside_window_does_not_start_pump(
+        self, scheduler: FiltrationScheduler, hass: MagicMock
+    ) -> None:
+        """Boost inside schedule window should not call start_pump (already running)."""
+        with patch.object(scheduler, "is_in_active_window", return_value=True):
+            await scheduler.async_boost(4.0)
+        hass.services.async_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_boost_inside_window_defers_boost_end(
+        self, scheduler: FiltrationScheduler
+    ) -> None:
+        """Boost inside window should defer boost_end until first stop is suppressed."""
+        with patch.object(scheduler, "is_in_active_window", return_value=True):
+            await scheduler.async_boost(4.0)
+        assert scheduler.boost_active is True
+        assert scheduler.boost_end is None  # Deferred
+        assert scheduler.boost_remaining == 4.0
+
+    @pytest.mark.asyncio
+    async def test_boost_notifies_listeners(self, scheduler: FiltrationScheduler) -> None:
+        """Boost activation should notify listeners with boost_started."""
+        listener = MagicMock()
+        scheduler.on_event(listener)
+        with patch.object(scheduler, "is_in_active_window", return_value=True):
+            await scheduler.async_boost(2.0)
+        listener.assert_called_once()
+        event_type, event_data = listener.call_args[0]
+        assert event_type == EVENT_BOOST_STARTED
+        assert event_data["boost_hours"] == 2.0
+
+    @pytest.mark.asyncio
+    async def test_boost_zero_hours_cancels(self, scheduler: FiltrationScheduler) -> None:
+        """Calling boost with 0 hours should cancel any active boost."""
+        with patch.object(scheduler, "is_in_active_window", return_value=True):
+            await scheduler.async_boost(4.0)
+        assert scheduler.boost_active is True
+
+        with patch.object(scheduler, "is_in_active_window", return_value=True):
+            await scheduler.async_boost(0)
+        assert scheduler.boost_active is False
+
+    @pytest.mark.asyncio
+    async def test_new_boost_replaces_previous(self, scheduler: FiltrationScheduler) -> None:
+        """A new boost should replace any previous boost."""
+        with patch.object(scheduler, "is_in_active_window", return_value=True):
+            await scheduler.async_boost(4.0)
+        assert scheduler.boost_remaining == 4.0
+
+        with patch.object(scheduler, "is_in_active_window", return_value=True):
+            await scheduler.async_boost(8.0)
+        assert scheduler.boost_remaining == 8.0
+
+
+class TestBoostCancellation:
+    """Tests for cancelling a filtration boost."""
+
+    @pytest.mark.asyncio
+    async def test_cancel_boost_clears_state(self, scheduler: FiltrationScheduler) -> None:
+        """Cancelling boost should reset all boost state."""
+        with patch.object(scheduler, "is_in_active_window", return_value=True):
+            await scheduler.async_boost(4.0)
+        assert scheduler.boost_active is True
+
+        with patch.object(scheduler, "is_in_active_window", return_value=True):
+            await scheduler.async_cancel_boost()
+        assert scheduler.boost_active is False
+        assert scheduler.boost_remaining == 0.0
+        assert scheduler.boost_end is None
+
+    @pytest.mark.asyncio
+    async def test_cancel_boost_stops_pump_outside_window(
+        self, scheduler: FiltrationScheduler, hass: MagicMock
+    ) -> None:
+        """Cancelling boost outside schedule should stop the pump."""
+        with (
+            patch.object(scheduler, "is_in_active_window", return_value=False),
+            patch("custom_components.poolman.scheduler.async_track_point_in_time") as mock_track,
+        ):
+            mock_track.return_value = MagicMock()
+            await scheduler.async_boost(4.0)
+        hass.services.async_call.reset_mock()
+
+        with patch.object(scheduler, "is_in_active_window", return_value=False):
+            await scheduler.async_cancel_boost()
+        hass.services.async_call.assert_called_once_with(
+            "switch", "turn_off", {"entity_id": "switch.pool_pump"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_cancel_boost_does_not_stop_pump_inside_window(
+        self, scheduler: FiltrationScheduler, hass: MagicMock
+    ) -> None:
+        """Cancelling boost inside schedule should not stop the pump."""
+        with patch.object(scheduler, "is_in_active_window", return_value=True):
+            await scheduler.async_boost(4.0)
+        hass.services.async_call.reset_mock()
+
+        with patch.object(scheduler, "is_in_active_window", return_value=True):
+            await scheduler.async_cancel_boost()
+        hass.services.async_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cancel_boost_notifies_listeners(self, scheduler: FiltrationScheduler) -> None:
+        """Cancelling boost should notify listeners with boost_cancelled."""
+        with patch.object(scheduler, "is_in_active_window", return_value=True):
+            await scheduler.async_boost(4.0)
+
+        listener = MagicMock()
+        scheduler.on_event(listener)
+        with patch.object(scheduler, "is_in_active_window", return_value=True):
+            await scheduler.async_cancel_boost()
+        listener.assert_called_once()
+        event_type, _ = listener.call_args[0]
+        assert event_type == EVENT_BOOST_CANCELLED
+
+    @pytest.mark.asyncio
+    async def test_cancel_noop_when_no_boost(self, scheduler: FiltrationScheduler) -> None:
+        """Cancelling when no boost is active should be a no-op."""
+        listener = MagicMock()
+        scheduler.on_event(listener)
+        await scheduler.async_cancel_boost()
+        listener.assert_not_called()
+
+
+class TestBoostStopSuppression:
+    """Tests for boost suppressing scheduled stops."""
+
+    @pytest.mark.asyncio
+    async def test_stop_callback_suppressed_during_boost(
+        self, scheduler: FiltrationScheduler, hass: MagicMock
+    ) -> None:
+        """Stop callback should be suppressed when boost is active."""
+        scheduler._enabled = True
+        with patch.object(scheduler, "is_in_active_window", return_value=True):
+            await scheduler.async_boost(4.0)
+        hass.services.async_call.reset_mock()
+
+        # Simulate stop callback firing
+        with patch("custom_components.poolman.scheduler.async_track_point_in_time") as mock_track:
+            mock_track.return_value = MagicMock()
+            cb = scheduler._make_stop_callback(0)
+            now = datetime(2025, 7, 15, 18, 0, 0)
+            await cb(now)
+
+        # Pump should NOT have been stopped
+        hass.services.async_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_first_suppressed_stop_sets_boost_end(
+        self, scheduler: FiltrationScheduler
+    ) -> None:
+        """First suppressed stop should calculate and set boost_end."""
+        scheduler._enabled = True
+        with patch.object(scheduler, "is_in_active_window", return_value=True):
+            await scheduler.async_boost(4.0)
+        assert scheduler.boost_end is None  # Not yet set
+
+        with patch("custom_components.poolman.scheduler.async_track_point_in_time") as mock_track:
+            mock_track.return_value = MagicMock()
+            cb = scheduler._make_stop_callback(0)
+            now = datetime(2025, 7, 15, 18, 0, 0)
+            await cb(now)
+
+        # Now boost_end should be set
+        from datetime import timedelta
+
+        expected_end = now + timedelta(hours=4.0)
+        assert scheduler.boost_end == expected_end
+
+    @pytest.mark.asyncio
+    async def test_second_suppressed_stop_does_not_change_boost_end(
+        self, scheduler: FiltrationScheduler
+    ) -> None:
+        """Subsequent suppressed stops should not change boost_end."""
+        scheduler._enabled = True
+        with patch.object(scheduler, "is_in_active_window", return_value=True):
+            await scheduler.async_boost(4.0)
+
+        with patch("custom_components.poolman.scheduler.async_track_point_in_time") as mock_track:
+            mock_track.return_value = MagicMock()
+            cb = scheduler._make_stop_callback(0)
+            now1 = datetime(2025, 7, 15, 18, 0, 0)
+            await cb(now1)
+
+        first_end = scheduler.boost_end
+
+        with patch("custom_components.poolman.scheduler.async_track_point_in_time") as mock_track:
+            mock_track.return_value = MagicMock()
+            cb2 = scheduler._make_stop_callback(1)
+            now2 = datetime(2025, 7, 15, 20, 0, 0)
+            await cb2(now2)
+
+        assert scheduler.boost_end == first_end  # Unchanged
+
+
+class TestBoostConsumed:
+    """Tests for natural boost expiry."""
+
+    @pytest.mark.asyncio
+    async def test_boost_consumed_clears_state(self, scheduler: FiltrationScheduler) -> None:
+        """Boost consumed should reset boost state."""
+        scheduler._boost_hours = 4.0
+        scheduler._boost_end = datetime(2025, 7, 15, 22, 0, 0)
+
+        with patch.object(scheduler, "is_in_active_window", return_value=False):
+            await scheduler._async_on_boost_consumed()
+
+        assert scheduler.boost_active is False
+        assert scheduler.boost_remaining == 0.0
+        assert scheduler.boost_end is None
+
+    @pytest.mark.asyncio
+    async def test_boost_consumed_stops_pump_outside_window(
+        self, scheduler: FiltrationScheduler, hass: MagicMock
+    ) -> None:
+        """Boost consumed outside schedule should stop the pump."""
+        scheduler._boost_hours = 4.0
+        scheduler._boost_end = datetime(2025, 7, 15, 22, 0, 0)
+
+        with patch.object(scheduler, "is_in_active_window", return_value=False):
+            await scheduler._async_on_boost_consumed()
+
+        hass.services.async_call.assert_called_once_with(
+            "switch", "turn_off", {"entity_id": "switch.pool_pump"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_boost_consumed_does_not_stop_inside_window(
+        self, scheduler: FiltrationScheduler, hass: MagicMock
+    ) -> None:
+        """Boost consumed inside schedule should not stop the pump."""
+        scheduler._boost_hours = 4.0
+        scheduler._boost_end = datetime(2025, 7, 15, 22, 0, 0)
+
+        with patch.object(scheduler, "is_in_active_window", return_value=True):
+            await scheduler._async_on_boost_consumed()
+
+        hass.services.async_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_boost_consumed_notifies_listeners(self, scheduler: FiltrationScheduler) -> None:
+        """Boost consumed should notify listeners with boost_consumed."""
+        scheduler._boost_hours = 4.0
+        scheduler._boost_end = datetime(2025, 7, 15, 22, 0, 0)
+
+        listener = MagicMock()
+        scheduler.on_event(listener)
+
+        with patch.object(scheduler, "is_in_active_window", return_value=False):
+            await scheduler._async_on_boost_consumed()
+
+        # First call should be boost_consumed, second is filtration_stopped from pump stop
+        assert listener.call_count >= 1
+        event_type, _ = listener.call_args_list[0][0]
+        assert event_type == EVENT_BOOST_CONSUMED
+
+
+class TestBoostRestore:
+    """Tests for restoring a boost after HA restart."""
+
+    @pytest.mark.asyncio
+    async def test_restore_valid_boost(self, scheduler: FiltrationScheduler) -> None:
+        """Restoring a boost with future end time should reactivate it."""
+        from datetime import timedelta
+
+        from homeassistant.util import dt as dt_util
+
+        future = dt_util.now() + timedelta(hours=3)
+        with (
+            patch.object(scheduler, "is_in_active_window", return_value=True),
+            patch("custom_components.poolman.scheduler.async_track_point_in_time") as mock_track,
+        ):
+            mock_track.return_value = MagicMock()
+            await scheduler.async_restore_boost(future)
+
+        assert scheduler.boost_active is True
+        assert scheduler.boost_end == future
+        assert scheduler.boost_remaining > 0
+
+    @pytest.mark.asyncio
+    async def test_restore_expired_boost_is_ignored(self, scheduler: FiltrationScheduler) -> None:
+        """Restoring a boost with past end time should be silently discarded."""
+        from datetime import timedelta
+
+        from homeassistant.util import dt as dt_util
+
+        past = dt_util.now() - timedelta(hours=1)
+        await scheduler.async_restore_boost(past)
+        assert scheduler.boost_active is False
+
+    @pytest.mark.asyncio
+    async def test_restore_boost_starts_pump_outside_window(
+        self, scheduler: FiltrationScheduler, hass: MagicMock
+    ) -> None:
+        """Restoring boost outside schedule should start the pump."""
+        from datetime import timedelta
+
+        from homeassistant.util import dt as dt_util
+
+        future = dt_util.now() + timedelta(hours=3)
+        with (
+            patch.object(scheduler, "is_in_active_window", return_value=False),
+            patch("custom_components.poolman.scheduler.async_track_point_in_time") as mock_track,
+        ):
+            mock_track.return_value = MagicMock()
+            await scheduler.async_restore_boost(future)
+
+        hass.services.async_call.assert_called_once_with(
+            "switch", "turn_on", {"entity_id": "switch.pool_pump"}
+        )
+
+
+class TestDisableClearsBoost:
+    """Tests that disabling the scheduler clears boost state."""
+
+    @pytest.mark.asyncio
+    async def test_disable_clears_boost(self, scheduler: FiltrationScheduler) -> None:
+        """Disabling the scheduler should cancel any active boost."""
+        with patch.object(scheduler, "is_in_active_window", return_value=True):
+            await scheduler.async_boost(4.0)
+        assert scheduler.boost_active is True
+
+        await scheduler.async_disable()
+        assert scheduler.boost_active is False
+        assert scheduler.boost_remaining == 0.0
+
+    def test_async_cancel_clears_boost(self, scheduler: FiltrationScheduler) -> None:
+        """async_cancel should clear boost state."""
+        scheduler._boost_hours = 4.0
+        scheduler._boost_end = datetime(2025, 7, 15, 22, 0, 0)
+        scheduler.async_cancel()
+        assert scheduler.boost_active is False
+        assert scheduler.boost_remaining == 0.0
+
+
+class TestBoostEventData:
+    """Tests for boost event data payload."""
+
+    def test_boost_event_data_without_end(self, scheduler: FiltrationScheduler) -> None:
+        """Boost event data before end is set should only contain boost_hours."""
+        scheduler._boost_hours = 4.0
+        data = scheduler._boost_event_data()
+        assert data["boost_hours"] == 4.0
+        assert "boost_end" not in data
+
+    def test_boost_event_data_with_end(self, scheduler: FiltrationScheduler) -> None:
+        """Boost event data after end is set should contain both fields."""
+        scheduler._boost_hours = 4.0
+        end = datetime(2025, 7, 15, 22, 0, 0)
+        scheduler._boost_end = end
+        data = scheduler._boost_event_data()
+        assert data["boost_hours"] == 4.0
+        assert data["boost_end"] == end.isoformat()

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,10 +1,11 @@
-"""Tests for the Pool Manager select platform (pool mode and filtration duration mode)."""
+"""Tests for the Pool Manager select platform (pool mode, filtration duration mode, and boost)."""
 
 from __future__ import annotations
 
 from homeassistant.core import HomeAssistant, State
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.poolman.const import BOOST_PRESET_NONE, BOOST_PRESETS
 from custom_components.poolman.coordinator import PoolmanCoordinator
 from custom_components.poolman.domain.model import FiltrationDurationMode, PoolMode
 from tests.conftest import setup_mock_states
@@ -213,3 +214,121 @@ class TestFiltrationDurationModeSelect:
         )
         coordinator = await _setup_integration(hass, mock_config_entry)
         assert coordinator.filtration_duration_mode == FiltrationDurationMode.DYNAMIC
+
+
+class TestFiltrationBoostSelect:
+    """Tests for the PoolmanFiltrationBoostSelect entity."""
+
+    async def test_entity_created_with_pump(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Filtration boost select should be created when pump is configured."""
+        await _setup_integration(hass, mock_config_entry)
+        state = hass.states.get("select.test_pool_filtration_boost")
+        assert state is not None
+        assert state.state == BOOST_PRESET_NONE
+
+    async def test_entity_not_created_without_pump(
+        self, hass: HomeAssistant, mock_config_entry_no_pump: MockConfigEntry
+    ) -> None:
+        """Filtration boost select should not be created without pump."""
+        await _setup_integration(hass, mock_config_entry_no_pump)
+        state = hass.states.get("select.test_pool_filtration_boost")
+        assert state is None
+
+    async def test_options_match_presets(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Options list should contain all boost presets."""
+        await _setup_integration(hass, mock_config_entry)
+        state = hass.states.get("select.test_pool_filtration_boost")
+        assert state is not None
+        options = state.attributes.get("options")
+        assert options == BOOST_PRESETS
+
+    async def test_select_preset_activates_boost(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Selecting a preset should activate a boost on the scheduler."""
+        coordinator = await _setup_integration(hass, mock_config_entry)
+
+        await hass.services.async_call(
+            "select",
+            "select_option",
+            {
+                "entity_id": "select.test_pool_filtration_boost",
+                "option": "4",
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+        assert coordinator.scheduler is not None
+        assert coordinator.scheduler.boost_active is True
+
+    async def test_select_none_cancels_boost(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Selecting 'none' should cancel any active boost."""
+        coordinator = await _setup_integration(hass, mock_config_entry)
+
+        # First activate a boost
+        await hass.services.async_call(
+            "select",
+            "select_option",
+            {
+                "entity_id": "select.test_pool_filtration_boost",
+                "option": "4",
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        assert coordinator.scheduler is not None
+        assert coordinator.scheduler.boost_active is True
+
+        # Then cancel it
+        await hass.services.async_call(
+            "select",
+            "select_option",
+            {
+                "entity_id": "select.test_pool_filtration_boost",
+                "option": BOOST_PRESET_NONE,
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        assert coordinator.scheduler.boost_active is False
+
+    async def test_boost_end_in_extra_attributes(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Extra state attributes should contain boost_end for persistence."""
+        await _setup_integration(hass, mock_config_entry)
+        state = hass.states.get("select.test_pool_filtration_boost")
+        assert state is not None
+        # Before boost, boost_end should be None
+        assert state.attributes.get("boost_end") is None
+
+    async def test_restore_boost_from_state(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Should restore boost from persisted boost_end attribute."""
+        from datetime import timedelta
+
+        from homeassistant.util import dt as dt_util
+        from pytest_homeassistant_custom_component.common import mock_restore_cache
+
+        future = dt_util.now() + timedelta(hours=3)
+        mock_restore_cache(
+            hass,
+            [
+                State(
+                    "select.test_pool_filtration_boost",
+                    "4",
+                    {"boost_end": future.isoformat()},
+                )
+            ],
+        )
+        coordinator = await _setup_integration(hass, mock_config_entry)
+        assert coordinator.scheduler is not None
+        assert coordinator.scheduler.boost_active is True


### PR DESCRIPTION
## Summary

- Add a **filtration boost** feature allowing users to trigger extra continuous pump runtime beyond the normal schedule, via a select entity (preset: +2h/+4h/+8h/+24h) or a `poolman.boost_filtration` service call for custom durations
- Boost extends past the next scheduled stop when activated during a window, or starts the pump immediately when outside; in split mode the pump runs continuously until the boost expires
- Boost state persists across HA restarts via `RestoreEntity`, with a `filtration_boost_remaining` sensor and boost lifecycle events (`boost_started`, `boost_consumed`, `boost_cancelled`)

## Changes

### Source (10 files)
| File | Change |
|------|--------|
| `const.py` | Boost constants, presets, service name |
| `domain/model.py` | `boost_remaining` field on `PoolState` |
| `scheduler.py` | Core boost logic: activation, stop suppression, cancellation, restore, events |
| `coordinator.py` | Bridge methods `async_boost_filtration` / `async_cancel_boost` + PoolState integration |
| `select.py` | `PoolmanFiltrationBoostSelect` entity with RestoreEntity persistence |
| `sensor.py` | `filtration_boost_remaining` sensor description |
| `event.py` | Boost event types on filtration event entity |
| `services.yaml` | `boost_filtration` service definition |
| `__init__.py` | Service registration and unload |
| `strings.json` + `translations/{en,fr}.json` | All translation strings |

### Tests (4 files, 477 total pass)
- `test_scheduler.py` — 8 boost test classes (activation, cancellation, stop suppression, consumed, restore, disable, event data)
- `test_select.py` — Boost select entity tests (creation, options, activation, cancellation, attributes, restore)
- `test_init.py` — Boost service registration and handler tests
- `test_coordinator_filtration.py` — Coordinator bridge and PoolState integration tests

### Documentation (2 files)
- `docs/filtration-control.md` — Comprehensive boost section
- `docs/entities.md` — Boost entities added to entity tables

Closes #14