### PR TITLE
feat(modes): add hibernating and activating pool modes

### DIFF
--- a/custom_components/poolman/const.py
+++ b/custom_components/poolman/const.py
@@ -62,10 +62,18 @@ FILTRATION_KINDS: Final = [
 ]
 
 # Pool modes
-MODE_RUNNING: Final = "running"
+MODE_ACTIVE: Final = "active"
+MODE_HIBERNATING: Final = "hibernating"
 MODE_WINTER_ACTIVE: Final = "winter_active"
 MODE_WINTER_PASSIVE: Final = "winter_passive"
-MODES: Final = [MODE_RUNNING, MODE_WINTER_ACTIVE, MODE_WINTER_PASSIVE]
+MODE_ACTIVATING: Final = "activating"
+MODES: Final = [
+    MODE_ACTIVE,
+    MODE_HIBERNATING,
+    MODE_WINTER_ACTIVE,
+    MODE_WINTER_PASSIVE,
+    MODE_ACTIVATING,
+]
 
 # Filtration duration modes
 FILTRATION_DURATION_MODE_MANUAL: Final = "manual"

--- a/custom_components/poolman/coordinator.py
+++ b/custom_components/poolman/coordinator.py
@@ -100,7 +100,7 @@ class PoolmanCoordinator(DataUpdateCoordinator[PoolState]):
         )
         self.pool = self._build_pool()
         self.engine = RuleEngine()
-        self._mode = PoolMode.RUNNING
+        self._mode = PoolMode.ACTIVE
         self._filtration_duration_mode = FiltrationDurationMode(DEFAULT_FILTRATION_DURATION_MODE)
         self._min_dynamic_period_duration = DEFAULT_MIN_DYNAMIC_DURATION_HOURS
         self._treatment_entities: dict[ChemicalProduct, PoolmanTreatmentEvent] = {}

--- a/custom_components/poolman/domain/filtration.py
+++ b/custom_components/poolman/domain/filtration.py
@@ -64,7 +64,7 @@ def compute_filtration_duration(
     if mode == PoolMode.WINTER_PASSIVE:
         return WINTER_PASSIVE_HOURS
 
-    if mode == PoolMode.WINTER_ACTIVE:
+    if mode in (PoolMode.WINTER_ACTIVE, PoolMode.HIBERNATING):
         return WINTER_ACTIVE_HOURS
 
     if reading.temp_c is None:

--- a/custom_components/poolman/domain/model.py
+++ b/custom_components/poolman/domain/model.py
@@ -38,11 +38,17 @@ class TreatmentType(StrEnum):
 
 
 class PoolMode(StrEnum):
-    """Operational mode of the pool."""
+    """Operational mode of the pool.
 
-    RUNNING = "running"
+    Lifecycle order: active -> hibernating -> winter_active / winter_passive
+    -> activating -> active.
+    """
+
+    ACTIVE = "active"
+    HIBERNATING = "hibernating"
     WINTER_ACTIVE = "winter_active"
     WINTER_PASSIVE = "winter_passive"
+    ACTIVATING = "activating"
 
 
 class FiltrationDurationMode(StrEnum):
@@ -276,7 +282,7 @@ class ActiveTreatment(BaseModel, frozen=True):
 class PoolState(BaseModel):
     """Computed state of the pool combining readings, mode, and recommendations."""
 
-    mode: PoolMode = PoolMode.RUNNING
+    mode: PoolMode = PoolMode.ACTIVE
     reading: PoolReading = Field(default_factory=PoolReading)
     recommendations: list[Recommendation] = Field(default_factory=list)
     filtration_hours: float | None = None

--- a/custom_components/poolman/domain/rules.py
+++ b/custom_components/poolman/domain/rules.py
@@ -199,7 +199,7 @@ class FiltrationRule(Rule):
         if hours is None:
             return []
 
-        if mode in (PoolMode.WINTER_ACTIVE, PoolMode.WINTER_PASSIVE):
+        if mode in (PoolMode.WINTER_ACTIVE, PoolMode.WINTER_PASSIVE, PoolMode.HIBERNATING):
             priority = RecommendationPriority.LOW
         elif hours >= 12:
             priority = RecommendationPriority.MEDIUM

--- a/custom_components/poolman/strings.json
+++ b/custom_components/poolman/strings.json
@@ -446,9 +446,11 @@
       "mode": {
         "name": "Pool mode",
         "state": {
-          "running": "Running",
+          "active": "Active",
+          "hibernating": "Hibernating",
           "winter_active": "Active wintering",
-          "winter_passive": "Passive wintering"
+          "winter_passive": "Passive wintering",
+          "activating": "Activating"
         }
       },
       "filtration_duration_mode": {

--- a/custom_components/poolman/translations/en.json
+++ b/custom_components/poolman/translations/en.json
@@ -446,9 +446,11 @@
       "mode": {
         "name": "Pool mode",
         "state": {
-          "running": "Running",
+          "active": "Active",
+          "hibernating": "Hibernating",
           "winter_active": "Active wintering",
-          "winter_passive": "Passive wintering"
+          "winter_passive": "Passive wintering",
+          "activating": "Activating"
         }
       },
       "filtration_duration_mode": {

--- a/custom_components/poolman/translations/fr.json
+++ b/custom_components/poolman/translations/fr.json
@@ -446,9 +446,11 @@
       "mode": {
         "name": "Mode piscine",
         "state": {
-          "running": "En fonctionnement",
+          "active": "En fonctionnement",
+          "hibernating": "Mise en hivernage",
           "winter_active": "Hivernage actif",
-          "winter_passive": "Hivernage passif"
+          "winter_passive": "Hivernage passif",
+          "activating": "Remise en route"
         }
       },
       "filtration_duration_mode": {

--- a/docs/pool-modes.md
+++ b/docs/pool-modes.md
@@ -4,11 +4,16 @@ icon: lucide/sun-snow
 
 # Pool Modes
 
-Pool Manager supports three operational modes, selectable via the
+Pool Manager supports five operational modes, selectable via the
 `select.{pool}_mode` entity. Each mode adapts filtration duration and rule
 behavior to the current season or pool status.
 
-## Running
+The modes follow a natural lifecycle:
+
+**Active** → **Hibernating** → **Active Wintering** / **Passive Wintering**
+→ **Activating** → **Active**
+
+## Active
 
 Normal season operation. This is the default mode.
 
@@ -146,6 +151,27 @@ The result is bounded between **2 hours minimum** and **24 hours maximum**.
 
 All chemistry rules are active: pH, sanitizer/ORP, TAC, and algae risk.
 
+## Hibernating
+
+Transition mode used when preparing the pool for winter. The pool is still
+operational but the system is being shut down progressively. Typical tasks
+during this phase include:
+
+- Lowering the water level
+- Cleaning the filter and skimmers
+- Adding winterizing product
+- Covering the pool
+
+### Hibernating filtration
+
+Fixed at **4 hours** per day, regardless of water temperature. This keeps
+water circulating while the pool is being prepared.
+
+### Hibernating rules
+
+All chemistry rules remain active. The pool still needs monitoring during
+the transition to catch any issues before full shutdown.
+
 ## Active Wintering
 
 Reduced operation during cold months when the pool is covered but the system
@@ -177,13 +203,35 @@ in this mode.
 
     Ensure your pool is properly winterized before switching to passive wintering mode. Pool Manager will not generate any alerts in this mode.
 
+## Activating
+
+Transition mode used when bringing the pool out of hibernation. The pool is
+not yet ready for swimming and typically requires:
+
+- Removing the cover
+- Raising the water level
+- Cleaning the pool and filter
+- Shock treatment
+- Intensive filtration to restore water clarity
+
+### Activating filtration
+
+Uses the full **dynamic multi-factor algorithm** (same as active mode).
+The pool needs intensive filtration to restore water quality after the
+winter period.
+
+### Activating rules
+
+All chemistry rules are active. Close monitoring is essential during this
+phase to bring water parameters back to safe levels.
+
 ## Mode Comparison
 
-| Aspect | Running | Active Wintering | Passive Wintering |
-| --- | --- | --- | --- |
-| Filtration | Multi-factor (2--24h) | 4h fixed | 0h |
-| pH rule | Active | Active | Disabled |
-| Sanitizer/ORP rule | Active | Active | Disabled |
-| TAC rule | Active | Active | Disabled |
-| Algae risk alert | Active | Active | Disabled |
-| Typical season | Spring--Autumn | Cold months | Full winter shutdown |
+| Aspect | Active | Hibernating | Active Wintering | Passive Wintering | Activating |
+| --- | --- | --- | --- | --- | --- |
+| Filtration | Multi-factor (2--24h) | 4h fixed | 4h fixed | 0h | Multi-factor (2--24h) |
+| pH rule | Active | Active | Active | Disabled | Active |
+| Sanitizer/ORP rule | Active | Active | Active | Disabled | Active |
+| TAC rule | Active | Active | Active | Disabled | Active |
+| Algae risk alert | Active | Active | Active | Disabled | Active |
+| Typical season | Spring--Autumn | Late autumn | Cold months | Full winter shutdown | Early spring |

--- a/tests/domain/test_filtration.py
+++ b/tests/domain/test_filtration.py
@@ -27,21 +27,21 @@ class TestFiltrationDuration:
     def test_basic_temperature_rule(self, pool: Pool) -> None:
         """Temperature / 2 rule: 26C -> ~13h (clamped if needed)."""
         reading = PoolReading(temp_c=26.0)
-        result = compute_filtration_duration(pool, reading, PoolMode.RUNNING)
+        result = compute_filtration_duration(pool, reading, PoolMode.ACTIVE)
         assert result is not None
         assert result >= 13.0
 
     def test_cold_water_minimum_filtration(self, pool: Pool) -> None:
         """Very cold water should still have minimum filtration."""
         reading = PoolReading(temp_c=2.0)
-        result = compute_filtration_duration(pool, reading, PoolMode.RUNNING)
+        result = compute_filtration_duration(pool, reading, PoolMode.ACTIVE)
         assert result is not None
         assert result >= MIN_FILTRATION_HOURS
 
     def test_hot_water_caps_at_max(self, pool: Pool) -> None:
         """Very hot water should cap at 24 hours."""
         reading = PoolReading(temp_c=50.0)
-        result = compute_filtration_duration(pool, reading, PoolMode.RUNNING)
+        result = compute_filtration_duration(pool, reading, PoolMode.ACTIVE)
         assert result is not None
         assert result <= MAX_FILTRATION_HOURS
 
@@ -55,10 +55,22 @@ class TestFiltrationDuration:
         result = compute_filtration_duration(pool, good_reading, PoolMode.WINTER_ACTIVE)
         assert result == WINTER_ACTIVE_HOURS
 
+    def test_hibernating_fixed(self, pool: Pool, good_reading: PoolReading) -> None:
+        """Hibernating mode should return fixed filtration hours (same as active wintering)."""
+        result = compute_filtration_duration(pool, good_reading, PoolMode.HIBERNATING)
+        assert result == WINTER_ACTIVE_HOURS
+
+    def test_activating_uses_dynamic_computation(self, pool: Pool) -> None:
+        """Activating mode should use the full dynamic computation (same as active)."""
+        reading = PoolReading(temp_c=26.0)
+        result_activating = compute_filtration_duration(pool, reading, PoolMode.ACTIVATING)
+        result_active = compute_filtration_duration(pool, reading, PoolMode.ACTIVE)
+        assert result_activating == result_active
+
     def test_no_temperature_returns_none(self, pool: Pool) -> None:
         """No temperature reading should return None."""
         reading = PoolReading()
-        result = compute_filtration_duration(pool, reading, PoolMode.RUNNING)
+        result = compute_filtration_duration(pool, reading, PoolMode.ACTIVE)
         assert result is None
 
     def test_ensures_full_turnover(self) -> None:
@@ -70,7 +82,7 @@ class TestFiltrationDuration:
             pump_flow_m3h=5.0,
         )
         reading = PoolReading(temp_c=20.0)  # temp/2 = 10h, but turnover = 20h
-        result = compute_filtration_duration(slow_pool, reading, PoolMode.RUNNING)
+        result = compute_filtration_duration(slow_pool, reading, PoolMode.ACTIVE)
         assert result is not None
         assert result >= 20.0
 
@@ -84,7 +96,7 @@ class TestFiltrationKindEfficiency:
             name="Sand", volume_m3=50.0, pump_flow_m3h=10.0, filtration_kind=FiltrationKind.SAND
         )
         reading = PoolReading(temp_c=24.0)
-        result = compute_filtration_duration(pool, reading, PoolMode.RUNNING)
+        result = compute_filtration_duration(pool, reading, PoolMode.ACTIVE)
         assert result is not None
         # 24/2 * 1.0 = 12.0, turnover = 50/10 = 5h -> 12.0
         assert result == pytest.approx(12.0)
@@ -101,8 +113,8 @@ class TestFiltrationKindEfficiency:
             filtration_kind=FiltrationKind.CARTRIDGE,
         )
         reading = PoolReading(temp_c=24.0)
-        sand_result = compute_filtration_duration(sand_pool, reading, PoolMode.RUNNING)
-        cart_result = compute_filtration_duration(cart_pool, reading, PoolMode.RUNNING)
+        sand_result = compute_filtration_duration(sand_pool, reading, PoolMode.ACTIVE)
+        cart_result = compute_filtration_duration(cart_pool, reading, PoolMode.ACTIVE)
         assert sand_result is not None
         assert cart_result is not None
         assert cart_result < sand_result
@@ -116,8 +128,8 @@ class TestFiltrationKindEfficiency:
             name="Glass", volume_m3=50.0, pump_flow_m3h=10.0, filtration_kind=FiltrationKind.GLASS
         )
         reading = PoolReading(temp_c=24.0)
-        sand_result = compute_filtration_duration(sand_pool, reading, PoolMode.RUNNING)
-        glass_result = compute_filtration_duration(glass_pool, reading, PoolMode.RUNNING)
+        sand_result = compute_filtration_duration(sand_pool, reading, PoolMode.ACTIVE)
+        glass_result = compute_filtration_duration(glass_pool, reading, PoolMode.ACTIVE)
         assert sand_result is not None
         assert glass_result is not None
         assert glass_result < sand_result
@@ -134,8 +146,8 @@ class TestFiltrationKindEfficiency:
             filtration_kind=FiltrationKind.DIATOMACEOUS_EARTH,
         )
         reading = PoolReading(temp_c=24.0)
-        sand_result = compute_filtration_duration(sand_pool, reading, PoolMode.RUNNING)
-        de_result = compute_filtration_duration(de_pool, reading, PoolMode.RUNNING)
+        sand_result = compute_filtration_duration(sand_pool, reading, PoolMode.ACTIVE)
+        de_result = compute_filtration_duration(de_pool, reading, PoolMode.ACTIVE)
         assert sand_result is not None
         assert de_result is not None
         assert de_result < sand_result
@@ -143,7 +155,7 @@ class TestFiltrationKindEfficiency:
         glass_pool = Pool(
             name="Glass", volume_m3=50.0, pump_flow_m3h=10.0, filtration_kind=FiltrationKind.GLASS
         )
-        glass_result = compute_filtration_duration(glass_pool, reading, PoolMode.RUNNING)
+        glass_result = compute_filtration_duration(glass_pool, reading, PoolMode.ACTIVE)
         assert glass_result is not None
         assert de_result < glass_result
 
@@ -154,7 +166,7 @@ class TestFiltrationKindEfficiency:
 
         for kind, coefficient in FILTRATION_EFFICIENCY.items():
             pool = Pool(name="Test", volume_m3=50.0, pump_flow_m3h=10.0, filtration_kind=kind)
-            result = compute_filtration_duration(pool, reading, PoolMode.RUNNING)
+            result = compute_filtration_duration(pool, reading, PoolMode.ACTIVE)
             assert result is not None
             expected = max(MIN_FILTRATION_HOURS, min(base * coefficient, MAX_FILTRATION_HOURS))
             # Account for turnover (50/10 = 5h, always below base*coeff here)
@@ -187,8 +199,8 @@ class TestOutdoorTemperatureAdjustment:
         """No outdoor temperature should not affect the result."""
         reading_without = PoolReading(temp_c=24.0, outdoor_temp_c=None)
         reading_with_normal = PoolReading(temp_c=24.0, outdoor_temp_c=25.0)
-        result_without = compute_filtration_duration(pool, reading_without, PoolMode.RUNNING)
-        result_normal = compute_filtration_duration(pool, reading_with_normal, PoolMode.RUNNING)
+        result_without = compute_filtration_duration(pool, reading_without, PoolMode.ACTIVE)
+        result_normal = compute_filtration_duration(pool, reading_with_normal, PoolMode.ACTIVE)
         assert result_without is not None
         assert result_normal is not None
         # Both should be equal since 25 < 28 threshold
@@ -198,8 +210,8 @@ class TestOutdoorTemperatureAdjustment:
         """Outdoor temp at or below 28 C should not increase filtration."""
         reading_no_outdoor = PoolReading(temp_c=24.0)
         reading_at_threshold = PoolReading(temp_c=24.0, outdoor_temp_c=OUTDOOR_TEMP_THRESHOLD)
-        result_base = compute_filtration_duration(pool, reading_no_outdoor, PoolMode.RUNNING)
-        result_threshold = compute_filtration_duration(pool, reading_at_threshold, PoolMode.RUNNING)
+        result_base = compute_filtration_duration(pool, reading_no_outdoor, PoolMode.ACTIVE)
+        result_threshold = compute_filtration_duration(pool, reading_at_threshold, PoolMode.ACTIVE)
         assert result_base is not None
         assert result_threshold is not None
         assert result_base == result_threshold
@@ -208,8 +220,8 @@ class TestOutdoorTemperatureAdjustment:
         """Outdoor temp above 28 C should increase filtration duration."""
         reading_cool = PoolReading(temp_c=24.0, outdoor_temp_c=25.0)
         reading_hot = PoolReading(temp_c=24.0, outdoor_temp_c=35.0)
-        result_cool = compute_filtration_duration(pool, reading_cool, PoolMode.RUNNING)
-        result_hot = compute_filtration_duration(pool, reading_hot, PoolMode.RUNNING)
+        result_cool = compute_filtration_duration(pool, reading_cool, PoolMode.ACTIVE)
+        result_hot = compute_filtration_duration(pool, reading_hot, PoolMode.ACTIVE)
         assert result_cool is not None
         assert result_hot is not None
         assert result_hot > result_cool
@@ -217,7 +229,7 @@ class TestOutdoorTemperatureAdjustment:
     def test_outdoor_temp_exact_factor(self, pool: Pool) -> None:
         """Verify the exact heat stress calculation: +5% per degree above 28 C."""
         reading = PoolReading(temp_c=24.0, outdoor_temp_c=33.0)
-        result = compute_filtration_duration(pool, reading, PoolMode.RUNNING)
+        result = compute_filtration_duration(pool, reading, PoolMode.ACTIVE)
         assert result is not None
         # base = 24/2 = 12.0
         # heat_factor = 1 + (33-28)*0.05 = 1.25
@@ -229,7 +241,7 @@ class TestOutdoorTemperatureAdjustment:
         """Even with extreme heat stress, result should be clamped at 24h."""
         pool = Pool(name="Hot", volume_m3=50.0, pump_flow_m3h=10.0)
         reading = PoolReading(temp_c=40.0, outdoor_temp_c=50.0)
-        result = compute_filtration_duration(pool, reading, PoolMode.RUNNING)
+        result = compute_filtration_duration(pool, reading, PoolMode.ACTIVE)
         assert result is not None
         assert result == MAX_FILTRATION_HOURS
 
@@ -259,7 +271,7 @@ class TestCombinedFactors:
             filtration_kind=FiltrationKind.GLASS,
         )
         reading = PoolReading(temp_c=24.0, outdoor_temp_c=33.0)
-        result = compute_filtration_duration(pool, reading, PoolMode.RUNNING)
+        result = compute_filtration_duration(pool, reading, PoolMode.ACTIVE)
         assert result is not None
         # base = 24/2 = 12.0
         # glass efficiency = 0.9 -> 12.0 * 0.9 = 10.8
@@ -276,7 +288,7 @@ class TestCombinedFactors:
             filtration_kind=FiltrationKind.DIATOMACEOUS_EARTH,
         )
         reading = PoolReading(temp_c=24.0, outdoor_temp_c=30.0)
-        result = compute_filtration_duration(pool, reading, PoolMode.RUNNING)
+        result = compute_filtration_duration(pool, reading, PoolMode.ACTIVE)
         assert result is not None
         # base = 24/2 = 12.0
         # DE efficiency = 0.85 -> 12.0 * 0.85 = 10.2
@@ -293,7 +305,7 @@ class TestCombinedFactors:
             filtration_kind=FiltrationKind.DIATOMACEOUS_EARTH,
         )
         reading = PoolReading(temp_c=20.0, outdoor_temp_c=25.0)
-        result = compute_filtration_duration(slow_pool, reading, PoolMode.RUNNING)
+        result = compute_filtration_duration(slow_pool, reading, PoolMode.ACTIVE)
         assert result is not None
         # base = 20/2 = 10.0
         # DE efficiency = 0.85 -> 10.0 * 0.85 = 8.5

--- a/tests/domain/test_rules.py
+++ b/tests/domain/test_rules.py
@@ -35,12 +35,12 @@ class TestPhRule:
 
     def test_good_ph_no_recommendation(self, pool: Pool) -> None:
         reading = PoolReading(ph=7.2)
-        result = PhRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = PhRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert result == []
 
     def test_high_ph_returns_recommendation(self, pool: Pool) -> None:
         reading = PoolReading(ph=7.8)
-        result = PhRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = PhRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert len(result) == 1
         assert result[0].product == "ph_minus"
         assert result[0].type == RecommendationType.CHEMICAL
@@ -48,7 +48,7 @@ class TestPhRule:
 
     def test_low_ph_returns_recommendation(self, pool: Pool) -> None:
         reading = PoolReading(ph=6.6)
-        result = PhRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = PhRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert len(result) == 1
         assert result[0].product == "ph_plus"
         assert result[0].priority == RecommendationPriority.HIGH
@@ -59,11 +59,25 @@ class TestPhRule:
         result = PhRule().evaluate(pool, reading, PoolMode.WINTER_PASSIVE)
         assert result == []
 
+    def test_hibernating_evaluates(self, pool: Pool) -> None:
+        """pH rule should still evaluate in hibernating mode."""
+        reading = PoolReading(ph=7.8)
+        result = PhRule().evaluate(pool, reading, PoolMode.HIBERNATING)
+        assert len(result) == 1
+        assert result[0].product == "ph_minus"
+
+    def test_activating_evaluates(self, pool: Pool) -> None:
+        """pH rule should still evaluate in activating mode."""
+        reading = PoolReading(ph=7.8)
+        result = PhRule().evaluate(pool, reading, PoolMode.ACTIVATING)
+        assert len(result) == 1
+        assert result[0].product == "ph_minus"
+
     def test_slightly_off_ph_returns_low_priority(self, pool: Pool) -> None:
         """pH slightly off target (within min/max, delta <= tolerance*3) -> LOW."""
         # PH_TARGET=7.2, PH_TOLERANCE=0.1, so delta <= 0.3 and within 6.8-7.8
         reading = PoolReading(ph=7.4)  # delta=0.2
-        result = PhRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = PhRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert len(result) == 1
         assert result[0].priority == RecommendationPriority.LOW
 
@@ -73,12 +87,12 @@ class TestSanitizerRule:
 
     def test_good_orp_no_recommendation(self, pool: Pool) -> None:
         reading = PoolReading(orp=750.0)
-        result = SanitizerRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = SanitizerRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert result == []
 
     def test_chlorine_critical_orp_shock(self, pool: Pool) -> None:
         reading = PoolReading(orp=600.0)
-        result = SanitizerRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = SanitizerRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert len(result) == 1
         assert result[0].priority == RecommendationPriority.CRITICAL
         assert result[0].product == "chlore_choc"
@@ -86,7 +100,7 @@ class TestSanitizerRule:
 
     def test_chlorine_low_orp_galet(self, pool: Pool) -> None:
         reading = PoolReading(orp=700.0)
-        result = SanitizerRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = SanitizerRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert len(result) == 1
         assert result[0].product == "galet_chlore"
         assert result[0].kind == ActionKind.SUGGESTION
@@ -99,7 +113,7 @@ class TestSanitizerRule:
             treatment=TreatmentType.SALT_ELECTROLYSIS,
         )
         reading = PoolReading(orp=700.0)
-        result = SanitizerRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = SanitizerRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert len(result) == 1
         assert result[0].product == "salt"
         assert "salt level" in result[0].message.lower()
@@ -112,7 +126,7 @@ class TestSanitizerRule:
             treatment=TreatmentType.SALT_ELECTROLYSIS,
         )
         reading = PoolReading(orp=600.0)
-        result = SanitizerRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = SanitizerRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert len(result) == 1
         assert result[0].priority == RecommendationPriority.CRITICAL
         # Salt pools still use shock chlorination in emergencies
@@ -126,7 +140,7 @@ class TestSanitizerRule:
             treatment=TreatmentType.BROMINE,
         )
         reading = PoolReading(orp=700.0)
-        result = SanitizerRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = SanitizerRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert len(result) == 1
         assert result[0].product == "bromine_tablet"
 
@@ -138,7 +152,7 @@ class TestSanitizerRule:
             treatment=TreatmentType.BROMINE,
         )
         reading = PoolReading(orp=600.0)
-        result = SanitizerRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = SanitizerRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert len(result) == 1
         assert result[0].product == "bromine_shock"
 
@@ -150,7 +164,7 @@ class TestSanitizerRule:
             treatment=TreatmentType.ACTIVE_OXYGEN,
         )
         reading = PoolReading(orp=700.0)
-        result = SanitizerRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = SanitizerRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert len(result) == 1
         assert result[0].product == "active_oxygen_tablet"
 
@@ -162,7 +176,7 @@ class TestSanitizerRule:
             treatment=TreatmentType.ACTIVE_OXYGEN,
         )
         reading = PoolReading(orp=600.0)
-        result = SanitizerRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = SanitizerRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert len(result) == 1
         assert result[0].product == "active_oxygen_activator"
 
@@ -170,6 +184,20 @@ class TestSanitizerRule:
         reading = PoolReading(orp=600.0)
         result = SanitizerRule().evaluate(pool, reading, PoolMode.WINTER_PASSIVE)
         assert result == []
+
+    def test_hibernating_evaluates(self, pool: Pool) -> None:
+        """Sanitizer rule should still evaluate in hibernating mode."""
+        reading = PoolReading(orp=600.0)
+        result = SanitizerRule().evaluate(pool, reading, PoolMode.HIBERNATING)
+        assert len(result) == 1
+        assert result[0].priority == RecommendationPriority.CRITICAL
+
+    def test_activating_evaluates(self, pool: Pool) -> None:
+        """Sanitizer rule should still evaluate in activating mode."""
+        reading = PoolReading(orp=600.0)
+        result = SanitizerRule().evaluate(pool, reading, PoolMode.ACTIVATING)
+        assert len(result) == 1
+        assert result[0].priority == RecommendationPriority.CRITICAL
 
     @pytest.mark.parametrize("treatment", list(TreatmentType))
     def test_high_orp_returns_neutralizer_for_all_treatments(
@@ -182,7 +210,7 @@ class TestSanitizerRule:
             treatment=treatment,
         )
         reading = PoolReading(orp=950.0)
-        result = SanitizerRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = SanitizerRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert len(result) == 1
         assert result[0].product == "neutralizer"
 
@@ -192,21 +220,35 @@ class TestFiltrationRule:
 
     def test_produces_recommendation(self, pool: Pool) -> None:
         reading = PoolReading(temp_c=26.0)
-        result = FiltrationRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = FiltrationRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert len(result) == 1
         assert result[0].type == RecommendationType.FILTRATION
 
     def test_no_temp_no_recommendation(self, pool: Pool) -> None:
         reading = PoolReading()
-        result = FiltrationRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = FiltrationRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert result == []
 
     def test_low_filtration_hours_returns_low_priority(self, pool: Pool) -> None:
         """When filtration hours < 12 in running mode, priority should be LOW."""
         reading = PoolReading(temp_c=20.0)  # 20/2 = 10h < 12
-        result = FiltrationRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = FiltrationRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert len(result) == 1
         assert result[0].priority == RecommendationPriority.LOW
+
+    def test_hibernating_returns_low_priority(self, pool: Pool) -> None:
+        """Hibernating mode should produce a LOW priority filtration recommendation."""
+        reading = PoolReading(temp_c=26.0)
+        result = FiltrationRule().evaluate(pool, reading, PoolMode.HIBERNATING)
+        assert len(result) == 1
+        assert result[0].priority == RecommendationPriority.LOW
+
+    def test_activating_produces_recommendation(self, pool: Pool) -> None:
+        """Activating mode should produce a filtration recommendation (dynamic)."""
+        reading = PoolReading(temp_c=26.0)
+        result = FiltrationRule().evaluate(pool, reading, PoolMode.ACTIVATING)
+        assert len(result) == 1
+        assert result[0].type == RecommendationType.FILTRATION
 
 
 class TestTacRule:
@@ -214,22 +256,42 @@ class TestTacRule:
 
     def test_tac_in_range_no_recommendation(self, pool: Pool) -> None:
         reading = PoolReading(tac=120.0)
-        result = TacRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = TacRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert result == []
 
     def test_low_tac_recommends_tac_plus(self, pool: Pool) -> None:
         reading = PoolReading(tac=50.0)
-        result = TacRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = TacRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert len(result) == 1
         assert result[0].product == "tac_plus"
 
     def test_high_tac_recommends_ph_minus(self, pool: Pool) -> None:
         """TAC above max should recommend using pH- to lower alkalinity."""
         reading = PoolReading(tac=160.0)  # TAC_MAX = 150
-        result = TacRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = TacRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert len(result) == 1
         assert result[0].priority == RecommendationPriority.LOW
         assert "too high" in result[0].message.lower()
+
+    def test_winter_passive_skips(self, pool: Pool) -> None:
+        """TAC rule should skip in passive winter mode."""
+        reading = PoolReading(tac=50.0)
+        result = TacRule().evaluate(pool, reading, PoolMode.WINTER_PASSIVE)
+        assert result == []
+
+    def test_hibernating_evaluates(self, pool: Pool) -> None:
+        """TAC rule should still evaluate in hibernating mode."""
+        reading = PoolReading(tac=50.0)
+        result = TacRule().evaluate(pool, reading, PoolMode.HIBERNATING)
+        assert len(result) == 1
+        assert result[0].product == "tac_plus"
+
+    def test_activating_evaluates(self, pool: Pool) -> None:
+        """TAC rule should still evaluate in activating mode."""
+        reading = PoolReading(tac=50.0)
+        result = TacRule().evaluate(pool, reading, PoolMode.ACTIVATING)
+        assert len(result) == 1
+        assert result[0].product == "tac_plus"
 
 
 class TestAlgaeRiskRule:
@@ -237,25 +299,45 @@ class TestAlgaeRiskRule:
 
     def test_warm_and_low_orp_triggers(self, pool: Pool) -> None:
         reading = PoolReading(temp_c=30.0, orp=650.0)
-        result = AlgaeRiskRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = AlgaeRiskRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert len(result) == 1
         assert result[0].priority == RecommendationPriority.HIGH
         assert result[0].kind == ActionKind.REQUIREMENT
 
     def test_cool_water_no_risk(self, pool: Pool) -> None:
         reading = PoolReading(temp_c=22.0, orp=650.0)
-        result = AlgaeRiskRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = AlgaeRiskRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert result == []
 
     def test_warm_but_good_orp_no_risk(self, pool: Pool) -> None:
         reading = PoolReading(temp_c=30.0, orp=750.0)
-        result = AlgaeRiskRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = AlgaeRiskRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert result == []
 
     def test_missing_data_no_risk(self, pool: Pool) -> None:
         reading = PoolReading(temp_c=30.0)
-        result = AlgaeRiskRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = AlgaeRiskRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert result == []
+
+    def test_winter_passive_skips(self, pool: Pool) -> None:
+        """Algae risk rule should skip in passive winter mode."""
+        reading = PoolReading(temp_c=30.0, orp=650.0)
+        result = AlgaeRiskRule().evaluate(pool, reading, PoolMode.WINTER_PASSIVE)
+        assert result == []
+
+    def test_hibernating_evaluates(self, pool: Pool) -> None:
+        """Algae risk rule should still evaluate in hibernating mode."""
+        reading = PoolReading(temp_c=30.0, orp=650.0)
+        result = AlgaeRiskRule().evaluate(pool, reading, PoolMode.HIBERNATING)
+        assert len(result) == 1
+        assert result[0].priority == RecommendationPriority.HIGH
+
+    def test_activating_evaluates(self, pool: Pool) -> None:
+        """Algae risk rule should still evaluate in activating mode."""
+        reading = PoolReading(temp_c=30.0, orp=650.0)
+        result = AlgaeRiskRule().evaluate(pool, reading, PoolMode.ACTIVATING)
+        assert len(result) == 1
+        assert result[0].priority == RecommendationPriority.HIGH
 
 
 class TestRuleEngine:
@@ -269,7 +351,7 @@ class TestRuleEngine:
         self, pool: Pool, good_reading: PoolReading
     ) -> None:
         engine = RuleEngine()
-        results = engine.evaluate(pool, good_reading, PoolMode.RUNNING)
+        results = engine.evaluate(pool, good_reading, PoolMode.ACTIVE)
         # Good readings should only produce filtration recommendation
         types = {r.type for r in results}
         assert RecommendationType.FILTRATION in types
@@ -281,12 +363,12 @@ class TestRuleEngine:
 
     def test_bad_readings_produce_multiple(self, pool: Pool, bad_reading: PoolReading) -> None:
         engine = RuleEngine()
-        results = engine.evaluate(pool, bad_reading, PoolMode.RUNNING)
+        results = engine.evaluate(pool, bad_reading, PoolMode.ACTIVE)
         assert len(results) > 1
 
     def test_results_sorted_by_priority(self, pool: Pool, bad_reading: PoolReading) -> None:
         engine = RuleEngine()
-        results = engine.evaluate(pool, bad_reading, PoolMode.RUNNING)
+        results = engine.evaluate(pool, bad_reading, PoolMode.ACTIVE)
         priorities = [r.priority for r in results]
         priority_order = {
             RecommendationPriority.CRITICAL: 0,
@@ -306,14 +388,14 @@ class TestRuleEngine:
     def test_empty_readings_minimal_output(self, pool: Pool) -> None:
         engine = RuleEngine()
         reading = PoolReading()
-        results = engine.evaluate(pool, reading, PoolMode.RUNNING)
+        results = engine.evaluate(pool, reading, PoolMode.ACTIVE)
         # No sensor data -> no recommendations
         assert results == []
 
     def test_custom_rules(self, pool: Pool) -> None:
         engine = RuleEngine(rules=[PhRule()])
         reading = PoolReading(ph=8.0, orp=600.0)
-        results = engine.evaluate(pool, reading, PoolMode.RUNNING)
+        results = engine.evaluate(pool, reading, PoolMode.ACTIVE)
         # Only pH rule should fire, not sanitizer
         assert all(r.product in ("ph_minus", "ph_plus") for r in results)
 
@@ -323,12 +405,12 @@ class TestCyaRule:
 
     def test_cya_in_range_no_recommendation(self, pool: Pool) -> None:
         reading = PoolReading(cya=40.0)
-        result = CyaRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = CyaRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert result == []
 
     def test_cya_too_low_recommends_stabilizer(self, pool: Pool) -> None:
         reading = PoolReading(cya=10.0)
-        result = CyaRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = CyaRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert len(result) == 1
         assert result[0].product == "stabilizer"
         assert result[0].type == RecommendationType.CHEMICAL
@@ -339,7 +421,7 @@ class TestCyaRule:
 
     def test_cya_too_high_recommends_drain(self, pool: Pool) -> None:
         reading = PoolReading(cya=100.0)
-        result = CyaRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = CyaRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert len(result) == 1
         assert result[0].type == RecommendationType.ALERT
         assert result[0].priority == RecommendationPriority.LOW
@@ -349,7 +431,7 @@ class TestCyaRule:
 
     def test_cya_none_no_recommendation(self, pool: Pool) -> None:
         reading = PoolReading(cya=None)
-        result = CyaRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = CyaRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert result == []
 
     def test_winter_passive_skips(self, pool: Pool) -> None:
@@ -357,14 +439,28 @@ class TestCyaRule:
         result = CyaRule().evaluate(pool, reading, PoolMode.WINTER_PASSIVE)
         assert result == []
 
+    def test_hibernating_evaluates(self, pool: Pool) -> None:
+        """CYA rule should still evaluate in hibernating mode."""
+        reading = PoolReading(cya=10.0)
+        result = CyaRule().evaluate(pool, reading, PoolMode.HIBERNATING)
+        assert len(result) == 1
+        assert result[0].product == "stabilizer"
+
+    def test_activating_evaluates(self, pool: Pool) -> None:
+        """CYA rule should still evaluate in activating mode."""
+        reading = PoolReading(cya=10.0)
+        result = CyaRule().evaluate(pool, reading, PoolMode.ACTIVATING)
+        assert len(result) == 1
+        assert result[0].product == "stabilizer"
+
     def test_cya_at_min_no_recommendation(self, pool: Pool) -> None:
         reading = PoolReading(cya=20.0)
-        result = CyaRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = CyaRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert result == []
 
     def test_cya_at_max_no_recommendation(self, pool: Pool) -> None:
         reading = PoolReading(cya=75.0)
-        result = CyaRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = CyaRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert result == []
 
 
@@ -373,12 +469,12 @@ class TestHardnessRule:
 
     def test_hardness_in_range_no_recommendation(self, pool: Pool) -> None:
         reading = PoolReading(hardness=250.0)
-        result = HardnessRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = HardnessRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert result == []
 
     def test_hardness_too_low_recommends_increaser(self, pool: Pool) -> None:
         reading = PoolReading(hardness=100.0)
-        result = HardnessRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = HardnessRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert len(result) == 1
         assert result[0].product == "calcium_hardness_increaser"
         assert result[0].type == RecommendationType.CHEMICAL
@@ -389,7 +485,7 @@ class TestHardnessRule:
 
     def test_hardness_too_high_recommends_drain(self, pool: Pool) -> None:
         reading = PoolReading(hardness=500.0)
-        result = HardnessRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = HardnessRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert len(result) == 1
         assert result[0].type == RecommendationType.ALERT
         assert result[0].priority == RecommendationPriority.LOW
@@ -399,7 +495,7 @@ class TestHardnessRule:
 
     def test_hardness_none_no_recommendation(self, pool: Pool) -> None:
         reading = PoolReading(hardness=None)
-        result = HardnessRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = HardnessRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert result == []
 
     def test_winter_passive_skips(self, pool: Pool) -> None:
@@ -407,14 +503,28 @@ class TestHardnessRule:
         result = HardnessRule().evaluate(pool, reading, PoolMode.WINTER_PASSIVE)
         assert result == []
 
+    def test_hibernating_evaluates(self, pool: Pool) -> None:
+        """Hardness rule should still evaluate in hibernating mode."""
+        reading = PoolReading(hardness=100.0)
+        result = HardnessRule().evaluate(pool, reading, PoolMode.HIBERNATING)
+        assert len(result) == 1
+        assert result[0].product == "calcium_hardness_increaser"
+
+    def test_activating_evaluates(self, pool: Pool) -> None:
+        """Hardness rule should still evaluate in activating mode."""
+        reading = PoolReading(hardness=100.0)
+        result = HardnessRule().evaluate(pool, reading, PoolMode.ACTIVATING)
+        assert len(result) == 1
+        assert result[0].product == "calcium_hardness_increaser"
+
     def test_hardness_at_min_no_recommendation(self, pool: Pool) -> None:
         reading = PoolReading(hardness=150.0)
-        result = HardnessRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = HardnessRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert result == []
 
     def test_hardness_at_max_no_recommendation(self, pool: Pool) -> None:
         reading = PoolReading(hardness=400.0)
-        result = HardnessRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = HardnessRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert result == []
 
 
@@ -429,7 +539,7 @@ class TestCalibrationRule:
     def test_no_manual_measures_no_recommendation(self, pool: Pool) -> None:
         """No recommendations when there are no manual measures."""
         reading = PoolReading(ph=7.2, orp=750.0)
-        result = CalibrationRule().evaluate(pool, reading, PoolMode.RUNNING)
+        result = CalibrationRule().evaluate(pool, reading, PoolMode.ACTIVE)
         assert result == []
 
     def test_no_deviation_no_recommendation(self, pool: Pool) -> None:
@@ -441,7 +551,7 @@ class TestCalibrationRule:
             ),
         }
         result = CalibrationRule().evaluate(
-            pool, reading, PoolMode.RUNNING, manual_measures=measures
+            pool, reading, PoolMode.ACTIVE, manual_measures=measures
         )
         assert result == []
 
@@ -454,7 +564,7 @@ class TestCalibrationRule:
             ),
         }
         result = CalibrationRule().evaluate(
-            pool, reading, PoolMode.RUNNING, manual_measures=measures
+            pool, reading, PoolMode.ACTIVE, manual_measures=measures
         )
         assert len(result) == 1
         assert result[0].type == RecommendationType.MAINTENANCE
@@ -473,7 +583,7 @@ class TestCalibrationRule:
             ),
         }
         result = CalibrationRule().evaluate(
-            pool, reading, PoolMode.RUNNING, manual_measures=measures
+            pool, reading, PoolMode.ACTIVE, manual_measures=measures
         )
         assert len(result) == 1
         assert "ORP" in result[0].message
@@ -487,7 +597,7 @@ class TestCalibrationRule:
             ),
         }
         result = CalibrationRule().evaluate(
-            pool, reading, PoolMode.RUNNING, manual_measures=measures
+            pool, reading, PoolMode.ACTIVE, manual_measures=measures
         )
         assert len(result) == 1
         assert "temperature" in result[0].message
@@ -501,7 +611,7 @@ class TestCalibrationRule:
             ),
         }
         result = CalibrationRule().evaluate(
-            pool, reading, PoolMode.RUNNING, manual_measures=measures
+            pool, reading, PoolMode.ACTIVE, manual_measures=measures
         )
         assert result == []
 
@@ -533,7 +643,7 @@ class TestCalibrationRule:
             ),
         }
         result = CalibrationRule().evaluate(
-            pool, reading, PoolMode.RUNNING, manual_measures=measures
+            pool, reading, PoolMode.ACTIVE, manual_measures=measures
         )
         assert len(result) == 3
 
@@ -546,7 +656,7 @@ class TestCalibrationRule:
             ),
         }
         result = CalibrationRule().evaluate(
-            pool, reading, PoolMode.RUNNING, manual_measures=measures
+            pool, reading, PoolMode.ACTIVE, manual_measures=measures
         )
         # 0.3 == threshold, not > threshold
         assert result == []
@@ -560,7 +670,7 @@ class TestCalibrationRule:
             ),
         }
         result = CalibrationRule().evaluate(
-            pool, reading, PoolMode.RUNNING, manual_measures=measures
+            pool, reading, PoolMode.ACTIVE, manual_measures=measures
         )
         assert len(result) == 1
         assert "TAC" in result[0].message
@@ -574,7 +684,7 @@ class TestCalibrationRule:
             ),
         }
         result = CalibrationRule().evaluate(
-            pool, reading, PoolMode.RUNNING, manual_measures=measures
+            pool, reading, PoolMode.ACTIVE, manual_measures=measures
         )
         assert len(result) == 1
         assert "CYA" in result[0].message
@@ -588,7 +698,7 @@ class TestCalibrationRule:
             ),
         }
         result = CalibrationRule().evaluate(
-            pool, reading, PoolMode.RUNNING, manual_measures=measures
+            pool, reading, PoolMode.ACTIVE, manual_measures=measures
         )
         assert len(result) == 1
         assert "hardness" in result[0].message
@@ -603,5 +713,31 @@ class TestCalibrationRule:
         }
         result = CalibrationRule().evaluate(
             pool, reading, PoolMode.WINTER_ACTIVE, manual_measures=measures
+        )
+        assert len(result) == 1
+
+    def test_hibernating_evaluates(self, pool: Pool) -> None:
+        """CalibrationRule should still evaluate in hibernating mode."""
+        reading = PoolReading(ph=7.8)
+        measures = {
+            MeasureParameter.PH: ManualMeasure(
+                parameter=MeasureParameter.PH, value=7.2, measured_at=_ts()
+            ),
+        }
+        result = CalibrationRule().evaluate(
+            pool, reading, PoolMode.HIBERNATING, manual_measures=measures
+        )
+        assert len(result) == 1
+
+    def test_activating_evaluates(self, pool: Pool) -> None:
+        """CalibrationRule should still evaluate in activating mode."""
+        reading = PoolReading(ph=7.8)
+        measures = {
+            MeasureParameter.PH: ManualMeasure(
+                parameter=MeasureParameter.PH, value=7.2, measured_at=_ts()
+            ),
+        }
+        result = CalibrationRule().evaluate(
+            pool, reading, PoolMode.ACTIVATING, manual_measures=measures
         )
         assert len(result) == 1

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -268,12 +268,12 @@ class TestReadOutdoorTemperature:
 class TestModeProperty:
     """Tests for mode getter/setter."""
 
-    async def test_default_mode_is_running(
+    async def test_default_mode_is_active(
         self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
     ) -> None:
-        """Default mode should be RUNNING."""
+        """Default mode should be ACTIVE."""
         coordinator = await _setup_coordinator(hass, mock_config_entry)
-        assert coordinator.mode == PoolMode.RUNNING
+        assert coordinator.mode == PoolMode.ACTIVE
 
     async def test_set_mode(self, hass: HomeAssistant, mock_config_entry: MockConfigEntry) -> None:
         """Setting mode should update the property."""

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -30,7 +30,7 @@ class TestPoolModeSelect:
         await _setup_integration(hass, mock_config_entry)
         state = hass.states.get("select.test_pool_pool_mode")
         assert state is not None
-        assert state.state == PoolMode.RUNNING.value
+        assert state.state == PoolMode.ACTIVE.value
 
     async def test_select_winter_active(
         self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
@@ -75,6 +75,50 @@ class TestPoolModeSelect:
         state = hass.states.get("select.test_pool_pool_mode")
         assert state is not None
         assert state.state == PoolMode.WINTER_PASSIVE.value
+
+    async def test_select_hibernating(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Selecting hibernating should update mode."""
+        coordinator = await _setup_integration(hass, mock_config_entry)
+
+        await hass.services.async_call(
+            "select",
+            "select_option",
+            {
+                "entity_id": "select.test_pool_pool_mode",
+                "option": PoolMode.HIBERNATING.value,
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+        assert coordinator.mode == PoolMode.HIBERNATING
+        state = hass.states.get("select.test_pool_pool_mode")
+        assert state is not None
+        assert state.state == PoolMode.HIBERNATING.value
+
+    async def test_select_activating(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Selecting activating should update mode."""
+        coordinator = await _setup_integration(hass, mock_config_entry)
+
+        await hass.services.async_call(
+            "select",
+            "select_option",
+            {
+                "entity_id": "select.test_pool_pool_mode",
+                "option": PoolMode.ACTIVATING.value,
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+        assert coordinator.mode == PoolMode.ACTIVATING
+        state = hass.states.get("select.test_pool_pool_mode")
+        assert state is not None
+        assert state.state == PoolMode.ACTIVATING.value
 
     async def test_options_list(
         self, hass: HomeAssistant, mock_config_entry: MockConfigEntry


### PR DESCRIPTION
## Summary

- Expand `PoolMode` enum from 3 to 5 modes to support gradual seasonal transitions: **active** (renamed from `running`), **hibernating**, `winter_active`, `winter_passive`, and **activating**
- `hibernating` uses fixed 4h filtration (same as `winter_active`) with all chemistry rules active; `activating` uses full dynamic computation (same as `active`) with all rules active
- Only `winter_passive` disables chemistry rules — no behavioral change for existing modes

## Changes

### Production code
- **`domain/model.py`** — Renamed `PoolMode.RUNNING` → `PoolMode.ACTIVE`, added `HIBERNATING` and `ACTIVATING` enum values, updated `PoolState.mode` default
- **`const.py`** — Renamed `MODE_RUNNING` → `MODE_ACTIVE`, added `MODE_HIBERNATING` and `MODE_ACTIVATING`, updated `MODES` list to 5 entries
- **`domain/filtration.py`** — `HIBERNATING` grouped with `WINTER_ACTIVE` for 4h fixed filtration; `ACTIVATING` falls through to dynamic computation
- **`domain/rules.py`** — `FiltrationRule` priority check includes `HIBERNATING` in the low-priority winter group
- **`coordinator.py`** — Updated default mode to `PoolMode.ACTIVE`
- **`strings.json`**, **`translations/en.json`**, **`translations/fr.json`** — Added UI strings for new modes

### Documentation
- **`docs/pool-modes.md`** — Full rewrite: 5-mode lifecycle, new sections for Hibernating and Activating, updated comparison table

### Tests
- Bulk rename `PoolMode.RUNNING` → `PoolMode.ACTIVE` across all test files
- New filtration tests: `test_hibernating_fixed`, `test_activating_uses_dynamic_computation`
- New rule tests: `test_hibernating_evaluates` and `test_activating_evaluates` for PhRule, SanitizerRule, TacRule, AlgaeRiskRule, CyaRule, HardnessRule, CalibrationRule
- New select tests: `test_select_hibernating`, `test_select_activating`

## Notes

- **Breaking change**: `running` → `active` rename. No migration needed because `PoolmanModeSelect` does not use `RestoreEntity` — mode resets to default on restart.
- **No config flow changes** — no version bump, no migration needed.
- `select.py` dynamically generates options from `PoolMode` enum, so it automatically picks up new modes without code changes.

Closes #20 