### PR TITLE
feat(wizard): add hibernation and activation wizard subentry flows

### DIFF
--- a/custom_components/poolman/__init__.py
+++ b/custom_components/poolman/__init__.py
@@ -11,7 +11,10 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr
 
 from .const import (
+    CONF_COMPLETED_AT,
     CONF_FILTRATION_KIND,
+    CONF_STARTED_AT,
+    CONF_STEPS,
     CONF_TREATMENT,
     DEFAULT_FILTRATION_KIND,
     DEFAULT_TREATMENT,
@@ -21,10 +24,12 @@ from .const import (
     SERVICE_BOOST_FILTRATION,
     SERVICE_CONFIRM_ACTIVATION_STEP,
     SERVICE_RECORD_MEASURE,
+    SUBENTRY_ACTIVATION,
+    SUBENTRY_HIBERNATION,
 )
 from .coordinator import PoolmanCoordinator
-from .domain.activation import ActivationStep
-from .domain.model import ChemicalProduct, MeasureParameter
+from .domain.activation import ActivationChecklist, ActivationStep
+from .domain.model import ChemicalProduct, MeasureParameter, PoolMode
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -66,6 +71,46 @@ SERVICE_CONFIRM_ACTIVATION_STEP_SCHEMA = vol.Schema(
 async def async_setup_entry(hass: HomeAssistant, entry: PoolmanConfigEntry) -> bool:
     """Set up Pool Manager from a config entry."""
     coordinator = PoolmanCoordinator(hass, entry)
+
+    # Restore HIBERNATING mode from any in-progress hibernation subentry
+    for subentry in entry.subentries.values():
+        if (
+            subentry.subentry_type == SUBENTRY_HIBERNATION
+            and subentry.data.get(CONF_COMPLETED_AT) is None
+        ):
+            await coordinator.async_set_mode(PoolMode.HIBERNATING)
+            break
+
+    # Restore ACTIVATING mode and checklist from any in-progress activation subentry
+    for subentry in entry.subentries.values():
+        if (
+            subentry.subentry_type == SUBENTRY_ACTIVATION
+            and subentry.data.get(CONF_COMPLETED_AT) is None
+        ):
+            await coordinator.async_set_mode(PoolMode.ACTIVATING)
+            # Rebuild checklist from persisted step data
+            steps_data = subentry.data.get(CONF_STEPS, {})
+            started_at_raw = subentry.data.get(CONF_STARTED_AT)
+            if started_at_raw is not None and coordinator.activation is not None:
+                from datetime import datetime
+
+                try:
+                    started_at = datetime.fromisoformat(started_at_raw)
+                except (ValueError, TypeError):
+                    break
+                steps = dict.fromkeys(ActivationStep, False)
+                for step_value, completed in steps_data.items():
+                    try:
+                        step = ActivationStep(step_value)
+                        steps[step] = bool(completed)
+                    except ValueError:
+                        continue
+                coordinator.activation = ActivationChecklist(
+                    started_at=started_at,
+                    steps=steps,
+                )
+            break
+
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))

--- a/custom_components/poolman/config_flow.py
+++ b/custom_components/poolman/config_flow.py
@@ -10,10 +10,14 @@ from homeassistant.config_entries import (
     ConfigEntry,
     ConfigFlow,
     ConfigFlowResult,
+    ConfigSubentryFlow,
     OptionsFlow,
     OptionsFlowWithConfigEntry,
+    SubentryFlowResult,
 )
+from homeassistant.core import callback
 from homeassistant.helpers.selector import (
+    BooleanSelector,
     EntitySelector,
     EntitySelectorConfig,
     NumberSelector,
@@ -23,8 +27,11 @@ from homeassistant.helpers.selector import (
     SelectSelectorConfig,
     SelectSelectorMode,
 )
+from homeassistant.util.dt import utcnow
 
 from .const import (
+    ACTIVATION_SOURCE_MODES,
+    CONF_COMPLETED_AT,
     CONF_CYA_ENTITY,
     CONF_FILTRATION_KIND,
     CONF_HARDNESS_ENTITY,
@@ -35,7 +42,10 @@ from .const import (
     CONF_PUMP_ENTITY,
     CONF_PUMP_FLOW_M3H,
     CONF_SHAPE,
+    CONF_STARTED_AT,
+    CONF_STEPS,
     CONF_TAC_ENTITY,
+    CONF_TARGET_MODE,
     CONF_TEMPERATURE_ENTITY,
     CONF_TREATMENT,
     CONF_VOLUME_M3,
@@ -46,9 +56,14 @@ from .const import (
     DEFAULT_VOLUME_M3,
     DOMAIN,
     FILTRATION_KINDS,
+    HIBERNATION_TARGET_MODES,
     SHAPES,
+    SUBENTRY_ACTIVATION,
+    SUBENTRY_HIBERNATION,
     TREATMENTS,
 )
+from .domain.activation import ActivationStep
+from .domain.model import PoolMode
 
 
 def _pool_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
@@ -203,6 +218,17 @@ class PoolmanConfigFlow(ConfigFlow, domain=DOMAIN):
         """Get the options flow handler."""
         return PoolmanOptionsFlowHandler(config_entry)
 
+    @classmethod
+    @callback
+    def async_get_supported_subentry_types(
+        cls, config_entry: ConfigEntry
+    ) -> dict[str, type[ConfigSubentryFlow]]:
+        """Return subentry types supported for this config entry."""
+        return {
+            SUBENTRY_HIBERNATION: HibernationSubentryFlowHandler,
+            SUBENTRY_ACTIVATION: ActivationSubentryFlowHandler,
+        }
+
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Handle the pool configuration step (pool basics)."""
         if user_input is not None:
@@ -284,4 +310,298 @@ class PoolmanOptionsFlowHandler(OptionsFlowWithConfigEntry):
         return self.async_show_form(
             step_id="filtration",
             data_schema=_filtration_schema(defaults=current),
+        )
+
+
+def _hibernation_type_schema() -> vol.Schema:
+    """Build the schema for hibernation type selection.
+
+    Returns:
+        A voluptuous schema for the hibernation wizard user step.
+    """
+    return vol.Schema(
+        {
+            vol.Required(CONF_TARGET_MODE): SelectSelector(
+                SelectSelectorConfig(
+                    options=HIBERNATION_TARGET_MODES,
+                    mode=SelectSelectorMode.DROPDOWN,
+                    translation_key="hibernation_target_mode",
+                )
+            ),
+        }
+    )
+
+
+def _hibernation_confirm_schema() -> vol.Schema:
+    """Build the schema for hibernation completion confirmation.
+
+    Returns:
+        A voluptuous schema for the hibernation wizard reconfigure step.
+    """
+    return vol.Schema(
+        {
+            vol.Required("confirm", default=False): BooleanSelector(),
+        }
+    )
+
+
+class HibernationSubentryFlowHandler(ConfigSubentryFlow):
+    """Handle the hibernation wizard subentry flow.
+
+    Session 1 (user): choose target winter mode, create subentry,
+    set pool to HIBERNATING.
+
+    Session 2 (reconfigure): confirm winterizing actions completed,
+    transition to target winter mode, record completion timestamp.
+    """
+
+    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> SubentryFlowResult:
+        """Handle step 1: choose the target winter mode.
+
+        Guards against starting a new hibernation when the pool is
+        already in a winter or hibernating mode, or when an
+        uncompleted hibernation subentry exists.
+
+        Args:
+            user_input: Form data submitted by the user, or None
+                to display the form.
+
+        Returns:
+            The next flow step result.
+        """
+        entry = self._get_entry()
+        coordinator = entry.runtime_data
+
+        # Guard: pool already in a winter or hibernating mode
+        if coordinator.mode in (
+            PoolMode.HIBERNATING,
+            PoolMode.WINTER_ACTIVE,
+            PoolMode.WINTER_PASSIVE,
+        ):
+            return self.async_abort(reason="already_wintering")
+
+        # Guard: an in-progress hibernation subentry already exists
+        for subentry in entry.subentries.values():
+            if (
+                subentry.subentry_type == SUBENTRY_HIBERNATION
+                and subentry.data.get(CONF_COMPLETED_AT) is None
+            ):
+                return self.async_abort(reason="hibernation_in_progress")
+
+        if user_input is not None:
+            target_mode = user_input[CONF_TARGET_MODE]
+            now = utcnow().isoformat()
+
+            # Transition to HIBERNATING mode
+            await coordinator.async_set_mode(PoolMode.HIBERNATING)
+            await coordinator.async_request_refresh()
+
+            target_label = PoolMode(target_mode).value
+            return self.async_create_entry(
+                title=f"Hibernation ({target_label})",
+                data={
+                    CONF_TARGET_MODE: target_mode,
+                    CONF_STARTED_AT: now,
+                    CONF_COMPLETED_AT: None,
+                },
+            )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=_hibernation_type_schema(),
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Handle step 2: confirm winterizing actions and complete hibernation.
+
+        Displays the list of recommended winterizing actions and asks
+        the user to confirm completion. On confirmation, transitions the
+        pool to the chosen winter mode and records the completion timestamp.
+
+        Args:
+            user_input: Form data submitted by the user, or None
+                to display the form.
+
+        Returns:
+            The next flow step result.
+        """
+        entry = self._get_entry()
+        subentry = self._get_reconfigure_subentry()
+
+        # Already completed: nothing to do
+        if subentry.data.get(CONF_COMPLETED_AT) is not None:
+            return self.async_abort(reason="already_completed")
+
+        if user_input is not None:
+            if not user_input.get("confirm"):
+                return self.async_show_form(
+                    step_id="reconfigure",
+                    data_schema=_hibernation_confirm_schema(),
+                    errors={"confirm": "must_confirm"},
+                )
+
+            target_mode = subentry.data[CONF_TARGET_MODE]
+            now = utcnow().isoformat()
+
+            # Transition to target winter mode
+            coordinator = entry.runtime_data
+            await coordinator.async_set_mode(PoolMode(target_mode))
+            await coordinator.async_request_refresh()
+
+            target_label = PoolMode(target_mode).value
+            return self.async_update_and_abort(
+                entry,
+                subentry,
+                data={
+                    **dict(subentry.data),
+                    CONF_COMPLETED_AT: now,
+                },
+                title=f"Hibernation ({target_label}) - completed",
+            )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=_hibernation_confirm_schema(),
+        )
+
+
+def _activation_confirm_schema() -> vol.Schema:
+    """Build the schema for activation completion confirmation.
+
+    Returns:
+        A voluptuous schema for the activation wizard reconfigure step.
+    """
+    return vol.Schema(
+        {
+            vol.Required("confirm", default=False): BooleanSelector(),
+        }
+    )
+
+
+class ActivationSubentryFlowHandler(ConfigSubentryFlow):
+    """Handle the activation wizard subentry flow.
+
+    Session 1 (user): start the activation process from a winter or
+    hibernating mode. Creates a subentry with all activation steps
+    set to incomplete, and transitions the pool to ACTIVATING.
+
+    Session 2 (reconfigure): view activation progress or confirm
+    completion when all steps are done.
+
+    Step confirmations happen outside this flow via the
+    ``confirm_activation_step`` service and auto-detection events.
+    """
+
+    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> SubentryFlowResult:
+        """Handle step 1: start the activation process.
+
+        Guards against starting activation from an inappropriate mode
+        or when an uncompleted activation subentry already exists.
+
+        Args:
+            user_input: Form data submitted by the user, or None
+                to display the form.
+
+        Returns:
+            The next flow step result.
+        """
+        entry = self._get_entry()
+        coordinator = entry.runtime_data
+
+        # Guard: pool must be in a winter or hibernating mode to start activation
+        if coordinator.mode.value not in ACTIVATION_SOURCE_MODES:
+            return self.async_abort(reason="not_wintering")
+
+        # Guard: an in-progress activation subentry already exists
+        for subentry in entry.subentries.values():
+            if (
+                subentry.subentry_type == SUBENTRY_ACTIVATION
+                and subentry.data.get(CONF_COMPLETED_AT) is None
+            ):
+                return self.async_abort(reason="activation_in_progress")
+
+        if user_input is not None:
+            if not user_input.get("confirm"):
+                return self.async_show_form(
+                    step_id="user",
+                    data_schema=_activation_confirm_schema(),
+                    errors={"confirm": "must_confirm"},
+                )
+
+            now = utcnow().isoformat()
+
+            # Build initial steps dict (all False)
+            steps = {step.value: False for step in ActivationStep}
+
+            # Transition to ACTIVATING mode
+            await coordinator.async_set_mode(PoolMode.ACTIVATING)
+            await coordinator.async_request_refresh()
+
+            return self.async_create_entry(
+                title="Activation",
+                data={
+                    CONF_STARTED_AT: now,
+                    CONF_COMPLETED_AT: None,
+                    CONF_STEPS: steps,
+                },
+            )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=_activation_confirm_schema(),
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Handle step 2: view activation progress.
+
+        Shows the current activation progress. If all steps are
+        already completed, the user can finalize the activation here.
+
+        Args:
+            user_input: Form data submitted by the user, or None
+                to display the form.
+
+        Returns:
+            The next flow step result.
+        """
+        entry = self._get_entry()
+        subentry = self._get_reconfigure_subentry()
+
+        # Already completed: nothing to do
+        if subentry.data.get(CONF_COMPLETED_AT) is not None:
+            return self.async_abort(reason="already_completed")
+
+        # Check if all steps are done
+        steps = subentry.data.get(CONF_STEPS, {})
+        all_done = all(steps.values()) and len(steps) > 0
+
+        if not all_done:
+            return self.async_abort(reason="activation_incomplete")
+
+        # All steps done - show confirmation to finalize
+        if user_input is not None:
+            now = utcnow().isoformat()
+
+            # Transition to ACTIVE mode
+            coordinator = entry.runtime_data
+            await coordinator.async_set_mode(PoolMode.ACTIVE)
+            await coordinator.async_request_refresh()
+
+            return self.async_update_and_abort(
+                entry,
+                subentry,
+                data={
+                    **dict(subentry.data),
+                    CONF_COMPLETED_AT: now,
+                },
+                title="Activation - completed",
+            )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=vol.Schema({}),
         )

--- a/custom_components/poolman/const.py
+++ b/custom_components/poolman/const.py
@@ -113,6 +113,26 @@ DEFAULT_FILTRATION_START_TIME_2: Final = time(16, 0)
 DEFAULT_FILTRATION_DURATION_HOURS_2: Final = 4.0
 DEFAULT_MIN_DYNAMIC_DURATION_HOURS: Final = 0.0
 
+# Wizard subentry types
+SUBENTRY_HIBERNATION: Final = "hibernation"
+SUBENTRY_ACTIVATION: Final = "activation"
+
+# Wizard subentry data keys
+CONF_TARGET_MODE: Final = "target_mode"
+CONF_STARTED_AT: Final = "started_at"
+CONF_COMPLETED_AT: Final = "completed_at"
+CONF_STEPS: Final = "steps"
+
+# Hibernation wizard
+HIBERNATION_TARGET_MODES: Final = [MODE_WINTER_PASSIVE, MODE_WINTER_ACTIVE]
+
+# Activation wizard: modes from which activation can be started
+ACTIVATION_SOURCE_MODES: Final = [
+    MODE_HIBERNATING,
+    MODE_WINTER_ACTIVE,
+    MODE_WINTER_PASSIVE,
+]
+
 # Service names
 SERVICE_ADD_TREATMENT: Final = "add_treatment"
 SERVICE_RECORD_MEASURE: Final = "record_measure"

--- a/custom_components/poolman/coordinator.py
+++ b/custom_components/poolman/coordinator.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util.dt import utcnow
 
 from .const import (
+    CONF_COMPLETED_AT,
     CONF_CYA_ENTITY,
     CONF_FILTRATION_KIND,
     CONF_HARDNESS_ENTITY,
@@ -24,6 +25,7 @@ from .const import (
     CONF_PUMP_ENTITY,
     CONF_PUMP_FLOW_M3H,
     CONF_SHAPE,
+    CONF_STEPS,
     CONF_TAC_ENTITY,
     CONF_TEMPERATURE_ENTITY,
     CONF_TREATMENT,
@@ -37,6 +39,7 @@ from .const import (
     DOMAIN,
     EVENT_FILTRATION_STOPPED,
     EVENT_POOLMAN,
+    SUBENTRY_ACTIVATION,
 )
 from .domain.activation import SHOCK_PRODUCT_VALUES, ActivationChecklist, ActivationStep
 from .domain.chemistry import compute_chemistry_report, compute_water_quality_score
@@ -263,6 +266,10 @@ class PoolmanCoordinator(DataUpdateCoordinator[PoolState]):
     async def async_confirm_activation_step(self, step: ActivationStep) -> None:
         """Confirm completion of an activation wizard step.
 
+        Updates both the in-memory activation checklist and the persisted
+        activation subentry data. When all steps are complete, transitions
+        the pool to ACTIVE mode and records the completion timestamp.
+
         Args:
             step: The activation step to mark as completed.
 
@@ -274,9 +281,14 @@ class PoolmanCoordinator(DataUpdateCoordinator[PoolState]):
             msg = "Cannot confirm activation step: pool is not in activating mode"
             raise ValueError(msg)
         self._activation.confirm(step)
+
         if self._activation.is_complete:
             self._mode = PoolMode.ACTIVE
             self._activation = None
+            self._persist_activation_completion()
+        else:
+            self._persist_activation_steps()
+
         await self.async_request_refresh()
 
     def _on_scheduler_event(self, event_type: str, _data: dict[str, object]) -> None:
@@ -298,6 +310,9 @@ class PoolmanCoordinator(DataUpdateCoordinator[PoolState]):
             if self._activation.is_complete:
                 self._mode = PoolMode.ACTIVE
                 self._activation = None
+                self._persist_activation_completion()
+            else:
+                self._persist_activation_steps()
             self.hass.async_create_task(self.async_request_refresh())
 
     def register_treatment_entity(
@@ -351,8 +366,72 @@ class PoolmanCoordinator(DataUpdateCoordinator[PoolState]):
             if self._activation.is_complete:
                 self._mode = PoolMode.ACTIVE
                 self._activation = None
+                self._persist_activation_completion()
+            else:
+                self._persist_activation_steps()
 
         await self.async_request_refresh()
+
+    def _find_activation_subentry(self) -> tuple[Any, Any] | None:
+        """Find the in-progress activation subentry.
+
+        Returns:
+            Tuple of (config_entry, subentry) or None if not found.
+        """
+        entry = self.config_entry
+        for subentry in entry.subentries.values():
+            if (
+                subentry.subentry_type == SUBENTRY_ACTIVATION
+                and subentry.data.get(CONF_COMPLETED_AT) is None
+            ):
+                return entry, subentry
+        return None
+
+    def _persist_activation_steps(self) -> None:
+        """Persist current activation step state to the subentry.
+
+        Updates the subentry data with the current checklist steps.
+        Does nothing if no in-progress activation subentry exists.
+        """
+        if self._activation is None:
+            return
+        result = self._find_activation_subentry()
+        if result is None:
+            return
+        entry, subentry = result
+        steps = {step.value: completed for step, completed in self._activation.steps.items()}
+        self.hass.config_entries.async_update_subentry(
+            entry,
+            subentry,
+            data={
+                **dict(subentry.data),
+                CONF_STEPS: steps,
+            },
+        )
+
+    def _persist_activation_completion(self) -> None:
+        """Mark the activation subentry as completed.
+
+        Sets ``completed_at`` and updates all steps to True.
+        Transitions the subentry title to indicate completion.
+        Does nothing if no in-progress activation subentry exists.
+        """
+        result = self._find_activation_subentry()
+        if result is None:
+            return
+        entry, subentry = result
+        now = utcnow().isoformat()
+        steps = {step.value: True for step in ActivationStep}
+        self.hass.config_entries.async_update_subentry(
+            entry,
+            subentry,
+            data={
+                **dict(subentry.data),
+                CONF_COMPLETED_AT: now,
+                CONF_STEPS: steps,
+            },
+            title="Activation - completed",
+        )
 
     def register_measure_entity(
         self,

--- a/custom_components/poolman/sensor.py
+++ b/custom_components/poolman/sensor.py
@@ -13,16 +13,15 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, UnitOfTemperature, UnitOfTime
+from homeassistant.const import UnitOfTemperature, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import StateType
 
 from . import PoolmanConfigEntry
 from .coordinator import PoolmanCoordinator
-from .domain.activation import ActivationChecklist, ActivationStep
-from .domain.model import ActionKind, ChemistryStatus, ParameterReport, PoolMode, PoolState
+from .domain.activation import ActivationStep
+from .domain.model import ActionKind, ChemistryStatus, ParameterReport, PoolState
 from .entity import PoolmanEntity
 
 
@@ -315,12 +314,13 @@ class PoolmanSensor(PoolmanEntity, SensorEntity):
         return None
 
 
-class PoolmanActivationStepSensor(PoolmanEntity, SensorEntity, RestoreEntity):
+class PoolmanActivationStepSensor(PoolmanEntity, SensorEntity):
     """Sensor showing the current activation wizard step.
 
     Displays the next pending activation step or None when the pool is
-    not in activating mode. Persists the activation checklist state
-    across HA restarts via RestoreEntity.
+    not in activating mode. State persistence is handled by the
+    activation subentry; the coordinator restores the checklist on
+    startup from subentry data.
     """
 
     _attr_translation_key = "activation_step"
@@ -343,7 +343,7 @@ class PoolmanActivationStepSensor(PoolmanEntity, SensorEntity, RestoreEntity):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        """Return activation progress details for persistence and display.
+        """Return activation progress details for display.
 
         Returns:
             Dictionary with completed_steps, pending_steps, progress,
@@ -359,40 +359,3 @@ class PoolmanActivationStepSensor(PoolmanEntity, SensorEntity, RestoreEntity):
             "progress": f"{completed}/{total}",
             "started_at": activation.started_at.isoformat(),
         }
-
-    async def async_added_to_hass(self) -> None:
-        """Restore activation checklist from persisted state after HA restart."""
-        await super().async_added_to_hass()
-        if self.coordinator.mode != PoolMode.ACTIVATING:
-            return
-
-        last_state = await self.async_get_last_state()
-        if last_state is None or last_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
-            return
-
-        # Restore the activation checklist from persisted attributes
-        attrs = last_state.attributes
-        completed_steps_raw = attrs.get("completed_steps", [])
-        started_at_raw = attrs.get("started_at")
-
-        if started_at_raw is None:
-            return
-
-        try:
-            started_at = datetime.fromisoformat(started_at_raw)
-        except (ValueError, TypeError):
-            return
-
-        # Rebuild the checklist with restored completion status
-        steps = dict.fromkeys(ActivationStep, False)
-        for step_value in completed_steps_raw:
-            try:
-                step = ActivationStep(step_value)
-                steps[step] = True
-            except ValueError:
-                continue
-
-        self.coordinator.activation = ActivationChecklist(
-            started_at=started_at,
-            steps=steps,
-        )

--- a/custom_components/poolman/strings.json
+++ b/custom_components/poolman/strings.json
@@ -60,6 +60,73 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
   },
+  "config_subentries": {
+    "hibernation": {
+      "entry_type": "Hibernation",
+      "initiate_flow": {
+        "user": "Start hibernation",
+        "reconfigure": "Complete hibernation"
+      },
+      "abort": {
+        "already_wintering": "The pool is already in a winter or hibernating mode. Switch back to active mode before starting a new hibernation.",
+        "hibernation_in_progress": "A hibernation process is already in progress. Complete or remove it before starting a new one.",
+        "already_completed": "This hibernation has already been completed.",
+        "reconfigure_successful": "Hibernation completed successfully."
+      },
+      "error": {
+        "must_confirm": "You must confirm that all actions have been completed."
+      },
+      "step": {
+        "user": {
+          "title": "Start hibernation",
+          "description": "Choose the type of wintering for your pool.\n\n**Passive wintering**: the pool is completely shut down. No filtration or chemistry monitoring.\n\n**Active wintering**: reduced operation. Filtration runs 4 hours daily and chemistry rules remain active.",
+          "data": {
+            "target_mode": "Wintering type"
+          },
+          "data_description": {
+            "target_mode": "The target wintering mode once the hibernation process is complete."
+          }
+        },
+        "reconfigure": {
+          "title": "Complete hibernation",
+          "description": "Before completing the hibernation, ensure you have performed the following actions:\n\n- Lower the water level below the skimmers\n- Clean the filter, skimmers, and baskets\n- Add winterizing product\n- Cover the pool with a winter cover\n\nOnce all actions are completed, confirm below to finalize the hibernation.",
+          "data": {
+            "confirm": "I have completed all winterizing actions"
+          }
+        }
+      }
+    },
+    "activation": {
+      "entry_type": "Activation",
+      "initiate_flow": {
+        "user": "Start activation",
+        "reconfigure": "View activation progress"
+      },
+      "abort": {
+        "not_wintering": "The pool must be in a winter or hibernating mode to start activation.",
+        "activation_in_progress": "An activation process is already in progress. Complete or remove it before starting a new one.",
+        "already_completed": "This activation has already been completed.",
+        "activation_incomplete": "The activation is still in progress. Confirm remaining steps using the confirm_activation_step service or wait for auto-detection.",
+        "reconfigure_successful": "Activation completed successfully."
+      },
+      "error": {
+        "must_confirm": "You must confirm to start the activation process."
+      },
+      "step": {
+        "user": {
+          "title": "Start activation",
+          "description": "Start the pool activation process to bring your pool out of winter mode.\n\nThe following steps will need to be completed:\n\n1. **Remove cover** - Remove the winter cover from the pool\n2. **Raise water level** - Restore the water level above the skimmers\n3. **Clean pool and filter** - Clean the pool, filter, skimmers, and baskets\n4. **Shock treatment** - Apply a shock treatment (auto-detected when recorded)\n5. **Intensive filtration** - Run an intensive filtration cycle (auto-detected when completed)\n\nConfirm below to start the activation process.",
+          "data": {
+            "confirm": "I want to start the activation process"
+          }
+        },
+        "reconfigure": {
+          "title": "Activation progress",
+          "description": "All activation steps have been completed. Confirm to finalize the activation and switch the pool to active mode."
+        }
+      }
+    }
+  },
   "options": {
     "step": {
       "init": {
@@ -568,6 +635,12 @@
         "clean_pool_and_filter": "Clean pool and filter",
         "shock_treatment": "Shock treatment",
         "intensive_filtration": "Intensive filtration"
+      }
+    },
+    "hibernation_target_mode": {
+      "options": {
+        "winter_passive": "Passive wintering",
+        "winter_active": "Active wintering"
       }
     }
   },

--- a/custom_components/poolman/translations/en.json
+++ b/custom_components/poolman/translations/en.json
@@ -60,6 +60,73 @@
       "already_configured": "Device is already configured"
     }
   },
+  "config_subentries": {
+    "hibernation": {
+      "entry_type": "Hibernation",
+      "initiate_flow": {
+        "user": "Start hibernation",
+        "reconfigure": "Complete hibernation"
+      },
+      "abort": {
+        "already_wintering": "The pool is already in a winter or hibernating mode. Switch back to active mode before starting a new hibernation.",
+        "hibernation_in_progress": "A hibernation process is already in progress. Complete or remove it before starting a new one.",
+        "already_completed": "This hibernation has already been completed.",
+        "reconfigure_successful": "Hibernation completed successfully."
+      },
+      "error": {
+        "must_confirm": "You must confirm that all actions have been completed."
+      },
+      "step": {
+        "user": {
+          "title": "Start hibernation",
+          "description": "Choose the type of wintering for your pool.\n\n**Passive wintering**: the pool is completely shut down. No filtration or chemistry monitoring.\n\n**Active wintering**: reduced operation. Filtration runs 4 hours daily and chemistry rules remain active.",
+          "data": {
+            "target_mode": "Wintering type"
+          },
+          "data_description": {
+            "target_mode": "The target wintering mode once the hibernation process is complete."
+          }
+        },
+        "reconfigure": {
+          "title": "Complete hibernation",
+          "description": "Before completing the hibernation, ensure you have performed the following actions:\n\n- Lower the water level below the skimmers\n- Clean the filter, skimmers, and baskets\n- Add winterizing product\n- Cover the pool with a winter cover\n\nOnce all actions are completed, confirm below to finalize the hibernation.",
+          "data": {
+            "confirm": "I have completed all winterizing actions"
+          }
+        }
+      }
+    },
+    "activation": {
+      "entry_type": "Activation",
+      "initiate_flow": {
+        "user": "Start activation",
+        "reconfigure": "View activation progress"
+      },
+      "abort": {
+        "not_wintering": "The pool must be in a winter or hibernating mode to start activation.",
+        "activation_in_progress": "An activation process is already in progress. Complete or remove it before starting a new one.",
+        "already_completed": "This activation has already been completed.",
+        "activation_incomplete": "The activation is still in progress. Confirm remaining steps using the confirm_activation_step service or wait for auto-detection.",
+        "reconfigure_successful": "Activation completed successfully."
+      },
+      "error": {
+        "must_confirm": "You must confirm to start the activation process."
+      },
+      "step": {
+        "user": {
+          "title": "Start activation",
+          "description": "Start the pool activation process to bring your pool out of winter mode.\n\nThe following steps will need to be completed:\n\n1. **Remove cover** - Remove the winter cover from the pool\n2. **Raise water level** - Restore the water level above the skimmers\n3. **Clean pool and filter** - Clean the pool, filter, skimmers, and baskets\n4. **Shock treatment** - Apply a shock treatment (auto-detected when recorded)\n5. **Intensive filtration** - Run an intensive filtration cycle (auto-detected when completed)\n\nConfirm below to start the activation process.",
+          "data": {
+            "confirm": "I want to start the activation process"
+          }
+        },
+        "reconfigure": {
+          "title": "Activation progress",
+          "description": "All activation steps have been completed. Confirm to finalize the activation and switch the pool to active mode."
+        }
+      }
+    }
+  },
   "options": {
     "step": {
       "init": {
@@ -568,6 +635,12 @@
         "clean_pool_and_filter": "Clean pool and filter",
         "shock_treatment": "Shock treatment",
         "intensive_filtration": "Intensive filtration"
+      }
+    },
+    "hibernation_target_mode": {
+      "options": {
+        "winter_passive": "Passive wintering",
+        "winter_active": "Active wintering"
       }
     }
   },

--- a/custom_components/poolman/translations/fr.json
+++ b/custom_components/poolman/translations/fr.json
@@ -60,6 +60,73 @@
       "already_configured": "L'appareil est d\u00e9j\u00e0 configur\u00e9"
     }
   },
+  "config_subentries": {
+    "hibernation": {
+      "entry_type": "Hivernage",
+      "initiate_flow": {
+        "user": "D\u00e9marrer l'hivernage",
+        "reconfigure": "Terminer l'hivernage"
+      },
+      "abort": {
+        "already_wintering": "La piscine est d\u00e9j\u00e0 en mode hivernage ou mise en hivernage. Repassez en mode actif avant de lancer un nouvel hivernage.",
+        "hibernation_in_progress": "Un processus d'hivernage est d\u00e9j\u00e0 en cours. Terminez-le ou supprimez-le avant d'en lancer un nouveau.",
+        "already_completed": "Cet hivernage est d\u00e9j\u00e0 termin\u00e9.",
+        "reconfigure_successful": "Hivernage termin\u00e9 avec succ\u00e8s."
+      },
+      "error": {
+        "must_confirm": "Vous devez confirmer que toutes les actions ont \u00e9t\u00e9 effectu\u00e9es."
+      },
+      "step": {
+        "user": {
+          "title": "D\u00e9marrer l'hivernage",
+          "description": "Choisissez le type d'hivernage pour votre piscine.\n\n**Hivernage passif** : la piscine est compl\u00e8tement arr\u00eat\u00e9e. Pas de filtration ni de surveillance de la chimie.\n\n**Hivernage actif** : fonctionnement r\u00e9duit. La filtration tourne 4 heures par jour et les r\u00e8gles de chimie restent actives.",
+          "data": {
+            "target_mode": "Type d'hivernage"
+          },
+          "data_description": {
+            "target_mode": "Le mode d'hivernage cible une fois le processus de mise en hivernage termin\u00e9."
+          }
+        },
+        "reconfigure": {
+          "title": "Terminer l'hivernage",
+          "description": "Avant de finaliser l'hivernage, assurez-vous d'avoir effectu\u00e9 les actions suivantes :\n\n- Baisser le niveau d'eau sous les skimmers\n- Nettoyer le filtre, les skimmers et les paniers\n- Ajouter le produit d'hivernage\n- Couvrir la piscine avec une b\u00e2che d'hivernage\n\nUne fois toutes les actions effectu\u00e9es, confirmez ci-dessous pour finaliser l'hivernage.",
+          "data": {
+            "confirm": "J'ai effectu\u00e9 toutes les actions d'hivernage"
+          }
+        }
+      }
+    },
+    "activation": {
+      "entry_type": "Remise en route",
+      "initiate_flow": {
+        "user": "Démarrer la remise en route",
+        "reconfigure": "Voir la progression de la remise en route"
+      },
+      "abort": {
+        "not_wintering": "La piscine doit être en mode hivernage ou mise en hivernage pour démarrer la remise en route.",
+        "activation_in_progress": "Un processus de remise en route est déjà en cours. Terminez-le ou supprimez-le avant d'en lancer un nouveau.",
+        "already_completed": "Cette remise en route est déjà terminée.",
+        "activation_incomplete": "La remise en route est toujours en cours. Confirmez les étapes restantes via le service confirm_activation_step ou attendez la détection automatique.",
+        "reconfigure_successful": "Remise en route terminée avec succès."
+      },
+      "error": {
+        "must_confirm": "Vous devez confirmer pour démarrer le processus de remise en route."
+      },
+      "step": {
+        "user": {
+          "title": "Démarrer la remise en route",
+          "description": "Démarrez le processus de remise en route pour sortir votre piscine du mode hivernage.\n\nLes étapes suivantes devront être complétées :\n\n1. **Retirer la couverture** - Retirer la bâche d'hivernage de la piscine\n2. **Remonter le niveau d'eau** - Rétablir le niveau d'eau au-dessus des skimmers\n3. **Nettoyer la piscine et le filtre** - Nettoyer la piscine, le filtre, les skimmers et les paniers\n4. **Traitement choc** - Appliquer un traitement choc (détecté automatiquement à l'enregistrement)\n5. **Filtration intensive** - Effectuer un cycle de filtration intensive (détecté automatiquement à la fin)\n\nConfirmez ci-dessous pour démarrer le processus de remise en route.",
+          "data": {
+            "confirm": "Je souhaite démarrer le processus de remise en route"
+          }
+        },
+        "reconfigure": {
+          "title": "Progression de la remise en route",
+          "description": "Toutes les étapes de remise en route ont été complétées. Confirmez pour finaliser la remise en route et passer la piscine en mode actif."
+        }
+      }
+    }
+  },
   "options": {
     "step": {
       "init": {
@@ -568,6 +635,12 @@
         "clean_pool_and_filter": "Nettoyer la piscine et le filtre",
         "shock_treatment": "Traitement choc",
         "intensive_filtration": "Filtration intensive"
+      }
+    },
+    "hibernation_target_mode": {
+      "options": {
+        "winter_passive": "Hivernage passif",
+        "winter_active": "Hivernage actif"
       }
     }
   },

--- a/docs/pool-modes.md
+++ b/docs/pool-modes.md
@@ -162,6 +162,47 @@ during this phase include:
 - Adding winterizing product
 - Covering the pool
 
+### Hibernation wizard
+
+Pool Manager provides a guided **Hibernation wizard** to walk you through
+the winterizing process in two sessions:
+
+#### Session 1 — Start hibernation
+
+1. Open the config entry and select **Start hibernation** from the
+   subentry actions.
+2. Choose your target wintering mode:
+   - **Passive wintering** — full shutdown, no filtration or monitoring.
+   - **Active wintering** — reduced operation with 4 hours daily
+     filtration and active chemistry rules.
+3. The wizard creates a hibernation subentry and immediately sets the pool
+   mode to **Hibernating**.
+
+#### Session 2 — Complete hibernation
+
+1. Once you have performed all winterizing tasks, open the hibernation
+   subentry and select **Complete hibernation** (reconfigure).
+2. Review the checklist of recommended actions and confirm completion.
+3. The pool transitions to your chosen winter mode and the subentry is
+   marked as completed with a timestamp.
+
+The completed subentry remains as a record of when the pool was winterized.
+
+!!! tip
+
+    You can also switch to **Hibernating** mode directly via the
+    `select.{pool}_mode` entity without using the wizard. The wizard
+    simply provides a structured, two-session workflow.
+
+!!! note
+
+    The wizard prevents starting a new hibernation if the pool is already
+    in Hibernating, Active Wintering, or Passive Wintering mode, or if an
+    uncompleted hibernation subentry already exists.
+
+    On Home Assistant restart, the pool mode is automatically restored to
+    **Hibernating** if an uncompleted hibernation subentry is found.
+
 ### Hibernating filtration
 
 Fixed at **4 hours** per day, regardless of water temperature. This keeps
@@ -241,10 +282,35 @@ not yet ready for swimming and typically requires:
 
 ### Activation Wizard
 
-When the pool mode is set to **Activating**, an activation wizard guides you
-through the five steps needed to bring the pool back to full operation.
-Progress is tracked via the `sensor.{pool}_activation_step` entity, which
-shows the current (next pending) step.
+Pool Manager provides a guided **Activation wizard** to walk you through
+the activation process. Like the hibernation wizard, it uses a two-session
+subentry flow.
+
+#### Session 1 — Start activation
+
+1. Open the config entry and select **Start activation** from the
+   subentry actions.
+2. The pool must be in **Hibernating**, **Active Wintering**, or
+   **Passive Wintering** mode.
+3. Review the list of required steps and confirm to start.
+4. The wizard creates an activation subentry and immediately sets the pool
+   mode to **Activating**.
+
+#### Session 2 — Complete activation
+
+Once all five steps have been confirmed (via the service or auto-detection),
+open the activation subentry and select **View activation progress**
+(reconfigure). If all steps are done, confirm to finalize.
+
+The pool transitions to **Active** mode and the subentry is marked as
+completed with a timestamp.
+
+!!! tip
+
+    Steps can also be completed automatically without using the
+    reconfigure flow. When the last step is confirmed via the service
+    or auto-detection, the pool transitions to Active mode and the
+    subentry is marked as completed automatically.
 
 #### Wizard steps
 
@@ -269,6 +335,9 @@ auto-detectable steps are confirmed automatically:
 When all five steps are confirmed, the pool mode automatically switches
 to **Active** and the activation checklist is cleared.
 
+Progress is tracked via the `sensor.{pool}_activation_step` entity, which
+shows the current (next pending) step.
+
 #### Confirming steps manually
 
 Use the `poolman.confirm_activation_step` service:
@@ -285,10 +354,21 @@ Valid step values: `remove_cover`, `raise_water_level`,
 
 #### Persistence
 
-The activation checklist persists across Home Assistant restarts. When
-HA restarts while the pool is in activating mode, already-confirmed
-steps are restored from the `activation_step` sensor's persisted state
-attributes.
+The activation state is persisted in the activation subentry data. On
+Home Assistant restart, the pool mode is automatically restored to
+**Activating** if an uncompleted activation subentry is found. The
+checklist step state is rebuilt from the persisted subentry data, so
+already-confirmed steps are preserved across restarts.
+
+!!! note
+
+    The wizard prevents starting a new activation if the pool is not
+    in a winter or hibernating mode, or if an uncompleted activation
+    subentry already exists.
+
+    You can also switch to **Activating** mode directly via the
+    `select.{pool}_mode` entity without using the wizard. The wizard
+    provides a structured workflow with persistent step tracking.
 
 ### Activating filtration
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -11,17 +11,29 @@ from homeassistant.data_entry_flow import FlowResultType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.poolman.const import (
+    CONF_COMPLETED_AT,
     CONF_FILTRATION_KIND,
     CONF_ORP_ENTITY,
     CONF_PH_ENTITY,
     CONF_POOL_NAME,
     CONF_PUMP_FLOW_M3H,
     CONF_SHAPE,
+    CONF_STARTED_AT,
+    CONF_STEPS,
+    CONF_TARGET_MODE,
     CONF_TEMPERATURE_ENTITY,
     CONF_TREATMENT,
     CONF_VOLUME_M3,
     DOMAIN,
+    MODE_WINTER_ACTIVE,
+    MODE_WINTER_PASSIVE,
+    SUBENTRY_ACTIVATION,
+    SUBENTRY_HIBERNATION,
 )
+from custom_components.poolman.coordinator import PoolmanCoordinator
+from custom_components.poolman.domain.activation import ActivationStep
+from custom_components.poolman.domain.model import PoolMode
+from tests.conftest import MOCK_CONFIG_DATA, setup_mock_states
 
 POOL_INPUT: dict[str, Any] = {
     CONF_POOL_NAME: "My Pool",
@@ -144,3 +156,794 @@ class TestOptionsFlow:
         assert result["type"] is FlowResultType.CREATE_ENTRY
         assert result["data"][CONF_TREATMENT] == "chlorine"
         assert result["data"][CONF_FILTRATION_KIND] == "sand"
+
+
+async def _setup_entry(hass: HomeAssistant, entry: MockConfigEntry) -> PoolmanCoordinator:
+    """Add a config entry to hass, set up mock states, and load the integration.
+
+    Args:
+        hass: The Home Assistant instance.
+        entry: The mock config entry to set up.
+
+    Returns:
+        The coordinator from the loaded config entry.
+    """
+    entry.add_to_hass(hass)
+    setup_mock_states(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    return entry.runtime_data
+
+
+class TestHibernationWizard:
+    """Tests for the hibernation wizard subentry flow."""
+
+    async def test_user_step_shows_form(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Starting the hibernation wizard should show the target mode form."""
+        await _setup_entry(hass, mock_config_entry)
+
+        result = await hass.config_entries.subentries.async_init(
+            (mock_config_entry.entry_id, SUBENTRY_HIBERNATION),
+            context={"source": "user"},
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "user"
+
+    async def test_user_step_creates_subentry_and_sets_hibernating(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Choosing a target mode should create a subentry and set HIBERNATING mode."""
+        coordinator = await _setup_entry(hass, mock_config_entry)
+        assert coordinator.mode == PoolMode.ACTIVE
+
+        result = await hass.config_entries.subentries.async_init(
+            (mock_config_entry.entry_id, SUBENTRY_HIBERNATION),
+            context={"source": "user"},
+        )
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"],
+            {CONF_TARGET_MODE: MODE_WINTER_PASSIVE},
+        )
+        assert result["type"] is FlowResultType.CREATE_ENTRY
+        assert coordinator.mode == PoolMode.HIBERNATING
+
+        # Verify the subentry was created with the right data
+        subentries = list(mock_config_entry.subentries.values())
+        assert len(subentries) == 1
+        subentry = subentries[0]
+        assert subentry.subentry_type == SUBENTRY_HIBERNATION
+        assert subentry.data[CONF_TARGET_MODE] == MODE_WINTER_PASSIVE
+        assert subentry.data[CONF_STARTED_AT] is not None
+        assert subentry.data[CONF_COMPLETED_AT] is None
+        assert "winter_passive" in subentry.title.lower()
+
+    async def test_user_step_target_active_wintering(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Choosing active wintering should create a subentry with winter_active target."""
+        coordinator = await _setup_entry(hass, mock_config_entry)
+
+        result = await hass.config_entries.subentries.async_init(
+            (mock_config_entry.entry_id, SUBENTRY_HIBERNATION),
+            context={"source": "user"},
+        )
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"],
+            {CONF_TARGET_MODE: MODE_WINTER_ACTIVE},
+        )
+        assert result["type"] is FlowResultType.CREATE_ENTRY
+        assert coordinator.mode == PoolMode.HIBERNATING
+
+        subentry = next(iter(mock_config_entry.subentries.values()))
+        assert subentry.data[CONF_TARGET_MODE] == MODE_WINTER_ACTIVE
+        assert "winter_active" in subentry.title.lower()
+
+    async def test_guard_already_wintering_hibernating(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Starting hibernation when already HIBERNATING should abort."""
+        coordinator = await _setup_entry(hass, mock_config_entry)
+        coordinator.mode = PoolMode.HIBERNATING
+
+        result = await hass.config_entries.subentries.async_init(
+            (mock_config_entry.entry_id, SUBENTRY_HIBERNATION),
+            context={"source": "user"},
+        )
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "already_wintering"
+
+    async def test_guard_already_wintering_winter_active(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Starting hibernation when in WINTER_ACTIVE should abort."""
+        coordinator = await _setup_entry(hass, mock_config_entry)
+        coordinator.mode = PoolMode.WINTER_ACTIVE
+
+        result = await hass.config_entries.subentries.async_init(
+            (mock_config_entry.entry_id, SUBENTRY_HIBERNATION),
+            context={"source": "user"},
+        )
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "already_wintering"
+
+    async def test_guard_already_wintering_winter_passive(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Starting hibernation when in WINTER_PASSIVE should abort."""
+        coordinator = await _setup_entry(hass, mock_config_entry)
+        coordinator.mode = PoolMode.WINTER_PASSIVE
+
+        result = await hass.config_entries.subentries.async_init(
+            (mock_config_entry.entry_id, SUBENTRY_HIBERNATION),
+            context={"source": "user"},
+        )
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "already_wintering"
+
+    async def test_guard_hibernation_in_progress(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Starting a new hibernation when one is in progress should abort.
+
+        When a subentry exists with no completed_at, the mode was restored
+        to HIBERNATING by async_setup_entry, so the already_wintering guard
+        fires first. If the user manually switched back to ACTIVE, the
+        in-progress guard catches it instead.
+        """
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=MOCK_CONFIG_DATA.copy(),
+            version=1,
+            minor_version=3,
+            subentries_data=[
+                {
+                    "data": {
+                        CONF_TARGET_MODE: MODE_WINTER_PASSIVE,
+                        CONF_STARTED_AT: "2025-11-01T10:00:00+00:00",
+                        CONF_COMPLETED_AT: None,
+                    },
+                    "subentry_type": SUBENTRY_HIBERNATION,
+                    "title": "Hibernation (winter_passive)",
+                    "unique_id": None,
+                },
+            ],
+        )
+        coordinator = await _setup_entry(hass, entry)
+        # Simulate user manually switching mode back to ACTIVE
+        # while an uncompleted subentry still exists
+        coordinator.mode = PoolMode.ACTIVE
+
+        result = await hass.config_entries.subentries.async_init(
+            (entry.entry_id, SUBENTRY_HIBERNATION),
+            context={"source": "user"},
+        )
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "hibernation_in_progress"
+
+    async def test_guard_allows_new_after_completed(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """A completed hibernation subentry should not block starting a new one."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=MOCK_CONFIG_DATA.copy(),
+            version=1,
+            minor_version=3,
+            subentries_data=[
+                {
+                    "data": {
+                        CONF_TARGET_MODE: MODE_WINTER_PASSIVE,
+                        CONF_STARTED_AT: "2025-11-01T10:00:00+00:00",
+                        CONF_COMPLETED_AT: "2025-11-15T10:00:00+00:00",
+                    },
+                    "subentry_type": SUBENTRY_HIBERNATION,
+                    "title": "Hibernation (winter_passive) - completed",
+                    "unique_id": None,
+                },
+            ],
+        )
+        await _setup_entry(hass, entry)
+
+        result = await hass.config_entries.subentries.async_init(
+            (entry.entry_id, SUBENTRY_HIBERNATION),
+            context={"source": "user"},
+        )
+        # Should show form, not abort
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "user"
+
+    async def test_reconfigure_shows_form(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Reconfiguring an in-progress hibernation should show the confirm form."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=MOCK_CONFIG_DATA.copy(),
+            version=1,
+            minor_version=3,
+            subentries_data=[
+                {
+                    "data": {
+                        CONF_TARGET_MODE: MODE_WINTER_PASSIVE,
+                        CONF_STARTED_AT: "2025-11-01T10:00:00+00:00",
+                        CONF_COMPLETED_AT: None,
+                    },
+                    "subentry_type": SUBENTRY_HIBERNATION,
+                    "title": "Hibernation (winter_passive)",
+                    "unique_id": None,
+                    "subentry_id": "test_sub_id",
+                },
+            ],
+        )
+        await _setup_entry(hass, entry)
+
+        result = await hass.config_entries.subentries.async_init(
+            (entry.entry_id, SUBENTRY_HIBERNATION),
+            context={"source": "reconfigure", "subentry_id": "test_sub_id"},
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "reconfigure"
+
+    async def test_reconfigure_confirm_completes_hibernation(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Confirming the reconfigure step should transition to the target mode."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=MOCK_CONFIG_DATA.copy(),
+            version=1,
+            minor_version=3,
+            subentries_data=[
+                {
+                    "data": {
+                        CONF_TARGET_MODE: MODE_WINTER_PASSIVE,
+                        CONF_STARTED_AT: "2025-11-01T10:00:00+00:00",
+                        CONF_COMPLETED_AT: None,
+                    },
+                    "subentry_type": SUBENTRY_HIBERNATION,
+                    "title": "Hibernation (winter_passive)",
+                    "unique_id": None,
+                    "subentry_id": "test_sub_id",
+                },
+            ],
+        )
+        coordinator = await _setup_entry(hass, entry)
+        assert coordinator.mode == PoolMode.HIBERNATING  # restored from subentry
+
+        result = await hass.config_entries.subentries.async_init(
+            (entry.entry_id, SUBENTRY_HIBERNATION),
+            context={"source": "reconfigure", "subentry_id": "test_sub_id"},
+        )
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"],
+            {"confirm": True},
+        )
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "reconfigure_successful"
+        assert coordinator.mode == PoolMode.WINTER_PASSIVE
+
+        # Verify subentry was updated with completed_at
+        subentry = entry.subentries["test_sub_id"]
+        assert subentry.data[CONF_COMPLETED_AT] is not None
+        assert "completed" in subentry.title.lower()
+
+    async def test_reconfigure_confirm_active_wintering(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Completing hibernation targeting active wintering should transition correctly."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=MOCK_CONFIG_DATA.copy(),
+            version=1,
+            minor_version=3,
+            subentries_data=[
+                {
+                    "data": {
+                        CONF_TARGET_MODE: MODE_WINTER_ACTIVE,
+                        CONF_STARTED_AT: "2025-11-01T10:00:00+00:00",
+                        CONF_COMPLETED_AT: None,
+                    },
+                    "subentry_type": SUBENTRY_HIBERNATION,
+                    "title": "Hibernation (winter_active)",
+                    "unique_id": None,
+                    "subentry_id": "test_sub_id",
+                },
+            ],
+        )
+        coordinator = await _setup_entry(hass, entry)
+
+        result = await hass.config_entries.subentries.async_init(
+            (entry.entry_id, SUBENTRY_HIBERNATION),
+            context={"source": "reconfigure", "subentry_id": "test_sub_id"},
+        )
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"],
+            {"confirm": True},
+        )
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "reconfigure_successful"
+        assert coordinator.mode == PoolMode.WINTER_ACTIVE
+
+    async def test_reconfigure_without_confirm_shows_error(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Submitting the reconfigure form without confirming should show an error."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=MOCK_CONFIG_DATA.copy(),
+            version=1,
+            minor_version=3,
+            subentries_data=[
+                {
+                    "data": {
+                        CONF_TARGET_MODE: MODE_WINTER_PASSIVE,
+                        CONF_STARTED_AT: "2025-11-01T10:00:00+00:00",
+                        CONF_COMPLETED_AT: None,
+                    },
+                    "subentry_type": SUBENTRY_HIBERNATION,
+                    "title": "Hibernation (winter_passive)",
+                    "unique_id": None,
+                    "subentry_id": "test_sub_id",
+                },
+            ],
+        )
+        await _setup_entry(hass, entry)
+
+        result = await hass.config_entries.subentries.async_init(
+            (entry.entry_id, SUBENTRY_HIBERNATION),
+            context={"source": "reconfigure", "subentry_id": "test_sub_id"},
+        )
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"],
+            {"confirm": False},
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "reconfigure"
+        assert result["errors"] == {"confirm": "must_confirm"}
+
+    async def test_reconfigure_already_completed_aborts(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Reconfiguring an already completed hibernation should abort."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=MOCK_CONFIG_DATA.copy(),
+            version=1,
+            minor_version=3,
+            subentries_data=[
+                {
+                    "data": {
+                        CONF_TARGET_MODE: MODE_WINTER_PASSIVE,
+                        CONF_STARTED_AT: "2025-11-01T10:00:00+00:00",
+                        CONF_COMPLETED_AT: "2025-11-15T10:00:00+00:00",
+                    },
+                    "subentry_type": SUBENTRY_HIBERNATION,
+                    "title": "Hibernation (winter_passive) - completed",
+                    "unique_id": None,
+                    "subentry_id": "test_sub_id",
+                },
+            ],
+        )
+        await _setup_entry(hass, entry)
+
+        result = await hass.config_entries.subentries.async_init(
+            (entry.entry_id, SUBENTRY_HIBERNATION),
+            context={"source": "reconfigure", "subentry_id": "test_sub_id"},
+        )
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "already_completed"
+
+
+def _all_steps_false() -> dict[str, bool]:
+    """Return activation steps dict with all steps set to False."""
+    return {step.value: False for step in ActivationStep}
+
+
+def _all_steps_true() -> dict[str, bool]:
+    """Return activation steps dict with all steps set to True."""
+    return {step.value: True for step in ActivationStep}
+
+
+class TestActivationWizard:
+    """Tests for the activation wizard subentry flow."""
+
+    async def test_user_step_shows_form(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Starting the activation wizard from a winter mode should show confirm form."""
+        coordinator = await _setup_entry(hass, mock_config_entry)
+        coordinator.mode = PoolMode.WINTER_PASSIVE
+
+        result = await hass.config_entries.subentries.async_init(
+            (mock_config_entry.entry_id, SUBENTRY_ACTIVATION),
+            context={"source": "user"},
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "user"
+
+    async def test_user_step_creates_subentry_and_sets_activating(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Confirming the user step should create a subentry and set ACTIVATING mode."""
+        coordinator = await _setup_entry(hass, mock_config_entry)
+        coordinator.mode = PoolMode.WINTER_PASSIVE
+        assert coordinator.activation is None
+
+        result = await hass.config_entries.subentries.async_init(
+            (mock_config_entry.entry_id, SUBENTRY_ACTIVATION),
+            context={"source": "user"},
+        )
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"],
+            {"confirm": True},
+        )
+        assert result["type"] is FlowResultType.CREATE_ENTRY
+        assert coordinator.mode == PoolMode.ACTIVATING
+
+        # Verify the subentry was created with correct data
+        subentries = list(mock_config_entry.subentries.values())
+        assert len(subentries) == 1
+        subentry = subentries[0]
+        assert subentry.subentry_type == SUBENTRY_ACTIVATION
+        assert subentry.data[CONF_STARTED_AT] is not None
+        assert subentry.data[CONF_COMPLETED_AT] is None
+        assert subentry.data[CONF_STEPS] == _all_steps_false()
+        assert subentry.title == "Activation"
+
+    async def test_user_step_from_hibernating(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Starting activation from HIBERNATING mode should succeed."""
+        coordinator = await _setup_entry(hass, mock_config_entry)
+        coordinator.mode = PoolMode.HIBERNATING
+
+        result = await hass.config_entries.subentries.async_init(
+            (mock_config_entry.entry_id, SUBENTRY_ACTIVATION),
+            context={"source": "user"},
+        )
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"],
+            {"confirm": True},
+        )
+        assert result["type"] is FlowResultType.CREATE_ENTRY
+        assert coordinator.mode == PoolMode.ACTIVATING
+
+    async def test_user_step_from_winter_active(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Starting activation from WINTER_ACTIVE mode should succeed."""
+        coordinator = await _setup_entry(hass, mock_config_entry)
+        coordinator.mode = PoolMode.WINTER_ACTIVE
+
+        result = await hass.config_entries.subentries.async_init(
+            (mock_config_entry.entry_id, SUBENTRY_ACTIVATION),
+            context={"source": "user"},
+        )
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"],
+            {"confirm": True},
+        )
+        assert result["type"] is FlowResultType.CREATE_ENTRY
+        assert coordinator.mode == PoolMode.ACTIVATING
+
+    async def test_user_step_without_confirm_shows_error(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Submitting the user form without confirming should show an error."""
+        coordinator = await _setup_entry(hass, mock_config_entry)
+        coordinator.mode = PoolMode.WINTER_PASSIVE
+
+        result = await hass.config_entries.subentries.async_init(
+            (mock_config_entry.entry_id, SUBENTRY_ACTIVATION),
+            context={"source": "user"},
+        )
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"],
+            {"confirm": False},
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "user"
+        assert result["errors"] == {"confirm": "must_confirm"}
+
+    async def test_guard_not_wintering_active(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Starting activation when in ACTIVE mode should abort."""
+        await _setup_entry(hass, mock_config_entry)
+        # Default mode is ACTIVE
+
+        result = await hass.config_entries.subentries.async_init(
+            (mock_config_entry.entry_id, SUBENTRY_ACTIVATION),
+            context={"source": "user"},
+        )
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "not_wintering"
+
+    async def test_guard_not_wintering_activating(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Starting activation when already in ACTIVATING mode should abort."""
+        coordinator = await _setup_entry(hass, mock_config_entry)
+        coordinator.mode = PoolMode.ACTIVATING
+
+        result = await hass.config_entries.subentries.async_init(
+            (mock_config_entry.entry_id, SUBENTRY_ACTIVATION),
+            context={"source": "user"},
+        )
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "not_wintering"
+
+    async def test_guard_activation_in_progress(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Starting a new activation when one is in progress should abort.
+
+        When the user manually switches back to a winter mode while an
+        uncompleted activation subentry exists, the in-progress guard
+        catches it.
+        """
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=MOCK_CONFIG_DATA.copy(),
+            version=1,
+            minor_version=3,
+            subentries_data=[
+                {
+                    "data": {
+                        CONF_STARTED_AT: "2025-04-01T10:00:00+00:00",
+                        CONF_COMPLETED_AT: None,
+                        CONF_STEPS: _all_steps_false(),
+                    },
+                    "subentry_type": SUBENTRY_ACTIVATION,
+                    "title": "Activation",
+                    "unique_id": None,
+                },
+            ],
+        )
+        coordinator = await _setup_entry(hass, entry)
+        # Simulate user manually switching back to winter mode
+        coordinator.mode = PoolMode.WINTER_PASSIVE
+
+        result = await hass.config_entries.subentries.async_init(
+            (entry.entry_id, SUBENTRY_ACTIVATION),
+            context={"source": "user"},
+        )
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "activation_in_progress"
+
+    async def test_guard_allows_new_after_completed(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """A completed activation subentry should not block starting a new one."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=MOCK_CONFIG_DATA.copy(),
+            version=1,
+            minor_version=3,
+            subentries_data=[
+                {
+                    "data": {
+                        CONF_STARTED_AT: "2025-04-01T10:00:00+00:00",
+                        CONF_COMPLETED_AT: "2025-04-05T10:00:00+00:00",
+                        CONF_STEPS: _all_steps_true(),
+                    },
+                    "subentry_type": SUBENTRY_ACTIVATION,
+                    "title": "Activation - completed",
+                    "unique_id": None,
+                },
+            ],
+        )
+        coordinator = await _setup_entry(hass, entry)
+        coordinator.mode = PoolMode.WINTER_PASSIVE
+
+        result = await hass.config_entries.subentries.async_init(
+            (entry.entry_id, SUBENTRY_ACTIVATION),
+            context={"source": "user"},
+        )
+        # Should show form, not abort
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "user"
+
+    async def test_reconfigure_incomplete_aborts(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Reconfiguring an incomplete activation should abort with activation_incomplete."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=MOCK_CONFIG_DATA.copy(),
+            version=1,
+            minor_version=3,
+            subentries_data=[
+                {
+                    "data": {
+                        CONF_STARTED_AT: "2025-04-01T10:00:00+00:00",
+                        CONF_COMPLETED_AT: None,
+                        CONF_STEPS: _all_steps_false(),
+                    },
+                    "subentry_type": SUBENTRY_ACTIVATION,
+                    "title": "Activation",
+                    "unique_id": None,
+                    "subentry_id": "test_act_id",
+                },
+            ],
+        )
+        await _setup_entry(hass, entry)
+
+        result = await hass.config_entries.subentries.async_init(
+            (entry.entry_id, SUBENTRY_ACTIVATION),
+            context={"source": "reconfigure", "subentry_id": "test_act_id"},
+        )
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "activation_incomplete"
+
+    async def test_reconfigure_partially_complete_aborts(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Reconfiguring a partially complete activation should abort."""
+        steps = _all_steps_false()
+        steps["remove_cover"] = True
+        steps["raise_water_level"] = True
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=MOCK_CONFIG_DATA.copy(),
+            version=1,
+            minor_version=3,
+            subentries_data=[
+                {
+                    "data": {
+                        CONF_STARTED_AT: "2025-04-01T10:00:00+00:00",
+                        CONF_COMPLETED_AT: None,
+                        CONF_STEPS: steps,
+                    },
+                    "subentry_type": SUBENTRY_ACTIVATION,
+                    "title": "Activation",
+                    "unique_id": None,
+                    "subentry_id": "test_act_id",
+                },
+            ],
+        )
+        await _setup_entry(hass, entry)
+
+        result = await hass.config_entries.subentries.async_init(
+            (entry.entry_id, SUBENTRY_ACTIVATION),
+            context={"source": "reconfigure", "subentry_id": "test_act_id"},
+        )
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "activation_incomplete"
+
+    async def test_reconfigure_all_done_shows_form(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Reconfiguring a fully complete activation should show the finalization form."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=MOCK_CONFIG_DATA.copy(),
+            version=1,
+            minor_version=3,
+            subentries_data=[
+                {
+                    "data": {
+                        CONF_STARTED_AT: "2025-04-01T10:00:00+00:00",
+                        CONF_COMPLETED_AT: None,
+                        CONF_STEPS: _all_steps_true(),
+                    },
+                    "subentry_type": SUBENTRY_ACTIVATION,
+                    "title": "Activation",
+                    "unique_id": None,
+                    "subentry_id": "test_act_id",
+                },
+            ],
+        )
+        await _setup_entry(hass, entry)
+
+        result = await hass.config_entries.subentries.async_init(
+            (entry.entry_id, SUBENTRY_ACTIVATION),
+            context={"source": "reconfigure", "subentry_id": "test_act_id"},
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "reconfigure"
+
+    async def test_reconfigure_confirm_completes_activation(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Confirming reconfigure with all steps done should complete the activation."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=MOCK_CONFIG_DATA.copy(),
+            version=1,
+            minor_version=3,
+            subentries_data=[
+                {
+                    "data": {
+                        CONF_STARTED_AT: "2025-04-01T10:00:00+00:00",
+                        CONF_COMPLETED_AT: None,
+                        CONF_STEPS: _all_steps_true(),
+                    },
+                    "subentry_type": SUBENTRY_ACTIVATION,
+                    "title": "Activation",
+                    "unique_id": None,
+                    "subentry_id": "test_act_id",
+                },
+            ],
+        )
+        coordinator = await _setup_entry(hass, entry)
+
+        result = await hass.config_entries.subentries.async_init(
+            (entry.entry_id, SUBENTRY_ACTIVATION),
+            context={"source": "reconfigure", "subentry_id": "test_act_id"},
+        )
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"],
+            {},
+        )
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "reconfigure_successful"
+        assert coordinator.mode == PoolMode.ACTIVE
+
+        # Verify subentry was updated with completed_at
+        subentry = entry.subentries["test_act_id"]
+        assert subentry.data[CONF_COMPLETED_AT] is not None
+        assert "completed" in subentry.title.lower()
+
+    async def test_reconfigure_already_completed_aborts(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Reconfiguring an already completed activation should abort."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=MOCK_CONFIG_DATA.copy(),
+            version=1,
+            minor_version=3,
+            subentries_data=[
+                {
+                    "data": {
+                        CONF_STARTED_AT: "2025-04-01T10:00:00+00:00",
+                        CONF_COMPLETED_AT: "2025-04-05T10:00:00+00:00",
+                        CONF_STEPS: _all_steps_true(),
+                    },
+                    "subentry_type": SUBENTRY_ACTIVATION,
+                    "title": "Activation - completed",
+                    "unique_id": None,
+                    "subentry_id": "test_act_id",
+                },
+            ],
+        )
+        await _setup_entry(hass, entry)
+
+        result = await hass.config_entries.subentries.async_init(
+            (entry.entry_id, SUBENTRY_ACTIVATION),
+            context={"source": "reconfigure", "subentry_id": "test_act_id"},
+        )
+        assert result["type"] is FlowResultType.ABORT
+        assert result["reason"] == "already_completed"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -8,15 +8,20 @@ from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.poolman.const import (
+    CONF_COMPLETED_AT,
     CONF_CYA_ENTITY,
     CONF_HARDNESS_ENTITY,
     CONF_OUTDOOR_TEMPERATURE_ENTITY,
+    CONF_STARTED_AT,
+    CONF_STEPS,
     CONF_TAC_ENTITY,
     CONF_WEATHER_ENTITY,
     DOMAIN,
     EVENT_POOLMAN,
+    SUBENTRY_ACTIVATION,
 )
 from custom_components.poolman.coordinator import PoolmanCoordinator
+from custom_components.poolman.domain.activation import ActivationStep
 from custom_components.poolman.domain.model import ChemicalProduct, MeasureParameter, PoolMode
 from tests.conftest import MOCK_CONFIG_DATA, setup_mock_states
 
@@ -818,3 +823,254 @@ class TestAsyncSetMode:
         # Second call should not error
         await coordinator.async_set_mode(PoolMode.WINTER_PASSIVE)
         assert coordinator.scheduler.paused is True
+
+
+class TestActivationSubentryPersistence:
+    """Tests for activation step persistence to subentry data."""
+
+    async def test_confirm_step_persists_to_subentry(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Confirming a step should update the subentry data."""
+        steps = {step.value: False for step in ActivationStep}
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=MOCK_CONFIG_DATA.copy(),
+            version=1,
+            minor_version=3,
+            subentries_data=[
+                {
+                    "data": {
+                        CONF_STARTED_AT: "2025-04-01T10:00:00+00:00",
+                        CONF_COMPLETED_AT: None,
+                        CONF_STEPS: steps,
+                    },
+                    "subentry_type": SUBENTRY_ACTIVATION,
+                    "title": "Activation",
+                    "unique_id": None,
+                    "subentry_id": "act_sub_id",
+                },
+            ],
+        )
+        coordinator = await _setup_coordinator(hass, entry)
+        assert coordinator.mode == PoolMode.ACTIVATING
+
+        await coordinator.async_confirm_activation_step(ActivationStep.REMOVE_COVER)
+        await hass.async_block_till_done()
+
+        subentry = entry.subentries["act_sub_id"]
+        assert subentry.data[CONF_STEPS]["remove_cover"] is True
+        assert subentry.data[CONF_COMPLETED_AT] is None
+
+    async def test_confirm_all_steps_persists_completion(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Confirming all steps should set completed_at and update title."""
+        steps = {step.value: False for step in ActivationStep}
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=MOCK_CONFIG_DATA.copy(),
+            version=1,
+            minor_version=3,
+            subentries_data=[
+                {
+                    "data": {
+                        CONF_STARTED_AT: "2025-04-01T10:00:00+00:00",
+                        CONF_COMPLETED_AT: None,
+                        CONF_STEPS: steps,
+                    },
+                    "subentry_type": SUBENTRY_ACTIVATION,
+                    "title": "Activation",
+                    "unique_id": None,
+                    "subentry_id": "act_sub_id",
+                },
+            ],
+        )
+        coordinator = await _setup_coordinator(hass, entry)
+
+        for step in ActivationStep:
+            await coordinator.async_confirm_activation_step(step)
+            await hass.async_block_till_done()
+
+        subentry = entry.subentries["act_sub_id"]
+        assert subentry.data[CONF_COMPLETED_AT] is not None
+        assert all(subentry.data[CONF_STEPS].values())
+        assert "completed" in subentry.title.lower()
+        assert coordinator.mode == PoolMode.ACTIVE
+
+    async def test_shock_auto_confirm_persists_to_subentry(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Auto-confirming shock_treatment via add_treatment should persist to subentry."""
+        steps = {step.value: False for step in ActivationStep}
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=MOCK_CONFIG_DATA.copy(),
+            version=1,
+            minor_version=3,
+            subentries_data=[
+                {
+                    "data": {
+                        CONF_STARTED_AT: "2025-04-01T10:00:00+00:00",
+                        CONF_COMPLETED_AT: None,
+                        CONF_STEPS: steps,
+                    },
+                    "subentry_type": SUBENTRY_ACTIVATION,
+                    "title": "Activation",
+                    "unique_id": None,
+                    "subentry_id": "act_sub_id",
+                },
+            ],
+        )
+        coordinator = await _setup_coordinator(hass, entry)
+        assert coordinator.mode == PoolMode.ACTIVATING
+
+        await coordinator.async_add_treatment(ChemicalProduct.CHLORE_CHOC, 200.0)
+        await hass.async_block_till_done()
+
+        subentry = entry.subentries["act_sub_id"]
+        assert subentry.data[CONF_STEPS]["shock_treatment"] is True
+
+    async def test_filtration_auto_confirm_persists_to_subentry(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Auto-confirming intensive_filtration via scheduler should persist to subentry."""
+        from custom_components.poolman.const import EVENT_FILTRATION_STOPPED
+
+        steps = {step.value: False for step in ActivationStep}
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=MOCK_CONFIG_DATA.copy(),
+            version=1,
+            minor_version=3,
+            subentries_data=[
+                {
+                    "data": {
+                        CONF_STARTED_AT: "2025-04-01T10:00:00+00:00",
+                        CONF_COMPLETED_AT: None,
+                        CONF_STEPS: steps,
+                    },
+                    "subentry_type": SUBENTRY_ACTIVATION,
+                    "title": "Activation",
+                    "unique_id": None,
+                    "subentry_id": "act_sub_id",
+                },
+            ],
+        )
+        coordinator = await _setup_coordinator(hass, entry)
+        assert coordinator.mode == PoolMode.ACTIVATING
+
+        coordinator._on_scheduler_event(EVENT_FILTRATION_STOPPED, {})
+        await hass.async_block_till_done()
+
+        subentry = entry.subentries["act_sub_id"]
+        assert subentry.data[CONF_STEPS]["intensive_filtration"] is True
+
+    async def test_no_subentry_does_not_crash(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Confirming a step without an activation subentry should not crash."""
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        coordinator.mode = PoolMode.ACTIVATING
+
+        # No subentry exists, but in-memory checklist does
+        await coordinator.async_confirm_activation_step(ActivationStep.REMOVE_COVER)
+        await hass.async_block_till_done()
+
+        # Should not crash; in-memory state is updated
+        assert coordinator.activation is not None
+        assert ActivationStep.REMOVE_COVER in coordinator.activation.completed_steps
+
+    async def test_shock_auto_complete_persists_completion(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """When shock is the last step, auto-confirm should persist completion to subentry."""
+        # Pre-complete all steps except shock_treatment
+        steps = {step.value: True for step in ActivationStep}
+        steps["shock_treatment"] = False
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=MOCK_CONFIG_DATA.copy(),
+            version=1,
+            minor_version=3,
+            subentries_data=[
+                {
+                    "data": {
+                        CONF_STARTED_AT: "2025-04-01T10:00:00+00:00",
+                        CONF_COMPLETED_AT: None,
+                        CONF_STEPS: steps,
+                    },
+                    "subentry_type": SUBENTRY_ACTIVATION,
+                    "title": "Activation",
+                    "unique_id": None,
+                    "subentry_id": "act_sub_id",
+                },
+            ],
+        )
+        coordinator = await _setup_coordinator(hass, entry)
+        assert coordinator.mode == PoolMode.ACTIVATING
+
+        # Confirm all steps except shock via confirm_activation_step
+        # (shock will be the only pending step since we restored from subentry)
+        await coordinator.async_add_treatment(ChemicalProduct.CHLORE_CHOC, 200.0)
+        await hass.async_block_till_done()
+
+        subentry = entry.subentries["act_sub_id"]
+        assert subentry.data[CONF_COMPLETED_AT] is not None
+        assert all(subentry.data[CONF_STEPS].values())
+        assert "completed" in subentry.title.lower()
+        assert coordinator.mode == PoolMode.ACTIVE
+
+    async def test_filtration_auto_complete_persists_completion(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """When filtration is the last step, auto-confirm should persist completion."""
+        from custom_components.poolman.const import EVENT_FILTRATION_STOPPED
+
+        # Pre-complete all steps except intensive_filtration
+        steps = {step.value: True for step in ActivationStep}
+        steps["intensive_filtration"] = False
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=MOCK_CONFIG_DATA.copy(),
+            version=1,
+            minor_version=3,
+            subentries_data=[
+                {
+                    "data": {
+                        CONF_STARTED_AT: "2025-04-01T10:00:00+00:00",
+                        CONF_COMPLETED_AT: None,
+                        CONF_STEPS: steps,
+                    },
+                    "subentry_type": SUBENTRY_ACTIVATION,
+                    "title": "Activation",
+                    "unique_id": None,
+                    "subentry_id": "act_sub_id",
+                },
+            ],
+        )
+        coordinator = await _setup_coordinator(hass, entry)
+        assert coordinator.mode == PoolMode.ACTIVATING
+
+        coordinator._on_scheduler_event(EVENT_FILTRATION_STOPPED, {})
+        await hass.async_block_till_done()
+
+        subentry = entry.subentries["act_sub_id"]
+        assert subentry.data[CONF_COMPLETED_AT] is not None
+        assert all(subentry.data[CONF_STEPS].values())
+        assert "completed" in subentry.title.lower()
+        assert coordinator.mode == PoolMode.ACTIVE

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -6,17 +6,25 @@ from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.poolman.const import (
+    CONF_COMPLETED_AT,
     CONF_FILTRATION_KIND,
+    CONF_STARTED_AT,
+    CONF_STEPS,
+    CONF_TARGET_MODE,
     CONF_TREATMENT,
     DEFAULT_FILTRATION_KIND,
     DEFAULT_TREATMENT,
     DOMAIN,
+    MODE_WINTER_PASSIVE,
     SERVICE_ADD_TREATMENT,
     SERVICE_BOOST_FILTRATION,
     SERVICE_CONFIRM_ACTIVATION_STEP,
     SERVICE_RECORD_MEASURE,
+    SUBENTRY_ACTIVATION,
+    SUBENTRY_HIBERNATION,
 )
 from custom_components.poolman.coordinator import PoolmanCoordinator
+from custom_components.poolman.domain.activation import ActivationStep
 from custom_components.poolman.domain.model import PoolMode
 from tests.conftest import MOCK_CONFIG_DATA, setup_mock_states
 
@@ -85,6 +93,177 @@ class TestSetupEntry:
         # Call again -- should be a no-op, not raise
         _async_register_services(hass)
         assert hass.services.has_service(DOMAIN, SERVICE_ADD_TREATMENT)
+
+    async def test_setup_restores_hibernating_from_subentry(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Setting up with an in-progress hibernation subentry should restore HIBERNATING mode."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=MOCK_CONFIG_DATA.copy(),
+            version=1,
+            minor_version=3,
+            subentries_data=[
+                {
+                    "data": {
+                        CONF_TARGET_MODE: MODE_WINTER_PASSIVE,
+                        CONF_STARTED_AT: "2025-11-01T10:00:00+00:00",
+                        CONF_COMPLETED_AT: None,
+                    },
+                    "subentry_type": SUBENTRY_HIBERNATION,
+                    "title": "Hibernation (winter_passive)",
+                    "unique_id": None,
+                },
+            ],
+        )
+        entry.add_to_hass(hass)
+        setup_mock_states(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        coordinator: PoolmanCoordinator = entry.runtime_data
+        assert coordinator.mode == PoolMode.HIBERNATING
+
+    async def test_setup_does_not_restore_from_completed_subentry(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """A completed hibernation subentry should not restore HIBERNATING mode."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=MOCK_CONFIG_DATA.copy(),
+            version=1,
+            minor_version=3,
+            subentries_data=[
+                {
+                    "data": {
+                        CONF_TARGET_MODE: MODE_WINTER_PASSIVE,
+                        CONF_STARTED_AT: "2025-11-01T10:00:00+00:00",
+                        CONF_COMPLETED_AT: "2025-11-15T10:00:00+00:00",
+                    },
+                    "subentry_type": SUBENTRY_HIBERNATION,
+                    "title": "Hibernation (winter_passive) - completed",
+                    "unique_id": None,
+                },
+            ],
+        )
+        entry.add_to_hass(hass)
+        setup_mock_states(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        coordinator: PoolmanCoordinator = entry.runtime_data
+        assert coordinator.mode == PoolMode.ACTIVE
+
+    async def test_setup_restores_activating_from_subentry(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Setting up with an in-progress activation subentry should restore ACTIVATING mode."""
+        steps = {step.value: False for step in ActivationStep}
+        steps["remove_cover"] = True  # One step already completed
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=MOCK_CONFIG_DATA.copy(),
+            version=1,
+            minor_version=3,
+            subentries_data=[
+                {
+                    "data": {
+                        CONF_STARTED_AT: "2025-04-01T10:00:00+00:00",
+                        CONF_COMPLETED_AT: None,
+                        CONF_STEPS: steps,
+                    },
+                    "subentry_type": SUBENTRY_ACTIVATION,
+                    "title": "Activation",
+                    "unique_id": None,
+                },
+            ],
+        )
+        entry.add_to_hass(hass)
+        setup_mock_states(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        coordinator: PoolmanCoordinator = entry.runtime_data
+        assert coordinator.mode == PoolMode.ACTIVATING
+        assert coordinator.activation is not None
+        assert ActivationStep.REMOVE_COVER in coordinator.activation.completed_steps
+        assert ActivationStep.RAISE_WATER_LEVEL in coordinator.activation.pending_steps
+
+    async def test_setup_restores_activation_all_steps_false(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """An in-progress activation with no completed steps should restore correctly."""
+        steps = {step.value: False for step in ActivationStep}
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=MOCK_CONFIG_DATA.copy(),
+            version=1,
+            minor_version=3,
+            subentries_data=[
+                {
+                    "data": {
+                        CONF_STARTED_AT: "2025-04-01T10:00:00+00:00",
+                        CONF_COMPLETED_AT: None,
+                        CONF_STEPS: steps,
+                    },
+                    "subentry_type": SUBENTRY_ACTIVATION,
+                    "title": "Activation",
+                    "unique_id": None,
+                },
+            ],
+        )
+        entry.add_to_hass(hass)
+        setup_mock_states(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        coordinator: PoolmanCoordinator = entry.runtime_data
+        assert coordinator.mode == PoolMode.ACTIVATING
+        assert coordinator.activation is not None
+        assert coordinator.activation.is_complete is False
+        assert len(coordinator.activation.pending_steps) == len(list(ActivationStep))
+
+    async def test_setup_does_not_restore_from_completed_activation(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """A completed activation subentry should not restore ACTIVATING mode."""
+        steps = {step.value: True for step in ActivationStep}
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=MOCK_CONFIG_DATA.copy(),
+            version=1,
+            minor_version=3,
+            subentries_data=[
+                {
+                    "data": {
+                        CONF_STARTED_AT: "2025-04-01T10:00:00+00:00",
+                        CONF_COMPLETED_AT: "2025-04-05T10:00:00+00:00",
+                        CONF_STEPS: steps,
+                    },
+                    "subentry_type": SUBENTRY_ACTIVATION,
+                    "title": "Activation - completed",
+                    "unique_id": None,
+                },
+            ],
+        )
+        entry.add_to_hass(hass)
+        setup_mock_states(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        coordinator: PoolmanCoordinator = entry.runtime_data
+        assert coordinator.mode == PoolMode.ACTIVE
+        assert coordinator.activation is None
 
 
 class TestUnloadEntry:


### PR DESCRIPTION
## Summary

Implements GitHub Issue #23: **Hibernation Wizard**, and migrates the existing **Activation Wizard** to the same `ConfigSubentryFlow` architecture.

- **Hibernation wizard**: Two-session subentry flow — start sets HIBERNATING mode, reconfigure finalizes transition to target winter mode (active or passive). Guards prevent duplicate or invalid starts. Subentry persists with `completed_at` timestamp.
- **Activation wizard**: Two-session subentry flow — start sets ACTIVATING mode, reconfigure finalizes to ACTIVE when all steps confirmed. Step state persisted to subentry data (survives HA restarts). `confirm_activation_step` service and auto-detection continue to work, updating both in-memory checklist and subentry. `RestoreEntity` removed from `PoolmanActivationStepSensor`.
- **50 new tests** covering wizard flows, persistence, and restoration (673 total pass)
- **Documentation** updated in `docs/pool-modes.md`

## Changes

| Area | Files |
|------|-------|
| Core | `__init__.py`, `config_flow.py`, `const.py`, `coordinator.py`, `sensor.py` |
| Translations | `strings.json`, `translations/en.json`, `translations/fr.json` |
| Docs | `docs/pool-modes.md` |
| Tests | `tests/test_config_flow.py`, `tests/test_coordinator.py`, `tests/test_init.py` |

Closes #23