### PR TITLE
feat(activation): add activation wizard with step-by-step checklist

### DIFF
--- a/custom_components/poolman/__init__.py
+++ b/custom_components/poolman/__init__.py
@@ -19,9 +19,11 @@ from .const import (
     PLATFORMS,
     SERVICE_ADD_TREATMENT,
     SERVICE_BOOST_FILTRATION,
+    SERVICE_CONFIRM_ACTIVATION_STEP,
     SERVICE_RECORD_MEASURE,
 )
 from .coordinator import PoolmanCoordinator
+from .domain.activation import ActivationStep
 from .domain.model import ChemicalProduct, MeasureParameter
 
 _LOGGER = logging.getLogger(__name__)
@@ -53,6 +55,13 @@ SERVICE_BOOST_FILTRATION_SCHEMA = vol.Schema(
     }
 )
 
+SERVICE_CONFIRM_ACTIVATION_STEP_SCHEMA = vol.Schema(
+    {
+        vol.Required("device_id"): str,
+        vol.Required("step"): vol.In([s.value for s in ActivationStep]),
+    }
+)
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: PoolmanConfigEntry) -> bool:
     """Set up Pool Manager from a config entry."""
@@ -75,6 +84,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: PoolmanConfigEntry) -> 
         hass.services.async_remove(DOMAIN, SERVICE_ADD_TREATMENT)
         hass.services.async_remove(DOMAIN, SERVICE_RECORD_MEASURE)
         hass.services.async_remove(DOMAIN, SERVICE_BOOST_FILTRATION)
+        hass.services.async_remove(DOMAIN, SERVICE_CONFIRM_ACTIVATION_STEP)
 
     return result
 
@@ -199,4 +209,32 @@ def _async_register_services(hass: HomeAssistant) -> None:
         SERVICE_BOOST_FILTRATION,
         async_handle_boost_filtration,
         schema=SERVICE_BOOST_FILTRATION_SCHEMA,
+    )
+
+    async def async_handle_confirm_activation_step(call: ServiceCall) -> None:
+        """Handle the confirm_activation_step service call.
+
+        Resolves the target device to find the corresponding coordinator,
+        then confirms the specified activation step.
+        """
+        step = ActivationStep(call.data["step"])
+        device_id: str = call.data["device_id"]
+
+        device_reg = dr.async_get(hass)
+        device = device_reg.async_get(device_id)
+        if device is None:
+            _LOGGER.warning("Device %s not found", device_id)
+            return
+
+        for entry_id in device.config_entries:
+            entry = hass.config_entries.async_get_entry(entry_id)
+            if entry and entry.domain == DOMAIN:
+                coordinator: PoolmanCoordinator = entry.runtime_data
+                await coordinator.async_confirm_activation_step(step)
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_CONFIRM_ACTIVATION_STEP,
+        async_handle_confirm_activation_step,
+        schema=SERVICE_CONFIRM_ACTIVATION_STEP_SCHEMA,
     )

--- a/custom_components/poolman/const.py
+++ b/custom_components/poolman/const.py
@@ -61,6 +61,20 @@ FILTRATION_KINDS: Final = [
     FILTRATION_KIND_GLASS,
 ]
 
+# Pool modes
+MODE_ACTIVE: Final = "active"
+MODE_HIBERNATING: Final = "hibernating"
+MODE_WINTER_ACTIVE: Final = "winter_active"
+MODE_WINTER_PASSIVE: Final = "winter_passive"
+MODE_ACTIVATING: Final = "activating"
+MODES: Final = [
+    MODE_ACTIVE,
+    MODE_HIBERNATING,
+    MODE_WINTER_ACTIVE,
+    MODE_WINTER_PASSIVE,
+    MODE_ACTIVATING,
+]
+
 # Filtration duration modes
 FILTRATION_DURATION_MODE_MANUAL: Final = "manual"
 FILTRATION_DURATION_MODE_DYNAMIC: Final = "dynamic"
@@ -103,3 +117,4 @@ DEFAULT_MIN_DYNAMIC_DURATION_HOURS: Final = 0.0
 SERVICE_ADD_TREATMENT: Final = "add_treatment"
 SERVICE_RECORD_MEASURE: Final = "record_measure"
 SERVICE_BOOST_FILTRATION: Final = "boost_filtration"
+SERVICE_CONFIRM_ACTIVATION_STEP: Final = "confirm_activation_step"

--- a/custom_components/poolman/coordinator.py
+++ b/custom_components/poolman/coordinator.py
@@ -35,8 +35,10 @@ from .const import (
     DEFAULT_TREATMENT,
     DEFAULT_UPDATE_INTERVAL_MINUTES,
     DOMAIN,
+    EVENT_FILTRATION_STOPPED,
     EVENT_POOLMAN,
 )
+from .domain.activation import SHOCK_PRODUCT_VALUES, ActivationChecklist, ActivationStep
 from .domain.chemistry import compute_chemistry_report, compute_water_quality_score
 from .domain.filtration import compute_filtration_duration
 from .domain.model import (
@@ -105,12 +107,17 @@ class PoolmanCoordinator(DataUpdateCoordinator[PoolState]):
         self._min_dynamic_period_duration = DEFAULT_MIN_DYNAMIC_DURATION_HOURS
         self._treatment_entities: dict[ChemicalProduct, PoolmanTreatmentEvent] = {}
         self._measure_entities: dict[MeasureParameter, PoolmanMeasureEvent] = {}
+        self._activation: ActivationChecklist | None = None
 
         # Filtration scheduler: only created when a pump entity is configured
         pump_entity_id = self._get_config(CONF_PUMP_ENTITY)
         self.scheduler: FiltrationScheduler | None = (
             FiltrationScheduler(hass, pump_entity_id) if pump_entity_id else None
         )
+
+        # Listen for filtration events to auto-confirm activation steps
+        if self.scheduler is not None:
+            self.scheduler.on_event(self._on_scheduler_event)
 
     def _get_config(self, key: str, default: Any = None) -> Any:
         """Get a config value, checking options first then data.
@@ -152,23 +159,48 @@ class PoolmanCoordinator(DataUpdateCoordinator[PoolState]):
     def mode(self, value: PoolMode) -> None:
         """Set the pool mode.
 
+        When switching to ACTIVATING, a new activation checklist is created
+        (unless one already exists). When switching away from ACTIVATING,
+        the checklist is cleared.
+
         For mode changes that require side effects (e.g. pausing the
         scheduler), use :meth:`async_set_mode` instead.
         """
+        previous = self._mode
         self._mode = value
+        if value == PoolMode.ACTIVATING and previous != PoolMode.ACTIVATING:
+            self._activation = ActivationChecklist(started_at=utcnow())
+        elif value != PoolMode.ACTIVATING:
+            self._activation = None
+
+    @property
+    def activation(self) -> ActivationChecklist | None:
+        """Return the current activation checklist, if any."""
+        return self._activation
+
+    @activation.setter
+    def activation(self, value: ActivationChecklist | None) -> None:
+        """Set or clear the activation checklist (used for state restoration)."""
+        self._activation = value
 
     async def async_set_mode(self, mode: PoolMode) -> None:
         """Set the pool mode with transition side effects.
 
         Handles scheduler pause/resume when entering or leaving
-        ``WINTER_PASSIVE`` mode.  The pump is stopped immediately
-        on entering passive wintering and resumed when leaving it.
+        ``WINTER_PASSIVE`` mode and activation checklist lifecycle
+        when entering or leaving ``ACTIVATING`` mode.
 
         Args:
             mode: The new pool mode to set.
         """
         old_mode = self._mode
         self._mode = mode
+
+        # Manage activation checklist lifecycle
+        if mode == PoolMode.ACTIVATING and old_mode != PoolMode.ACTIVATING:
+            self._activation = ActivationChecklist(started_at=utcnow())
+        elif mode != PoolMode.ACTIVATING:
+            self._activation = None
 
         if (
             mode == PoolMode.WINTER_PASSIVE
@@ -228,6 +260,46 @@ class PoolmanCoordinator(DataUpdateCoordinator[PoolState]):
             await self.scheduler.async_cancel_boost()
             await self.async_request_refresh()
 
+    async def async_confirm_activation_step(self, step: ActivationStep) -> None:
+        """Confirm completion of an activation wizard step.
+
+        Args:
+            step: The activation step to mark as completed.
+
+        Raises:
+            ValueError: If the pool is not in activating mode or the step
+                has already been confirmed.
+        """
+        if self._mode != PoolMode.ACTIVATING or self._activation is None:
+            msg = "Cannot confirm activation step: pool is not in activating mode"
+            raise ValueError(msg)
+        self._activation.confirm(step)
+        if self._activation.is_complete:
+            self._mode = PoolMode.ACTIVE
+            self._activation = None
+        await self.async_request_refresh()
+
+    def _on_scheduler_event(self, event_type: str, _data: dict[str, object]) -> None:
+        """Handle scheduler events to auto-confirm activation steps.
+
+        When a filtration cycle completes (filtration_stopped) during
+        activating mode, the intensive_filtration step is auto-confirmed.
+
+        Args:
+            event_type: The scheduler event type.
+            _data: Event data payload (unused).
+        """
+        if event_type != EVENT_FILTRATION_STOPPED:
+            return
+        if self._mode != PoolMode.ACTIVATING or self._activation is None:
+            return
+        if ActivationStep.INTENSIVE_FILTRATION in self._activation.pending_steps:
+            self._activation.confirm(ActivationStep.INTENSIVE_FILTRATION)
+            if self._activation.is_complete:
+                self._mode = PoolMode.ACTIVE
+                self._activation = None
+            self.hass.async_create_task(self.async_request_refresh())
+
     def register_treatment_entity(
         self,
         product: ChemicalProduct,
@@ -254,6 +326,9 @@ class PoolmanCoordinator(DataUpdateCoordinator[PoolState]):
         Fires the event on the corresponding event entity and triggers
         a coordinator refresh to update derived sensors.
 
+        When in activating mode, recording a shock product automatically
+        confirms the shock_treatment activation step.
+
         Args:
             product: The chemical product applied.
             quantity_g: Amount of product used in grams.
@@ -264,6 +339,19 @@ class PoolmanCoordinator(DataUpdateCoordinator[PoolState]):
             _LOGGER.warning("No treatment entity registered for product %s", product)
             return
         entity.apply_treatment(quantity_g=quantity_g, notes=notes)
+
+        # Auto-confirm shock_treatment step during activation
+        if (
+            self._mode == PoolMode.ACTIVATING
+            and self._activation is not None
+            and product in SHOCK_PRODUCT_VALUES
+            and ActivationStep.SHOCK_TREATMENT in self._activation.pending_steps
+        ):
+            self._activation.confirm(ActivationStep.SHOCK_TREATMENT)
+            if self._activation.is_complete:
+                self._mode = PoolMode.ACTIVE
+                self._activation = None
+
         await self.async_request_refresh()
 
     def register_measure_entity(
@@ -567,6 +655,7 @@ class PoolmanCoordinator(DataUpdateCoordinator[PoolState]):
             manual_measures=manual_measures,
             reading_sources=reading_sources,
             boost_remaining=(self.scheduler.boost_remaining if self.scheduler is not None else 0.0),
+            activation=self._activation,
         )
 
         self._fire_status_change_events(new_state)

--- a/custom_components/poolman/domain/activation.py
+++ b/custom_components/poolman/domain/activation.py
@@ -1,0 +1,108 @@
+"""Activation wizard domain logic.
+
+Pure Python models for the step-by-step activation process that brings
+a pool out of hibernation. No Home Assistant dependencies.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+
+class ActivationStep(StrEnum):
+    """Steps in the activation wizard.
+
+    Ordered from first to last in the activation process.
+    Manual steps require explicit user confirmation via a service call.
+    Auto-detectable steps are confirmed automatically when the corresponding
+    system event occurs (e.g., shock treatment recorded, filtration cycle
+    completed).
+    """
+
+    REMOVE_COVER = "remove_cover"
+    RAISE_WATER_LEVEL = "raise_water_level"
+    CLEAN_POOL_AND_FILTER = "clean_pool_and_filter"
+    SHOCK_TREATMENT = "shock_treatment"
+    INTENSIVE_FILTRATION = "intensive_filtration"
+
+
+# Chemical product values that auto-confirm the shock_treatment step.
+# Defined as plain strings to avoid a circular import with model.py.
+# These must match ChemicalProduct enum values.
+SHOCK_PRODUCT_VALUES: frozenset[str] = frozenset(
+    {
+        "chlore_choc",
+        "bromine_shock",
+        "active_oxygen_activator",
+    }
+)
+
+# Ordered list of all activation steps for iteration
+ACTIVATION_STEPS: tuple[ActivationStep, ...] = tuple(ActivationStep)
+
+
+class ActivationChecklist(BaseModel):
+    """Tracks progress through the activation wizard.
+
+    Each step starts as incomplete (False) and is marked as complete (True)
+    either by the user via a service call or automatically by the system
+    when the corresponding event is detected.
+
+    Attributes:
+        started_at: When the activation process was started.
+        steps: Mapping of each step to its completion status.
+    """
+
+    started_at: datetime
+    steps: dict[ActivationStep, bool] = Field(
+        default_factory=lambda: dict.fromkeys(ActivationStep, False),
+    )
+
+    @property
+    def completed_steps(self) -> list[ActivationStep]:
+        """Return the list of completed steps in order."""
+        return [step for step in ACTIVATION_STEPS if self.steps.get(step, False)]
+
+    @property
+    def pending_steps(self) -> list[ActivationStep]:
+        """Return the list of pending (incomplete) steps in order."""
+        return [step for step in ACTIVATION_STEPS if not self.steps.get(step, False)]
+
+    @property
+    def current_step(self) -> ActivationStep | None:
+        """Return the first pending step, or None if all steps are complete."""
+        pending = self.pending_steps
+        return pending[0] if pending else None
+
+    @property
+    def is_complete(self) -> bool:
+        """Return True if all activation steps have been completed."""
+        return all(self.steps.values())
+
+    @property
+    def progress(self) -> tuple[int, int]:
+        """Return the number of completed steps and total steps.
+
+        Returns:
+            Tuple of (completed_count, total_count).
+        """
+        total = len(ACTIVATION_STEPS)
+        completed = sum(1 for v in self.steps.values() if v)
+        return completed, total
+
+    def confirm(self, step: ActivationStep) -> None:
+        """Mark an activation step as completed.
+
+        Args:
+            step: The step to confirm.
+
+        Raises:
+            ValueError: If the step has already been confirmed.
+        """
+        if self.steps.get(step, False):
+            msg = f"Activation step '{step}' is already confirmed"
+            raise ValueError(msg)
+        self.steps[step] = True

--- a/custom_components/poolman/domain/model.py
+++ b/custom_components/poolman/domain/model.py
@@ -10,6 +10,8 @@ from enum import StrEnum
 
 from pydantic import BaseModel, Field
 
+from .activation import ActivationChecklist
+
 
 class PoolShape(StrEnum):
     """Pool shape types."""
@@ -294,6 +296,7 @@ class PoolState(BaseModel):
     manual_measures: dict[MeasureParameter, ManualMeasure] = Field(default_factory=dict)
     reading_sources: dict[str, str] = Field(default_factory=dict)
     boost_remaining: float = Field(0.0, ge=0, description="Remaining boost filtration hours")
+    activation: ActivationChecklist | None = None
 
     @property
     def water_ok(self) -> bool:

--- a/custom_components/poolman/sensor.py
+++ b/custom_components/poolman/sensor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any
+from typing import Any, ClassVar
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -13,14 +13,16 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import UnitOfTemperature, UnitOfTime
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, UnitOfTemperature, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import StateType
 
 from . import PoolmanConfigEntry
 from .coordinator import PoolmanCoordinator
-from .domain.model import ActionKind, ChemistryStatus, ParameterReport, PoolState
+from .domain.activation import ActivationChecklist, ActivationStep
+from .domain.model import ActionKind, ChemistryStatus, ParameterReport, PoolMode, PoolState
 from .entity import PoolmanEntity
 
 
@@ -278,7 +280,11 @@ async def async_setup_entry(
     descriptions = list(SENSOR_DESCRIPTIONS)
     if coordinator.scheduler is not None:
         descriptions.extend(FILTRATION_SENSOR_DESCRIPTIONS)
-    async_add_entities(PoolmanSensor(coordinator, description) for description in descriptions)
+    entities: list[SensorEntity] = [
+        PoolmanSensor(coordinator, description) for description in descriptions
+    ]
+    entities.append(PoolmanActivationStepSensor(coordinator))
+    async_add_entities(entities)
 
 
 class PoolmanSensor(PoolmanEntity, SensorEntity):
@@ -307,3 +313,86 @@ class PoolmanSensor(PoolmanEntity, SensorEntity):
         if self.entity_description.extra_attrs_fn is not None:
             return self.entity_description.extra_attrs_fn(self.pool_state)
         return None
+
+
+class PoolmanActivationStepSensor(PoolmanEntity, SensorEntity, RestoreEntity):
+    """Sensor showing the current activation wizard step.
+
+    Displays the next pending activation step or None when the pool is
+    not in activating mode. Persists the activation checklist state
+    across HA restarts via RestoreEntity.
+    """
+
+    _attr_translation_key = "activation_step"
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options: ClassVar[list[str]] = [step.value for step in ActivationStep]
+    _attr_icon = "mdi:wizard-hat"
+
+    def __init__(self, coordinator: PoolmanCoordinator) -> None:
+        """Initialize the activation step sensor."""
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}_activation_step"
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the current (next pending) activation step."""
+        activation = self.pool_state.activation
+        if activation is None:
+            return None
+        return activation.current_step
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return activation progress details for persistence and display.
+
+        Returns:
+            Dictionary with completed_steps, pending_steps, progress,
+            and started_at. Empty dict when not in activating mode.
+        """
+        activation = self.pool_state.activation
+        if activation is None:
+            return {}
+        completed, total = activation.progress
+        return {
+            "completed_steps": [s.value for s in activation.completed_steps],
+            "pending_steps": [s.value for s in activation.pending_steps],
+            "progress": f"{completed}/{total}",
+            "started_at": activation.started_at.isoformat(),
+        }
+
+    async def async_added_to_hass(self) -> None:
+        """Restore activation checklist from persisted state after HA restart."""
+        await super().async_added_to_hass()
+        if self.coordinator.mode != PoolMode.ACTIVATING:
+            return
+
+        last_state = await self.async_get_last_state()
+        if last_state is None or last_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+            return
+
+        # Restore the activation checklist from persisted attributes
+        attrs = last_state.attributes
+        completed_steps_raw = attrs.get("completed_steps", [])
+        started_at_raw = attrs.get("started_at")
+
+        if started_at_raw is None:
+            return
+
+        try:
+            started_at = datetime.fromisoformat(started_at_raw)
+        except (ValueError, TypeError):
+            return
+
+        # Rebuild the checklist with restored completion status
+        steps = dict.fromkeys(ActivationStep, False)
+        for step_value in completed_steps_raw:
+            try:
+                step = ActivationStep(step_value)
+                steps[step] = True
+            except ValueError:
+                continue
+
+        self.coordinator.activation = ActivationChecklist(
+            started_at=started_at,
+            steps=steps,
+        )

--- a/custom_components/poolman/services.yaml
+++ b/custom_components/poolman/services.yaml
@@ -110,3 +110,28 @@ boost_filtration:
           step: 0.5
           unit_of_measurement: h
           mode: box
+
+confirm_activation_step:
+  name: Confirm activation step
+  description: Confirm completion of an activation wizard step.
+  fields:
+    device_id:
+      name: Pool device
+      description: The pool to confirm the activation step for.
+      required: true
+      selector:
+        device:
+          integration: poolman
+    step:
+      name: Step
+      description: The activation step to confirm as completed.
+      required: true
+      selector:
+        select:
+          translation_key: activation_step
+          options:
+            - "remove_cover"
+            - "raise_water_level"
+            - "clean_pool_and_filter"
+            - "shock_treatment"
+            - "intensive_filtration"

--- a/custom_components/poolman/strings.json
+++ b/custom_components/poolman/strings.json
@@ -173,6 +173,16 @@
       },
       "filtration_boost_remaining": {
         "name": "Filtration boost remaining"
+      },
+      "activation_step": {
+        "name": "Activation step",
+        "state": {
+          "remove_cover": "Remove cover",
+          "raise_water_level": "Raise water level",
+          "clean_pool_and_filter": "Clean pool and filter",
+          "shock_treatment": "Shock treatment",
+          "intensive_filtration": "Intensive filtration"
+        }
       }
     },
     "binary_sensor": {
@@ -550,6 +560,15 @@
         "hardness": "Calcium hardness",
         "temperature": "Temperature"
       }
+    },
+    "activation_step": {
+      "options": {
+        "remove_cover": "Remove cover",
+        "raise_water_level": "Raise water level",
+        "clean_pool_and_filter": "Clean pool and filter",
+        "shock_treatment": "Shock treatment",
+        "intensive_filtration": "Intensive filtration"
+      }
     }
   },
   "services": {
@@ -608,6 +627,20 @@
         "hours": {
           "name": "Duration (hours)",
           "description": "Number of extra filtration hours to add. Set to 0 to cancel an active boost."
+        }
+      }
+    },
+    "confirm_activation_step": {
+      "name": "Confirm activation step",
+      "description": "Confirm completion of an activation wizard step.",
+      "fields": {
+        "device_id": {
+          "name": "Pool device",
+          "description": "The pool to confirm the activation step for."
+        },
+        "step": {
+          "name": "Step",
+          "description": "The activation step to confirm as completed."
         }
       }
     }

--- a/custom_components/poolman/translations/en.json
+++ b/custom_components/poolman/translations/en.json
@@ -173,6 +173,16 @@
       },
       "filtration_boost_remaining": {
         "name": "Filtration boost remaining"
+      },
+      "activation_step": {
+        "name": "Activation step",
+        "state": {
+          "remove_cover": "Remove cover",
+          "raise_water_level": "Raise water level",
+          "clean_pool_and_filter": "Clean pool and filter",
+          "shock_treatment": "Shock treatment",
+          "intensive_filtration": "Intensive filtration"
+        }
       }
     },
     "binary_sensor": {
@@ -550,6 +560,15 @@
         "hardness": "Calcium hardness",
         "temperature": "Temperature"
       }
+    },
+    "activation_step": {
+      "options": {
+        "remove_cover": "Remove cover",
+        "raise_water_level": "Raise water level",
+        "clean_pool_and_filter": "Clean pool and filter",
+        "shock_treatment": "Shock treatment",
+        "intensive_filtration": "Intensive filtration"
+      }
     }
   },
   "services": {
@@ -608,6 +627,20 @@
         "hours": {
           "name": "Hours",
           "description": "Number of extra filtration hours (0 to cancel)."
+        }
+      }
+    },
+    "confirm_activation_step": {
+      "name": "Confirm activation step",
+      "description": "Confirm completion of an activation wizard step.",
+      "fields": {
+        "device_id": {
+          "name": "Pool device",
+          "description": "The pool to confirm the activation step for."
+        },
+        "step": {
+          "name": "Step",
+          "description": "The activation step to confirm as completed."
         }
       }
     }

--- a/custom_components/poolman/translations/fr.json
+++ b/custom_components/poolman/translations/fr.json
@@ -173,6 +173,16 @@
       },
       "filtration_boost_remaining": {
         "name": "Boost de filtration restant"
+      },
+      "activation_step": {
+        "name": "\u00c9tape de remise en route",
+        "state": {
+          "remove_cover": "Retirer la couverture",
+          "raise_water_level": "Remonter le niveau d'eau",
+          "clean_pool_and_filter": "Nettoyer la piscine et le filtre",
+          "shock_treatment": "Traitement choc",
+          "intensive_filtration": "Filtration intensive"
+        }
       }
     },
     "binary_sensor": {
@@ -550,6 +560,15 @@
         "hardness": "Duret\u00e9 calcique",
         "temperature": "Temp\u00e9rature"
       }
+    },
+    "activation_step": {
+      "options": {
+        "remove_cover": "Retirer la couverture",
+        "raise_water_level": "Remonter le niveau d'eau",
+        "clean_pool_and_filter": "Nettoyer la piscine et le filtre",
+        "shock_treatment": "Traitement choc",
+        "intensive_filtration": "Filtration intensive"
+      }
     }
   },
   "services": {
@@ -608,6 +627,20 @@
         "hours": {
           "name": "Heures",
           "description": "Nombre d'heures de filtration suppl\u00e9mentaires (0 pour annuler)."
+        }
+      }
+    },
+    "confirm_activation_step": {
+      "name": "Confirmer une \u00e9tape de remise en route",
+      "description": "Confirmer la compl\u00e9tion d'une \u00e9tape de l'assistant de remise en route.",
+      "fields": {
+        "device_id": {
+          "name": "Appareil piscine",
+          "description": "La piscine pour laquelle confirmer l'\u00e9tape."
+        },
+        "step": {
+          "name": "\u00c9tape",
+          "description": "L'\u00e9tape de remise en route \u00e0 confirmer."
         }
       }
     }

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -11,7 +11,7 @@ name you set during configuration.
 
 ## Sensors
 
-The integration creates 14 sensor entities:
+The integration creates 15 sensor entities:
 
 ### Reading sensors
 
@@ -100,6 +100,30 @@ The `active_treatments` sensor exposes additional detail through its state attri
 | Attribute | Type | Description |
 | --- | --- | --- |
 | `treatments` | list of objects | Details of each active treatment: `product`, `applied_at`, `safe_at`, `quantity_g` |
+
+### Activation step sensor
+
+The `activation_step` sensor tracks progress through the
+[Activation Wizard](pool-modes.md#activation-wizard). It shows the next
+pending step when the pool is in **Activating** mode, or has no state
+when the pool is in any other mode.
+
+| Entity | Name | Device Class | Options | Description |
+| --- | --- | --- | --- | --- |
+| `sensor.{pool}_activation_step` | Activation step | `enum` | `remove_cover`, `raise_water_level`, `clean_pool_and_filter`, `shock_treatment`, `intensive_filtration` | Current (next pending) activation wizard step |
+
+#### Activation step sensor attributes
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `completed_steps` | list of strings | Steps already confirmed |
+| `pending_steps` | list of strings | Steps still to be confirmed |
+| `progress` | string | Progress in the format `"N/5"` (e.g. `"2/5"`) |
+| `started_at` | string (ISO 8601) | When the activation process was started |
+
+These attributes are empty when the pool is not in activating mode.
+The checklist state persists across Home Assistant restarts via the
+`RestoreEntity` mechanism.
 
 ## Binary Sensors
 

--- a/docs/pool-modes.md
+++ b/docs/pool-modes.md
@@ -239,6 +239,57 @@ not yet ready for swimming and typically requires:
 - Shock treatment
 - Intensive filtration to restore water clarity
 
+### Activation Wizard
+
+When the pool mode is set to **Activating**, an activation wizard guides you
+through the five steps needed to bring the pool back to full operation.
+Progress is tracked via the `sensor.{pool}_activation_step` entity, which
+shows the current (next pending) step.
+
+#### Wizard steps
+
+| # | Step | Confirmation |
+| --- | --- | --- |
+| 1 | **Remove cover** | Manual |
+| 2 | **Raise water level** | Manual |
+| 3 | **Clean pool and filter** | Manual |
+| 4 | **Shock treatment** | Auto-detected when a shock product is recorded |
+| 5 | **Intensive filtration** | Auto-detected when a filtration cycle completes |
+
+Steps can be confirmed in any order. The three manual steps require
+calling the `poolman.confirm_activation_step` service. The two
+auto-detectable steps are confirmed automatically:
+
+- **Shock treatment** is auto-confirmed when a shock product
+  (`chlore_choc`, `bromine_shock`, or `active_oxygen_activator`) is
+  recorded via the `poolman.add_treatment` service.
+- **Intensive filtration** is auto-confirmed when a filtration cycle
+  completes (the scheduler fires a `filtration_stopped` event).
+
+When all five steps are confirmed, the pool mode automatically switches
+to **Active** and the activation checklist is cleared.
+
+#### Confirming steps manually
+
+Use the `poolman.confirm_activation_step` service:
+
+```yaml
+service: poolman.confirm_activation_step
+data:
+  device_id: "<your_pool_device_id>"
+  step: "remove_cover"
+```
+
+Valid step values: `remove_cover`, `raise_water_level`,
+`clean_pool_and_filter`, `shock_treatment`, `intensive_filtration`.
+
+#### Persistence
+
+The activation checklist persists across Home Assistant restarts. When
+HA restarts while the pool is in activating mode, already-confirmed
+steps are restored from the `activation_step` sensor's persisted state
+attributes.
+
 ### Activating filtration
 
 Uses the full **dynamic multi-factor algorithm** (same as active mode).

--- a/tests/domain/test_activation.py
+++ b/tests/domain/test_activation.py
@@ -1,0 +1,224 @@
+"""Tests for the activation wizard domain logic."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from custom_components.poolman.domain.activation import (
+    ACTIVATION_STEPS,
+    SHOCK_PRODUCT_VALUES,
+    ActivationChecklist,
+    ActivationStep,
+)
+from custom_components.poolman.domain.model import ChemicalProduct
+
+# Fixed reference time for deterministic tests
+NOW = datetime(2025, 3, 15, 10, 0, 0, tzinfo=UTC)
+
+
+class TestActivationStep:
+    """Tests for the ActivationStep enum."""
+
+    def test_has_five_steps(self) -> None:
+        """There should be exactly 5 activation steps."""
+        assert len(ActivationStep) == 5
+
+    def test_step_values(self) -> None:
+        """Each step should have the expected string value."""
+        assert ActivationStep.REMOVE_COVER == "remove_cover"
+        assert ActivationStep.RAISE_WATER_LEVEL == "raise_water_level"
+        assert ActivationStep.CLEAN_POOL_AND_FILTER == "clean_pool_and_filter"
+        assert ActivationStep.SHOCK_TREATMENT == "shock_treatment"
+        assert ActivationStep.INTENSIVE_FILTRATION == "intensive_filtration"
+
+    def test_activation_steps_tuple_matches_enum(self) -> None:
+        """ACTIVATION_STEPS tuple should contain all enum members in order."""
+        assert tuple(ActivationStep) == ACTIVATION_STEPS
+        assert len(ACTIVATION_STEPS) == 5
+
+
+class TestShockProducts:
+    """Tests for the SHOCK_PRODUCT_VALUES set."""
+
+    def test_contains_expected_products(self) -> None:
+        """SHOCK_PRODUCT_VALUES should contain the three shock chemicals."""
+        assert ChemicalProduct.CHLORE_CHOC.value in SHOCK_PRODUCT_VALUES
+        assert ChemicalProduct.BROMINE_SHOCK.value in SHOCK_PRODUCT_VALUES
+        assert ChemicalProduct.ACTIVE_OXYGEN_ACTIVATOR.value in SHOCK_PRODUCT_VALUES
+
+    def test_does_not_contain_non_shock_products(self) -> None:
+        """Non-shock products should not be in SHOCK_PRODUCT_VALUES."""
+        assert ChemicalProduct.PH_MINUS.value not in SHOCK_PRODUCT_VALUES
+        assert ChemicalProduct.FLOCCULANT.value not in SHOCK_PRODUCT_VALUES
+
+    def test_exactly_three_products(self) -> None:
+        """There should be exactly 3 shock products."""
+        assert len(SHOCK_PRODUCT_VALUES) == 3
+
+
+class TestActivationChecklistInit:
+    """Tests for ActivationChecklist initial state."""
+
+    def test_all_steps_start_incomplete(self) -> None:
+        """All steps should be False (incomplete) on creation."""
+        checklist = ActivationChecklist(started_at=NOW)
+        for step in ActivationStep:
+            assert checklist.steps[step] is False
+
+    def test_started_at_is_set(self) -> None:
+        """started_at should match the provided datetime."""
+        checklist = ActivationChecklist(started_at=NOW)
+        assert checklist.started_at == NOW
+
+    def test_all_steps_present(self) -> None:
+        """Every ActivationStep should have an entry in steps."""
+        checklist = ActivationChecklist(started_at=NOW)
+        assert set(checklist.steps.keys()) == set(ActivationStep)
+
+
+class TestActivationChecklistProperties:
+    """Tests for ActivationChecklist computed properties."""
+
+    def test_completed_steps_initially_empty(self) -> None:
+        """No steps should be completed at the start."""
+        checklist = ActivationChecklist(started_at=NOW)
+        assert checklist.completed_steps == []
+
+    def test_pending_steps_initially_all(self) -> None:
+        """All steps should be pending at the start."""
+        checklist = ActivationChecklist(started_at=NOW)
+        assert checklist.pending_steps == list(ActivationStep)
+
+    def test_current_step_initially_first(self) -> None:
+        """Current step should be the first step initially."""
+        checklist = ActivationChecklist(started_at=NOW)
+        assert checklist.current_step == ActivationStep.REMOVE_COVER
+
+    def test_is_complete_initially_false(self) -> None:
+        """Checklist should not be complete initially."""
+        checklist = ActivationChecklist(started_at=NOW)
+        assert checklist.is_complete is False
+
+    def test_progress_initially_zero(self) -> None:
+        """Progress should be 0/5 initially."""
+        checklist = ActivationChecklist(started_at=NOW)
+        assert checklist.progress == (0, 5)
+
+    def test_completed_steps_after_confirming(self) -> None:
+        """Completed steps should include confirmed steps in order."""
+        checklist = ActivationChecklist(started_at=NOW)
+        checklist.confirm(ActivationStep.REMOVE_COVER)
+        checklist.confirm(ActivationStep.SHOCK_TREATMENT)
+        assert checklist.completed_steps == [
+            ActivationStep.REMOVE_COVER,
+            ActivationStep.SHOCK_TREATMENT,
+        ]
+
+    def test_pending_steps_after_confirming(self) -> None:
+        """Pending steps should exclude confirmed steps."""
+        checklist = ActivationChecklist(started_at=NOW)
+        checklist.confirm(ActivationStep.REMOVE_COVER)
+        assert ActivationStep.REMOVE_COVER not in checklist.pending_steps
+        assert len(checklist.pending_steps) == 4
+
+    def test_current_step_skips_completed(self) -> None:
+        """Current step should be the first pending step, skipping completed ones."""
+        checklist = ActivationChecklist(started_at=NOW)
+        checklist.confirm(ActivationStep.REMOVE_COVER)
+        assert checklist.current_step == ActivationStep.RAISE_WATER_LEVEL
+
+    def test_current_step_none_when_all_complete(self) -> None:
+        """Current step should be None when all steps are done."""
+        checklist = ActivationChecklist(started_at=NOW)
+        for step in ActivationStep:
+            checklist.confirm(step)
+        assert checklist.current_step is None
+
+    def test_progress_increments(self) -> None:
+        """Progress should increment as steps are confirmed."""
+        checklist = ActivationChecklist(started_at=NOW)
+        checklist.confirm(ActivationStep.REMOVE_COVER)
+        assert checklist.progress == (1, 5)
+        checklist.confirm(ActivationStep.RAISE_WATER_LEVEL)
+        assert checklist.progress == (2, 5)
+
+    def test_is_complete_when_all_done(self) -> None:
+        """is_complete should be True when all steps are confirmed."""
+        checklist = ActivationChecklist(started_at=NOW)
+        for step in ActivationStep:
+            checklist.confirm(step)
+        assert checklist.is_complete is True
+
+
+class TestActivationChecklistConfirm:
+    """Tests for the confirm() method."""
+
+    def test_confirm_marks_step_as_true(self) -> None:
+        """Confirming a step should set it to True."""
+        checklist = ActivationChecklist(started_at=NOW)
+        checklist.confirm(ActivationStep.REMOVE_COVER)
+        assert checklist.steps[ActivationStep.REMOVE_COVER] is True
+
+    def test_confirm_out_of_order(self) -> None:
+        """Steps can be confirmed out of order."""
+        checklist = ActivationChecklist(started_at=NOW)
+        checklist.confirm(ActivationStep.SHOCK_TREATMENT)
+        assert checklist.steps[ActivationStep.SHOCK_TREATMENT] is True
+        assert checklist.steps[ActivationStep.REMOVE_COVER] is False
+
+    def test_confirm_already_confirmed_raises(self) -> None:
+        """Confirming an already-confirmed step should raise ValueError."""
+        checklist = ActivationChecklist(started_at=NOW)
+        checklist.confirm(ActivationStep.REMOVE_COVER)
+        with pytest.raises(ValueError, match="already confirmed"):
+            checklist.confirm(ActivationStep.REMOVE_COVER)
+
+    def test_confirm_all_steps_sequentially(self) -> None:
+        """All steps can be confirmed one by one."""
+        checklist = ActivationChecklist(started_at=NOW)
+        for step in ActivationStep:
+            checklist.confirm(step)
+        assert checklist.is_complete is True
+        assert checklist.progress == (5, 5)
+
+    def test_confirm_does_not_affect_other_steps(self) -> None:
+        """Confirming one step should not change the status of others."""
+        checklist = ActivationChecklist(started_at=NOW)
+        checklist.confirm(ActivationStep.CLEAN_POOL_AND_FILTER)
+        for step in ActivationStep:
+            if step == ActivationStep.CLEAN_POOL_AND_FILTER:
+                assert checklist.steps[step] is True
+            else:
+                assert checklist.steps[step] is False
+
+
+class TestActivationChecklistSerialization:
+    """Tests for Pydantic serialization/deserialization."""
+
+    def test_roundtrip_json(self) -> None:
+        """Checklist should survive JSON round-trip."""
+        checklist = ActivationChecklist(started_at=NOW)
+        checklist.confirm(ActivationStep.REMOVE_COVER)
+        checklist.confirm(ActivationStep.SHOCK_TREATMENT)
+
+        json_str = checklist.model_dump_json()
+        restored = ActivationChecklist.model_validate_json(json_str)
+
+        assert restored.started_at == checklist.started_at
+        assert restored.steps == checklist.steps
+        assert restored.completed_steps == checklist.completed_steps
+        assert restored.pending_steps == checklist.pending_steps
+
+    def test_roundtrip_dict(self) -> None:
+        """Checklist should survive dict round-trip."""
+        checklist = ActivationChecklist(started_at=NOW)
+        checklist.confirm(ActivationStep.INTENSIVE_FILTRATION)
+
+        data = checklist.model_dump()
+        restored = ActivationChecklist.model_validate(data)
+
+        assert restored.steps == checklist.steps
+        assert restored.is_complete is False
+        assert restored.progress == (1, 5)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -425,6 +425,227 @@ class TestGetEntityId:
         assert entity_id is None
 
 
+class TestActivationLifecycle:
+    """Tests for activation checklist lifecycle during mode transitions."""
+
+    async def test_activating_mode_creates_checklist(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Switching to ACTIVATING should create an activation checklist."""
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        assert coordinator.activation is None
+        coordinator.mode = PoolMode.ACTIVATING
+        assert coordinator.activation is not None
+        assert coordinator.activation.is_complete is False
+
+    async def test_leaving_activating_clears_checklist(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Switching away from ACTIVATING should clear the checklist."""
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        coordinator.mode = PoolMode.ACTIVATING
+        assert coordinator.activation is not None
+        coordinator.mode = PoolMode.ACTIVE
+        assert coordinator.activation is None
+
+    async def test_activating_to_activating_preserves_checklist(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Setting ACTIVATING when already ACTIVATING should keep existing checklist."""
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        coordinator.mode = PoolMode.ACTIVATING
+        checklist = coordinator.activation
+        assert checklist is not None
+        # Set mode to ACTIVATING again
+        coordinator.mode = PoolMode.ACTIVATING
+        # Should be the same checklist instance (not recreated)
+        assert coordinator.activation is checklist
+
+    async def test_checklist_in_pool_state(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Activation checklist should be included in PoolState."""
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        coordinator.mode = PoolMode.ACTIVATING
+        await coordinator.async_request_refresh()
+        await hass.async_block_till_done()
+        assert coordinator.data.activation is not None
+
+    async def test_pool_state_activation_none_when_not_activating(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Activation should be None in PoolState when not in ACTIVATING mode."""
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        assert coordinator.data.activation is None
+
+
+class TestConfirmActivationStep:
+    """Tests for async_confirm_activation_step."""
+
+    async def test_confirm_step(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Confirming a step should mark it as completed."""
+        from custom_components.poolman.domain.activation import ActivationStep
+
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        coordinator.mode = PoolMode.ACTIVATING
+        await coordinator.async_confirm_activation_step(ActivationStep.REMOVE_COVER)
+        await hass.async_block_till_done()
+        assert coordinator.activation is not None
+        assert ActivationStep.REMOVE_COVER in coordinator.activation.completed_steps
+
+    async def test_confirm_all_steps_switches_to_active(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Confirming all steps should switch mode to ACTIVE and clear checklist."""
+        from custom_components.poolman.domain.activation import ActivationStep
+
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        coordinator.mode = PoolMode.ACTIVATING
+        for step in ActivationStep:
+            await coordinator.async_confirm_activation_step(step)
+            await hass.async_block_till_done()
+        assert coordinator.mode == PoolMode.ACTIVE
+        assert coordinator.activation is None
+
+    async def test_confirm_fails_when_not_activating(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Confirming a step when not in ACTIVATING mode should raise ValueError."""
+        from custom_components.poolman.domain.activation import ActivationStep
+
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        assert coordinator.mode == PoolMode.ACTIVE
+        with pytest.raises(ValueError, match="not in activating mode"):
+            await coordinator.async_confirm_activation_step(ActivationStep.REMOVE_COVER)
+
+
+class TestAutoConfirmShockTreatment:
+    """Tests for auto-confirming shock_treatment via add_treatment."""
+
+    async def test_shock_product_auto_confirms(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Recording a shock product during activation should auto-confirm shock_treatment."""
+        from custom_components.poolman.domain.activation import ActivationStep
+
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        coordinator.mode = PoolMode.ACTIVATING
+        await coordinator.async_add_treatment(ChemicalProduct.CHLORE_CHOC, 200.0)
+        await hass.async_block_till_done()
+        assert coordinator.activation is not None
+        assert ActivationStep.SHOCK_TREATMENT in coordinator.activation.completed_steps
+
+    async def test_non_shock_product_does_not_auto_confirm(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Recording a non-shock product should not auto-confirm shock_treatment."""
+        from custom_components.poolman.domain.activation import ActivationStep
+
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        coordinator.mode = PoolMode.ACTIVATING
+        await coordinator.async_add_treatment(ChemicalProduct.PH_MINUS, 100.0)
+        await hass.async_block_till_done()
+        assert coordinator.activation is not None
+        assert ActivationStep.SHOCK_TREATMENT not in coordinator.activation.completed_steps
+
+    async def test_shock_outside_activating_does_nothing(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Recording a shock product outside activating mode should not create a checklist."""
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        assert coordinator.mode == PoolMode.ACTIVE
+        await coordinator.async_add_treatment(ChemicalProduct.CHLORE_CHOC, 200.0)
+        await hass.async_block_till_done()
+        assert coordinator.activation is None
+
+    async def test_shock_auto_complete_switches_to_active(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """If shock_treatment is the last step, auto-confirm should switch to ACTIVE."""
+        from custom_components.poolman.domain.activation import ActivationStep
+
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        coordinator.mode = PoolMode.ACTIVATING
+        # Confirm all steps except shock_treatment
+        for step in ActivationStep:
+            if step != ActivationStep.SHOCK_TREATMENT:
+                await coordinator.async_confirm_activation_step(step)
+                await hass.async_block_till_done()
+        assert coordinator.mode == PoolMode.ACTIVATING
+        # Auto-confirm via treatment
+        await coordinator.async_add_treatment(ChemicalProduct.CHLORE_CHOC, 200.0)
+        await hass.async_block_till_done()
+        assert coordinator.mode == PoolMode.ACTIVE
+        assert coordinator.activation is None
+
+
+class TestAutoConfirmIntensiveFiltration:
+    """Tests for auto-confirming intensive_filtration via scheduler event."""
+
+    async def test_filtration_stopped_auto_confirms(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """A filtration_stopped event during activation should auto-confirm intensive_filtration."""
+        from custom_components.poolman.const import EVENT_FILTRATION_STOPPED
+        from custom_components.poolman.domain.activation import ActivationStep
+
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        coordinator.mode = PoolMode.ACTIVATING
+        # Simulate scheduler event
+        coordinator._on_scheduler_event(EVENT_FILTRATION_STOPPED, {})
+        await hass.async_block_till_done()
+        assert coordinator.activation is not None
+        assert ActivationStep.INTENSIVE_FILTRATION in coordinator.activation.completed_steps
+
+    async def test_non_filtration_event_does_not_auto_confirm(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Other scheduler events should not auto-confirm intensive_filtration."""
+        from custom_components.poolman.domain.activation import ActivationStep
+
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        coordinator.mode = PoolMode.ACTIVATING
+        coordinator._on_scheduler_event("filtration_started", {})
+        await hass.async_block_till_done()
+        assert coordinator.activation is not None
+        assert ActivationStep.INTENSIVE_FILTRATION not in coordinator.activation.completed_steps
+
+    async def test_filtration_stopped_outside_activating_does_nothing(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """filtration_stopped outside activating mode should not create a checklist."""
+        from custom_components.poolman.const import EVENT_FILTRATION_STOPPED
+
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        assert coordinator.mode == PoolMode.ACTIVE
+        coordinator._on_scheduler_event(EVENT_FILTRATION_STOPPED, {})
+        await hass.async_block_till_done()
+        assert coordinator.activation is None
+
+    async def test_filtration_auto_complete_switches_to_active(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """If intensive_filtration is the last step, auto-confirm should switch to ACTIVE."""
+        from custom_components.poolman.const import EVENT_FILTRATION_STOPPED
+        from custom_components.poolman.domain.activation import ActivationStep
+
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        coordinator.mode = PoolMode.ACTIVATING
+        # Confirm all steps except intensive_filtration
+        for step in ActivationStep:
+            if step != ActivationStep.INTENSIVE_FILTRATION:
+                await coordinator.async_confirm_activation_step(step)
+                await hass.async_block_till_done()
+        assert coordinator.mode == PoolMode.ACTIVATING
+        # Auto-confirm via scheduler event
+        coordinator._on_scheduler_event(EVENT_FILTRATION_STOPPED, {})
+        await hass.async_block_till_done()
+        assert coordinator.mode == PoolMode.ACTIVE
+        assert coordinator.activation is None
+
+
 class TestAsyncAddTreatment:
     """Tests for async_add_treatment."""
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -13,9 +13,11 @@ from custom_components.poolman.const import (
     DOMAIN,
     SERVICE_ADD_TREATMENT,
     SERVICE_BOOST_FILTRATION,
+    SERVICE_CONFIRM_ACTIVATION_STEP,
     SERVICE_RECORD_MEASURE,
 )
 from custom_components.poolman.coordinator import PoolmanCoordinator
+from custom_components.poolman.domain.model import PoolMode
 from tests.conftest import MOCK_CONFIG_DATA, setup_mock_states
 
 
@@ -55,6 +57,17 @@ class TestSetupEntry:
         await hass.async_block_till_done()
 
         assert hass.services.has_service(DOMAIN, SERVICE_BOOST_FILTRATION)
+
+    async def test_setup_registers_confirm_activation_step_service(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Setting up should register the confirm_activation_step service."""
+        mock_config_entry.add_to_hass(hass)
+        setup_mock_states(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert hass.services.has_service(DOMAIN, SERVICE_CONFIRM_ACTIVATION_STEP)
 
     async def test_service_registration_idempotent(
         self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
@@ -122,6 +135,22 @@ class TestUnloadEntry:
         await hass.async_block_till_done()
 
         assert not hass.services.has_service(DOMAIN, SERVICE_BOOST_FILTRATION)
+
+    async def test_unload_last_entry_removes_confirm_activation_step_service(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Unloading the last entry should remove the confirm_activation_step service."""
+        mock_config_entry.add_to_hass(hass)
+        setup_mock_states(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert hass.services.has_service(DOMAIN, SERVICE_CONFIRM_ACTIVATION_STEP)
+
+        await hass.config_entries.async_unload(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert not hass.services.has_service(DOMAIN, SERVICE_CONFIRM_ACTIVATION_STEP)
 
 
 class TestMigrateEntry:
@@ -487,3 +516,94 @@ class TestBoostServiceHandler:
             blocking=True,
         )
         await hass.async_block_till_done()
+
+
+class TestConfirmActivationStepServiceHandler:
+    """Tests for the confirm_activation_step service handler."""
+
+    async def test_confirm_step_service_with_valid_device(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Service call with a valid device should confirm the activation step."""
+        from homeassistant.helpers import device_registry as dr
+
+        mock_config_entry.add_to_hass(hass)
+        setup_mock_states(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        coordinator: PoolmanCoordinator = mock_config_entry.runtime_data
+        coordinator.mode = PoolMode.ACTIVATING
+
+        device_registry = dr.async_get(hass)
+        device = device_registry.async_get_device(
+            identifiers={(DOMAIN, mock_config_entry.entry_id)}
+        )
+        assert device is not None
+
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_CONFIRM_ACTIVATION_STEP,
+            {
+                "device_id": device.id,
+                "step": "remove_cover",
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+        assert coordinator.activation is not None
+        assert "remove_cover" in [s.value for s in coordinator.activation.completed_steps]
+
+    async def test_confirm_step_service_with_unknown_device(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Service call with unknown device_id should not crash."""
+        mock_config_entry.add_to_hass(hass)
+        setup_mock_states(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_CONFIRM_ACTIVATION_STEP,
+            {
+                "device_id": "nonexistent_device_id",
+                "step": "remove_cover",
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    async def test_confirm_step_service_fails_when_not_activating(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Service call when not in activating mode should raise."""
+        import pytest
+
+        from homeassistant.helpers import device_registry as dr
+
+        mock_config_entry.add_to_hass(hass)
+        setup_mock_states(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        device_registry = dr.async_get(hass)
+        device = device_registry.async_get_device(
+            identifiers={(DOMAIN, mock_config_entry.entry_id)}
+        )
+        assert device is not None
+
+        coordinator: PoolmanCoordinator = mock_config_entry.runtime_data
+        assert coordinator.mode == PoolMode.ACTIVE
+
+        with pytest.raises(ValueError, match="not in activating mode"):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_CONFIRM_ACTIVATION_STEP,
+                {
+                    "device_id": device.id,
+                    "step": "remove_cover",
+                },
+                blocking=True,
+            )


### PR DESCRIPTION
## Summary

Implements the activation wizard (closes #8) that guides users through bringing the pool out of hibernation with a step-by-step checklist.

- Adds `ActivationChecklist` domain model with 5 ordered steps: remove cover, raise water level, clean pool/filter, shock treatment, intensive filtration
- Adds `sensor.{pool}_activation_step` entity (with `RestoreEntity` persistence) that tracks current progress
- Adds `poolman.confirm_activation_step` service for manual step confirmation
- Auto-confirms shock_treatment when a shock product is recorded via `add_treatment`
- Auto-confirms intensive_filtration when a filtration cycle completes (scheduler event)
- Automatically transitions from `ACTIVATING` to `ACTIVE` mode when all steps are complete
- Integrates activation lifecycle into both `mode` setter and `async_set_mode()` (scheduler pause/resume)

## Tests

- 27 domain model tests (`tests/domain/test_activation.py`)
- 16 coordinator tests (`tests/test_coordinator.py`) covering lifecycle, step confirmation, auto-confirm
- 5 service tests (`tests/test_init.py`) covering registration, unload, and handler
- All 634 tests pass, linters pass

## Documentation

- Updated `docs/pool-modes.md` with Activation Wizard section (wizard steps, confirmation methods, persistence)
- Updated `docs/entities.md` with activation_step sensor documentation