### PR TITLE
fix(skill): clarify question tool usage in consistency-check skill

### DIFF
--- a/.agents/skills/consistency-check/SKILL.md
+++ b/.agents/skills/consistency-check/SKILL.md
@@ -27,8 +27,8 @@ This skill follows a 4-phase interactive workflow:
 
 ## Phase 1: Ask the User
 
-Present the user with a choice of review scope. Use the question tool if available,
-otherwise ask in plain text:
+Ask the user to choose a review scope. Use the `question` tool to present the
+options below. If the `question` tool is not available, ask in plain text instead:
 
 **Review types:**
 


### PR DESCRIPTION
## Summary

- Clarifies the consistency-check skill Phase 1 instructions to explicitly use the `question` tool for scope selection, with plain text as a fallback
- Ran a full consistency review of the codebase (report saved locally to `reports/consistency-report.md`, gitignored) identifying 4 critical, 12 warning, and 6 info-level findings across documentation, code, and translations

## Context

During a full consistency review, the skill's Phase 1 wording was found to be ambiguous about tool usage. The updated wording makes the `question` tool the primary instruction rather than a conditional afterthought.

The full consistency report is available in the branch at `reports/consistency-report.md` (gitignored) and covers findings across navigation, terminology, water chemistry docs vs code, rules docs vs code, translations, and constants.