### PR TITLE
feat(modes): implement passive winter hibernation mode

### DIFF
--- a/custom_components/poolman/const.py
+++ b/custom_components/poolman/const.py
@@ -61,20 +61,6 @@ FILTRATION_KINDS: Final = [
     FILTRATION_KIND_GLASS,
 ]
 
-# Pool modes
-MODE_ACTIVE: Final = "active"
-MODE_HIBERNATING: Final = "hibernating"
-MODE_WINTER_ACTIVE: Final = "winter_active"
-MODE_WINTER_PASSIVE: Final = "winter_passive"
-MODE_ACTIVATING: Final = "activating"
-MODES: Final = [
-    MODE_ACTIVE,
-    MODE_HIBERNATING,
-    MODE_WINTER_ACTIVE,
-    MODE_WINTER_PASSIVE,
-    MODE_ACTIVATING,
-]
-
 # Filtration duration modes
 FILTRATION_DURATION_MODE_MANUAL: Final = "manual"
 FILTRATION_DURATION_MODE_DYNAMIC: Final = "dynamic"

--- a/custom_components/poolman/coordinator.py
+++ b/custom_components/poolman/coordinator.py
@@ -150,8 +150,40 @@ class PoolmanCoordinator(DataUpdateCoordinator[PoolState]):
 
     @mode.setter
     def mode(self, value: PoolMode) -> None:
-        """Set the pool mode and trigger a refresh."""
+        """Set the pool mode.
+
+        For mode changes that require side effects (e.g. pausing the
+        scheduler), use :meth:`async_set_mode` instead.
+        """
         self._mode = value
+
+    async def async_set_mode(self, mode: PoolMode) -> None:
+        """Set the pool mode with transition side effects.
+
+        Handles scheduler pause/resume when entering or leaving
+        ``WINTER_PASSIVE`` mode.  The pump is stopped immediately
+        on entering passive wintering and resumed when leaving it.
+
+        Args:
+            mode: The new pool mode to set.
+        """
+        old_mode = self._mode
+        self._mode = mode
+
+        if (
+            mode == PoolMode.WINTER_PASSIVE
+            and old_mode != PoolMode.WINTER_PASSIVE
+            and self.scheduler is not None
+        ):
+            # Entering passive wintering: pause the scheduler
+            await self.scheduler.async_pause()
+        elif (
+            mode != PoolMode.WINTER_PASSIVE
+            and old_mode == PoolMode.WINTER_PASSIVE
+            and self.scheduler is not None
+        ):
+            # Leaving passive wintering: resume the scheduler
+            await self.scheduler.async_resume()
 
     @property
     def min_dynamic_period_duration(self) -> float:

--- a/custom_components/poolman/domain/rules.py
+++ b/custom_components/poolman/domain/rules.py
@@ -195,11 +195,14 @@ class FiltrationRule(Rule):
         manual_measures: dict[MeasureParameter, ManualMeasure] | None = None,
     ) -> list[Recommendation]:
         """Recommend filtration duration."""
+        if mode == PoolMode.WINTER_PASSIVE:
+            return []
+
         hours = compute_filtration_duration(pool, reading, mode)
         if hours is None:
             return []
 
-        if mode in (PoolMode.WINTER_ACTIVE, PoolMode.WINTER_PASSIVE, PoolMode.HIBERNATING):
+        if mode in (PoolMode.WINTER_ACTIVE, PoolMode.HIBERNATING):
             priority = RecommendationPriority.LOW
         elif hours >= 12:
             priority = RecommendationPriority.MEDIUM

--- a/custom_components/poolman/scheduler.py
+++ b/custom_components/poolman/scheduler.py
@@ -101,6 +101,7 @@ class FiltrationScheduler:
         self._hass = hass
         self._pump_entity_id = pump_entity_id
         self._enabled = False
+        self._paused = False
         self._periods: list[FiltrationPeriod] = [FiltrationPeriod()]
         self._unsub_triggers: list[CALLBACK_TYPE] = []
         self._listeners: list[EventCallback] = []
@@ -116,6 +117,17 @@ class FiltrationScheduler:
     def enabled(self) -> bool:
         """Return whether the scheduler is currently active."""
         return self._enabled
+
+    @property
+    def paused(self) -> bool:
+        """Return whether the scheduler is paused by the pool mode.
+
+        A paused scheduler keeps its enabled state but suppresses all
+        pump operations.  This is used by ``WINTER_PASSIVE`` mode to
+        prevent pump starts without changing the user's enable/disable
+        preference.
+        """
+        return self._paused
 
     @property
     def periods(self) -> list[FiltrationPeriod]:
@@ -284,10 +296,16 @@ class FiltrationScheduler:
         """Enable the filtration schedule.
 
         Sets up daily time triggers for pump start and stop for all periods.
-        If the current time falls within any active window, the pump is
-        turned on immediately.
+        If the current time falls within any active window and the scheduler
+        is not paused, the pump is turned on immediately.
         """
         self._enabled = True
+        if self._paused:
+            _LOGGER.debug(
+                "Filtration control enabled (paused, pump: %s)",
+                self._pump_entity_id,
+            )
+            return
         self._setup_triggers()
 
         if self.is_in_active_window():
@@ -309,6 +327,39 @@ class FiltrationScheduler:
         self._clear_boost()
         await self._async_stop_pump()
         _LOGGER.debug("Filtration control disabled (pump: %s)", self._pump_entity_id)
+
+    async def async_pause(self) -> None:
+        """Pause the scheduler due to pool mode (e.g. passive wintering).
+
+        Stops the pump immediately, cancels any active boost, and
+        suppresses future pump starts.  Unlike :meth:`async_disable`,
+        the scheduler remains enabled so that the user's switch
+        preference is preserved.
+        """
+        if self._paused:
+            return
+        self._paused = True
+        self._clear_boost()
+        if self._enabled:
+            self._cancel_triggers()
+        await self._async_stop_pump()
+        _LOGGER.debug("Filtration scheduler paused (pump: %s)", self._pump_entity_id)
+
+    async def async_resume(self) -> None:
+        """Resume the scheduler after a pause.
+
+        Clears the paused flag and, if the scheduler is enabled,
+        re-registers time triggers and starts the pump if the
+        current time falls within an active window.
+        """
+        if not self._paused:
+            return
+        self._paused = False
+        if self._enabled:
+            self._setup_triggers()
+            if self.is_in_active_window():
+                await self._async_start_pump()
+        _LOGGER.debug("Filtration scheduler resumed (pump: %s)", self._pump_entity_id)
 
     # ── Schedule management ─────────────────────────────────────
 
@@ -343,6 +394,9 @@ class FiltrationScheduler:
             period.duration_hours = duration_hours
 
         if not self._enabled:
+            return
+
+        if self._paused:
             return
 
         self._cancel_triggers()
@@ -392,6 +446,9 @@ class FiltrationScheduler:
         if not self._enabled:
             return
 
+        if self._paused:
+            return
+
         self._cancel_triggers()
         self._setup_triggers()
 
@@ -420,9 +477,15 @@ class FiltrationScheduler:
 
         A new boost replaces any previously active boost.
 
+        Has no effect when the scheduler is paused (e.g. passive wintering).
+
         Args:
             hours: Number of extra filtration hours (must be > 0).
         """
+        if self._paused:
+            _LOGGER.debug("Boost request ignored: scheduler is paused")
+            return
+
         if hours <= 0:
             await self.async_cancel_boost()
             return
@@ -589,7 +652,7 @@ class FiltrationScheduler:
         """
 
         async def _on_start_time(_now: datetime) -> None:
-            if self._enabled:
+            if self._enabled and not self._paused:
                 await self._async_start_pump(period_index)
 
         return _on_start_time

--- a/custom_components/poolman/select.py
+++ b/custom_components/poolman/select.py
@@ -52,8 +52,13 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class PoolmanModeSelect(PoolmanEntity, SelectEntity):
-    """Select entity for pool operating mode."""
+class PoolmanModeSelect(PoolmanEntity, SelectEntity, RestoreEntity):
+    """Select entity for pool operating mode.
+
+    The selected mode is persisted across restarts via RestoreEntity.
+    When entering ``WINTER_PASSIVE`` mode, the filtration scheduler is
+    paused and the pump is stopped immediately.
+    """
 
     entity_description: SelectEntityDescription
 
@@ -68,9 +73,21 @@ class PoolmanModeSelect(PoolmanEntity, SelectEntity):
         """Return the current pool mode."""
         return self.coordinator.mode.value
 
+    async def async_added_to_hass(self) -> None:
+        """Restore the last known pool mode."""
+        await super().async_added_to_hass()
+        if (
+            last_state := await self.async_get_last_state()
+        ) is not None and last_state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+            try:
+                restored_mode = PoolMode(last_state.state)
+            except ValueError:
+                restored_mode = PoolMode.ACTIVE
+            await self.coordinator.async_set_mode(restored_mode)
+
     async def async_select_option(self, option: str) -> None:
         """Change the pool mode."""
-        self.coordinator.mode = PoolMode(option)
+        await self.coordinator.async_set_mode(PoolMode(option))
         await self.coordinator.async_request_refresh()
 
 

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -133,7 +133,7 @@ The integration creates select entities to control operational settings:
 
 | Entity | Name | Options | Default | Description |
 | --- | --- | --- | --- | --- |
-| `select.{pool}_mode` | Pool mode | `running`, `winter_active`, `winter_passive` | `running` | Controls the current operational mode. See [Pool Modes](pool-modes.md) for details on each mode. |
+| `select.{pool}_mode` | Pool mode | `active`, `hibernating`, `winter_active`, `winter_passive`, `activating` | `active` | Controls the current operational mode. Persisted across restarts. See [Pool Modes](pool-modes.md) for details on each mode. |
 
 Changing the mode immediately triggers a data refresh and recalculation of all computed values.
 

--- a/tests/domain/test_rules.py
+++ b/tests/domain/test_rules.py
@@ -250,6 +250,12 @@ class TestFiltrationRule:
         assert len(result) == 1
         assert result[0].type == RecommendationType.FILTRATION
 
+    def test_winter_passive_skips(self, pool: Pool) -> None:
+        """WINTER_PASSIVE mode should produce no filtration recommendation."""
+        reading = PoolReading(temp_c=26.0)
+        result = FiltrationRule().evaluate(pool, reading, PoolMode.WINTER_PASSIVE)
+        assert result == []
+
 
 class TestTacRule:
     """Tests for TAC rule evaluation."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -477,3 +477,75 @@ class TestReadingSourceTracking:
 
         assert MeasureParameter.PH in coordinator.data.manual_measures
         assert coordinator.data.manual_measures[MeasureParameter.PH].value == pytest.approx(7.1)
+
+
+class TestAsyncSetMode:
+    """Tests for async_set_mode transition side effects."""
+
+    async def test_set_mode_updates_mode(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Setting mode via async_set_mode should update the mode property."""
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        await coordinator.async_set_mode(PoolMode.WINTER_ACTIVE)
+        assert coordinator.mode == PoolMode.WINTER_ACTIVE
+
+    async def test_entering_winter_passive_pauses_scheduler(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Entering WINTER_PASSIVE should pause the scheduler."""
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        assert coordinator.scheduler is not None
+        assert coordinator.scheduler.paused is False
+
+        await coordinator.async_set_mode(PoolMode.WINTER_PASSIVE)
+        assert coordinator.scheduler.paused is True
+
+    async def test_leaving_winter_passive_resumes_scheduler(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Leaving WINTER_PASSIVE should resume the scheduler."""
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        assert coordinator.scheduler is not None
+
+        await coordinator.async_set_mode(PoolMode.WINTER_PASSIVE)
+        assert coordinator.scheduler.paused is True
+
+        await coordinator.async_set_mode(PoolMode.ACTIVE)
+        assert coordinator.scheduler.paused is False
+
+    async def test_non_passive_to_non_passive_no_pause(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Switching between non-WINTER_PASSIVE modes should not pause."""
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        assert coordinator.scheduler is not None
+
+        await coordinator.async_set_mode(PoolMode.HIBERNATING)
+        assert coordinator.scheduler.paused is False
+
+        await coordinator.async_set_mode(PoolMode.WINTER_ACTIVE)
+        assert coordinator.scheduler.paused is False
+
+    async def test_winter_passive_no_scheduler(
+        self, hass: HomeAssistant, mock_config_entry_no_pump: MockConfigEntry
+    ) -> None:
+        """Entering WINTER_PASSIVE with no scheduler should not raise."""
+        coordinator = await _setup_coordinator(hass, mock_config_entry_no_pump)
+        assert coordinator.scheduler is None
+        await coordinator.async_set_mode(PoolMode.WINTER_PASSIVE)
+        assert coordinator.mode == PoolMode.WINTER_PASSIVE
+
+    async def test_passive_to_passive_noop(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Setting WINTER_PASSIVE when already in WINTER_PASSIVE should be idempotent."""
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        assert coordinator.scheduler is not None
+
+        await coordinator.async_set_mode(PoolMode.WINTER_PASSIVE)
+        assert coordinator.scheduler.paused is True
+
+        # Second call should not error
+        await coordinator.async_set_mode(PoolMode.WINTER_PASSIVE)
+        assert coordinator.scheduler.paused is True

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1057,3 +1057,240 @@ class TestBoostEventData:
         data = scheduler._boost_event_data()
         assert data["boost_hours"] == 4.0
         assert data["boost_end"] == end.isoformat()
+
+
+# ---------- Pause / Resume tests ----------
+
+
+class TestPauseDefaults:
+    """Tests for default pause state."""
+
+    def test_not_paused_by_default(self, scheduler: FiltrationScheduler) -> None:
+        """Scheduler should not be paused by default."""
+        assert scheduler.paused is False
+
+
+class TestPause:
+    """Tests for pausing the scheduler."""
+
+    @pytest.mark.asyncio
+    async def test_pause_sets_flag(self, scheduler: FiltrationScheduler) -> None:
+        """Pausing should set the paused flag."""
+        await scheduler.async_pause()
+        assert scheduler.paused is True
+
+    @pytest.mark.asyncio
+    async def test_pause_stops_pump(self, scheduler: FiltrationScheduler, hass: MagicMock) -> None:
+        """Pausing should immediately turn off the pump."""
+        await scheduler.async_pause()
+        hass.services.async_call.assert_called_once_with(
+            "switch", "turn_off", {"entity_id": "switch.pool_pump"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_pause_clears_boost(self, scheduler: FiltrationScheduler) -> None:
+        """Pausing should cancel any active boost."""
+        with patch.object(scheduler, "is_in_active_window", return_value=True):
+            await scheduler.async_boost(4.0)
+        assert scheduler.boost_active is True
+
+        await scheduler.async_pause()
+        assert scheduler.boost_active is False
+
+    @pytest.mark.asyncio
+    async def test_pause_cancels_triggers_when_enabled(
+        self, scheduler: FiltrationScheduler
+    ) -> None:
+        """Pausing an enabled scheduler should cancel time triggers."""
+        unsub1 = MagicMock()
+        unsub2 = MagicMock()
+        scheduler._enabled = True
+        scheduler._unsub_triggers = [unsub1, unsub2]
+
+        await scheduler.async_pause()
+
+        unsub1.assert_called_once()
+        unsub2.assert_called_once()
+        assert len(scheduler._unsub_triggers) == 0
+
+    @pytest.mark.asyncio
+    async def test_pause_preserves_enabled(self, scheduler: FiltrationScheduler) -> None:
+        """Pausing should not change the enabled state."""
+        with patch.object(scheduler, "_setup_triggers"):
+            await scheduler.async_enable()
+        assert scheduler.enabled is True
+
+        await scheduler.async_pause()
+        assert scheduler.enabled is True
+        assert scheduler.paused is True
+
+    @pytest.mark.asyncio
+    async def test_pause_idempotent(self, scheduler: FiltrationScheduler, hass: MagicMock) -> None:
+        """Pausing twice should be a no-op on the second call."""
+        await scheduler.async_pause()
+        hass.services.async_call.reset_mock()
+
+        await scheduler.async_pause()
+        hass.services.async_call.assert_not_called()
+
+
+class TestResume:
+    """Tests for resuming the scheduler."""
+
+    @pytest.mark.asyncio
+    async def test_resume_clears_flag(self, scheduler: FiltrationScheduler) -> None:
+        """Resuming should clear the paused flag."""
+        await scheduler.async_pause()
+        assert scheduler.paused is True
+
+        with patch.object(scheduler, "_setup_triggers"):
+            await scheduler.async_resume()
+        assert scheduler.paused is False
+
+    @pytest.mark.asyncio
+    async def test_resume_restarts_pump_in_window(
+        self, scheduler: FiltrationScheduler, hass: MagicMock
+    ) -> None:
+        """Resuming an enabled scheduler in active window should start the pump."""
+        scheduler._enabled = True
+        await scheduler.async_pause()
+        hass.services.async_call.reset_mock()
+
+        with (
+            patch.object(scheduler, "_setup_triggers"),
+            patch.object(scheduler, "is_in_active_window", return_value=True),
+        ):
+            await scheduler.async_resume()
+
+        hass.services.async_call.assert_called_once_with(
+            "switch", "turn_on", {"entity_id": "switch.pool_pump"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_resume_does_not_start_pump_outside_window(
+        self, scheduler: FiltrationScheduler, hass: MagicMock
+    ) -> None:
+        """Resuming an enabled scheduler outside active window should not start pump."""
+        scheduler._enabled = True
+        await scheduler.async_pause()
+        hass.services.async_call.reset_mock()
+
+        with (
+            patch.object(scheduler, "_setup_triggers"),
+            patch.object(scheduler, "is_in_active_window", return_value=False),
+        ):
+            await scheduler.async_resume()
+
+        hass.services.async_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_resume_sets_up_triggers_when_enabled(
+        self, scheduler: FiltrationScheduler
+    ) -> None:
+        """Resuming an enabled scheduler should re-register time triggers."""
+        scheduler._enabled = True
+        await scheduler.async_pause()
+
+        with patch.object(scheduler, "_setup_triggers") as mock_setup:
+            await scheduler.async_resume()
+        mock_setup.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_resume_noop_when_disabled(
+        self, scheduler: FiltrationScheduler, hass: MagicMock
+    ) -> None:
+        """Resuming a disabled scheduler should not set up triggers or start pump."""
+        await scheduler.async_pause()
+        hass.services.async_call.reset_mock()
+
+        await scheduler.async_resume()
+        hass.services.async_call.assert_not_called()
+        assert scheduler.paused is False
+
+    @pytest.mark.asyncio
+    async def test_resume_idempotent(self, scheduler: FiltrationScheduler) -> None:
+        """Resuming when not paused should be a no-op."""
+        assert scheduler.paused is False
+        with patch.object(scheduler, "_setup_triggers") as mock_setup:
+            await scheduler.async_resume()
+        mock_setup.assert_not_called()
+
+
+class TestPausedBehavior:
+    """Tests for scheduler behavior while paused."""
+
+    @pytest.mark.asyncio
+    async def test_enable_while_paused_sets_enabled_but_no_pump(
+        self, scheduler: FiltrationScheduler, hass: MagicMock
+    ) -> None:
+        """Enabling while paused should set enabled flag but not start pump."""
+        await scheduler.async_pause()
+        hass.services.async_call.reset_mock()
+
+        await scheduler.async_enable()
+        assert scheduler.enabled is True
+        assert scheduler.paused is True
+        hass.services.async_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_start_callback_suppressed_while_paused(
+        self, scheduler: FiltrationScheduler, hass: MagicMock
+    ) -> None:
+        """Start callback should not start pump when scheduler is paused."""
+        scheduler._enabled = True
+        scheduler._paused = True
+        cb = scheduler._make_start_callback(0)
+        await cb(datetime.now())
+        hass.services.async_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_boost_rejected_while_paused(
+        self, scheduler: FiltrationScheduler, hass: MagicMock
+    ) -> None:
+        """Boost request should be ignored when scheduler is paused."""
+        scheduler._paused = True
+        with patch.object(scheduler, "is_in_active_window", return_value=False):
+            await scheduler.async_boost(4.0)
+        assert scheduler.boost_active is False
+        hass.services.async_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_schedule_while_paused_stores_values(
+        self, scheduler: FiltrationScheduler
+    ) -> None:
+        """Updating schedule while paused should store values but not adjust pump."""
+        scheduler._enabled = True
+        scheduler._paused = True
+        await scheduler.async_update_schedule(start_time=time(14, 0), duration_hours=6.0)
+        assert scheduler.start_time == time(14, 0)
+        assert scheduler.duration_hours == 6.0
+
+    @pytest.mark.asyncio
+    async def test_update_schedule_while_paused_does_not_touch_pump(
+        self, scheduler: FiltrationScheduler, hass: MagicMock
+    ) -> None:
+        """Updating schedule while paused should not call any services."""
+        scheduler._enabled = True
+        scheduler._paused = True
+        await scheduler.async_update_schedule(start_time=time(14, 0))
+        hass.services.async_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_set_split_while_paused_stores_periods(
+        self, scheduler: FiltrationScheduler
+    ) -> None:
+        """Enabling split while paused should add period but not touch pump."""
+        scheduler._enabled = True
+        scheduler._paused = True
+        await scheduler.async_set_split(enabled=True)
+        assert len(scheduler.periods) == 2
+
+    @pytest.mark.asyncio
+    async def test_set_split_while_paused_does_not_touch_pump(
+        self, scheduler: FiltrationScheduler, hass: MagicMock
+    ) -> None:
+        """Enabling split while paused should not call any services."""
+        scheduler._enabled = True
+        scheduler._paused = True
+        await scheduler.async_set_split(enabled=True)
+        hass.services.async_call.assert_not_called()

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -131,6 +131,66 @@ class TestPoolModeSelect:
         assert options is not None
         assert set(options) == {m.value for m in PoolMode}
 
+    async def test_restore_winter_passive(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Should restore winter_passive mode from previous state."""
+        from pytest_homeassistant_custom_component.common import mock_restore_cache
+
+        mock_restore_cache(
+            hass,
+            [State("select.test_pool_pool_mode", "winter_passive")],
+        )
+        coordinator = await _setup_integration(hass, mock_config_entry)
+        assert coordinator.mode == PoolMode.WINTER_PASSIVE
+
+    async def test_restore_hibernating(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Should restore hibernating mode from previous state."""
+        from pytest_homeassistant_custom_component.common import mock_restore_cache
+
+        mock_restore_cache(
+            hass,
+            [State("select.test_pool_pool_mode", "hibernating")],
+        )
+        coordinator = await _setup_integration(hass, mock_config_entry)
+        assert coordinator.mode == PoolMode.HIBERNATING
+
+    async def test_restore_invalid_mode_uses_active(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Should fall back to ACTIVE when restored mode is invalid."""
+        from pytest_homeassistant_custom_component.common import mock_restore_cache
+
+        mock_restore_cache(
+            hass,
+            [State("select.test_pool_pool_mode", "invalid_mode")],
+        )
+        coordinator = await _setup_integration(hass, mock_config_entry)
+        assert coordinator.mode == PoolMode.ACTIVE
+
+    async def test_restore_winter_passive_pauses_scheduler(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Restoring WINTER_PASSIVE should pause the scheduler."""
+        from pytest_homeassistant_custom_component.common import mock_restore_cache
+
+        mock_restore_cache(
+            hass,
+            [State("select.test_pool_pool_mode", "winter_passive")],
+        )
+        coordinator = await _setup_integration(hass, mock_config_entry)
+        assert coordinator.scheduler is not None
+        assert coordinator.scheduler.paused is True
+
+    async def test_restore_no_previous_state_uses_active(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """No previous state should keep default ACTIVE mode."""
+        coordinator = await _setup_integration(hass, mock_config_entry)
+        assert coordinator.mode == PoolMode.ACTIVE
+
 
 class TestFiltrationDurationModeSelect:
     """Tests for the PoolmanFiltrationDurationModeSelect entity."""


### PR DESCRIPTION
## Summary

Implements passive winter hibernation mode (#21). When the pool mode is set to `WINTER_PASSIVE`, the filtration pump stops immediately and all scheduling (cycles, boosts) is suppressed until the mode is changed back.

## Changes

- **Scheduler pause/resume** — New `async_pause()` / `async_resume()` methods on `FiltrationScheduler` with a `_paused` flag orthogonal to `_enabled`. This preserves the user's filtration control switch preference while suppressing all pump operations. All start callbacks, `async_enable()`, `async_boost()`, `async_update_schedule()`, and `async_set_split()` guard against `_paused`.
- **Coordinator `async_set_mode()`** — Handles transition side effects: pauses the scheduler on entering `WINTER_PASSIVE`, resumes it on leaving.
- **Mode persistence** — `PoolmanModeSelect` now extends `RestoreEntity` so the pool mode survives HA restarts. A winterized pool no longer silently resets to `ACTIVE` on reboot.
- **FiltrationRule fix** — Early return in `WINTER_PASSIVE` suppresses the misleading "run filtration for 0.0 hours" recommendation.
- **Dead code cleanup** — Removed unused `MODE_*` string constants from `const.py` (all code uses the `PoolMode` enum directly).
- **Doc fix** — Updated `docs/entities.md` mode select table with all 5 modes, correct names, and a note about persistence.

## Testing

- 568 tests pass (375 new lines of test code covering pause/resume, mode transitions, persistence restore, and rule skip)
- Linters pass (ruff, mypy, codespell, markdownlint)

Closes #21