### PR TITLE
feat(dashboard): add sample pool dashboards to documentation and demo

### DIFF
--- a/demo/configuration.yaml
+++ b/demo/configuration.yaml
@@ -1,0 +1,15 @@
+# Pool Manager demo configuration
+# This file is mounted into the Home Assistant container to register
+# custom card frontend resources.
+
+homeassistant:
+  country: FR
+
+# Loads the default set of integrations. Do not remove.
+default_config:
+
+# Custom card JS modules are registered as Lovelace resources by
+# setup.py via the WebSocket API (lovelace/resources/create).
+# Sample dashboards are created as storage-mode dashboards by
+# setup.py via the WebSocket API. They appear in the sidebar and
+# can be edited from the HA UI. Reset with: docker compose up -V

--- a/demo/dashboards/pool-builtin.yaml
+++ b/demo/dashboards/pool-builtin.yaml
@@ -1,0 +1,452 @@
+title: "Pool (Built-in Cards)"
+views:
+  - title: Pool
+    icon: mdi:pool
+    cards:
+      # ── Pool Status ──────────────────────────────────────────────
+      - type: heading
+        heading: Pool Status
+        heading_style: title
+        icon: mdi:pool
+
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          - type: tile
+            entity: select.demo_pool_pool_mode
+            name: Pool Mode
+            icon: mdi:pool
+          - type: tile
+            entity: binary_sensor.demo_pool_action_required
+            name: Action Required
+
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          - type: tile
+            entity: binary_sensor.demo_pool_water_quality
+            name: Water Quality
+            color: green
+          - type: tile
+            entity: binary_sensor.demo_pool_swimming_safe
+            name: Swimming Safe
+            color: cyan
+
+      - type: gauge
+        entity: sensor.demo_pool_water_quality
+        name: Water Quality Score
+        min: 0
+        max: 100
+        needle: true
+        severity:
+          green: 80
+          yellow: 50
+          red: 0
+
+      # ── Chemistry Readings ───────────────────────────────────────
+      - type: heading
+        heading: Chemistry Readings
+        heading_style: title
+        icon: mdi:flask
+
+      - type: grid
+        columns: 3
+        square: false
+        cards:
+          - type: sensor
+            entity: sensor.demo_pool_water_temperature
+            name: Temperature
+            graph: line
+          - type: sensor
+            entity: sensor.demo_pool_ph
+            name: pH
+            graph: line
+          - type: sensor
+            entity: sensor.demo_pool_orp
+            name: ORP
+            graph: line
+
+      - type: grid
+        columns: 5
+        square: false
+        cards:
+          - type: tile
+            entity: sensor.demo_pool_ph_status
+            name: pH
+            vertical: true
+          - type: tile
+            entity: sensor.demo_pool_orp_status
+            name: ORP
+            vertical: true
+          - type: tile
+            entity: sensor.demo_pool_tac_status
+            name: TAC
+            vertical: true
+          - type: tile
+            entity: sensor.demo_pool_cya_status
+            name: CYA
+            vertical: true
+          - type: tile
+            entity: sensor.demo_pool_hardness_status
+            name: Hardness
+            vertical: true
+
+      - type: history-graph
+        title: Chemistry History (24h)
+        hours_to_show: 24
+        entities:
+          - entity: sensor.demo_pool_water_temperature
+            name: Temperature
+          - entity: sensor.demo_pool_ph
+            name: pH
+          - entity: sensor.demo_pool_orp
+            name: ORP
+
+      # ── Recommendations ──────────────────────────────────────────
+      - type: heading
+        heading: Recommendations
+        heading_style: title
+        icon: mdi:clipboard-check
+
+      - type: entities
+        entities:
+          - entity: sensor.demo_pool_recommendations
+            name: Active Recommendations
+            icon: mdi:clipboard-list
+          - entity: sensor.demo_pool_chemistry_actions
+            name: Chemistry Actions
+            icon: mdi:beaker-check
+          - entity: binary_sensor.demo_pool_action_required
+            name: Action Required
+
+      - type: markdown
+        title: Current Recommendations
+        content: >
+          {% set recs = state_attr('sensor.demo_pool_recommendations', 'actions') %}
+          {% if recs and recs | length > 0 %}
+          {% for action in recs %}
+          - {{ action }}
+          {% endfor %}
+          {% else %}
+          No recommendations at this time.
+          {% endif %}
+
+      # ── Filtration Control ───────────────────────────────────────
+      - type: heading
+        heading: Filtration Control
+        heading_style: title
+        icon: mdi:pump
+
+      - type: entities
+        entities:
+          - entity: switch.demo_pool_filtration_control
+            name: Automatic Filtration
+          - entity: sensor.demo_pool_recommended_filtration
+            name: Recommended Duration
+          - entity: select.demo_pool_filtration_duration_mode
+            name: Duration Mode
+          - entity: number.demo_pool_filtration_duration
+            name: Duration Setting
+          - entity: time.demo_pool_filtration_start_time
+            name: Start Time
+
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          - type: tile
+            entity: select.demo_pool_filtration_boost
+            name: Boost
+            icon: mdi:rocket-launch
+          - type: tile
+            entity: sensor.demo_pool_filtration_boost_remaining
+            name: Boost Remaining
+
+      - type: grid
+        columns: 5
+        square: false
+        cards:
+          - type: button
+            name: Cancel
+            icon: mdi:cancel
+            show_name: true
+            show_icon: true
+            tap_action:
+              action: perform-action
+              perform_action: select.select_option
+              target:
+                entity_id: select.demo_pool_filtration_boost
+              data:
+                option: "none"
+          - type: button
+            name: +2h
+            icon: mdi:numeric-2
+            show_name: true
+            show_icon: true
+            tap_action:
+              action: perform-action
+              perform_action: select.select_option
+              target:
+                entity_id: select.demo_pool_filtration_boost
+              data:
+                option: "2"
+          - type: button
+            name: +4h
+            icon: mdi:numeric-4
+            show_name: true
+            show_icon: true
+            tap_action:
+              action: perform-action
+              perform_action: select.select_option
+              target:
+                entity_id: select.demo_pool_filtration_boost
+              data:
+                option: "4"
+          - type: button
+            name: +8h
+            icon: mdi:numeric-8
+            show_name: true
+            show_icon: true
+            tap_action:
+              action: perform-action
+              perform_action: select.select_option
+              target:
+                entity_id: select.demo_pool_filtration_boost
+              data:
+                option: "8"
+          - type: button
+            name: +24h
+            icon: mdi:hours-24
+            show_name: true
+            show_icon: true
+            tap_action:
+              action: perform-action
+              perform_action: select.select_option
+              target:
+                entity_id: select.demo_pool_filtration_boost
+              data:
+                option: "24"
+
+      - type: history-graph
+        title: Filtration History (24h)
+        hours_to_show: 24
+        entities:
+          - entity: switch.demo_pool_filtration_control
+            name: Filtration
+
+      # ── Treatments ──────────────────────────────────────────────
+      - type: heading
+        heading: Treatments
+        heading_style: title
+        icon: mdi:bottle-tonic-plus
+
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          - type: tile
+            entity: sensor.demo_pool_active_treatments
+            name: Active Treatments
+            icon: mdi:bottle-tonic
+          - type: tile
+            entity: sensor.demo_pool_safe_to_swim_at
+            name: Safe to Swim At
+            icon: mdi:clock-check
+
+      - type: markdown
+        title: Active Treatments
+        content: >
+          {% set treats = state_attr('sensor.demo_pool_active_treatments', 'treatments') %}
+          {% if treats and treats | length > 0 %}
+          | Product | Applied | Safe at | Quantity |
+          | ------- | ------- | ------- | -------- |
+          {% for t in treats %}
+          | {{ t.product }} | {{ t.applied_at }} | {{ t.safe_at }} | {{ t.quantity_g }}g |
+          {% endfor %}
+          {% else %}
+          No active treatments.
+          {% endif %}
+
+      # ── Activity Log ─────────────────────────────────────────────
+      - type: heading
+        heading: Activity Log
+        heading_style: title
+        icon: mdi:history
+
+      - type: logbook
+        hours_to_show: 48
+        entities:
+          - event.demo_pool_ph_measurement
+          - event.demo_pool_orp_measurement
+          - event.demo_pool_tac_measurement
+          - event.demo_pool_cya_measurement
+          - event.demo_pool_hardness_measurement
+          - event.demo_pool_temperature_measurement
+          - event.demo_pool_ph_minus_treatment
+          - event.demo_pool_ph_plus_treatment
+          - event.demo_pool_shock_chlorine_treatment
+          - event.demo_pool_chlorine_tablet_treatment
+          - event.demo_pool_filtration
+
+      # ── Activation Wizard (visible only in activating mode) ─────
+      - type: conditional
+        conditions:
+          - condition: state
+            entity: select.demo_pool_pool_mode
+            state: activating
+        card:
+          type: vertical-stack
+          cards:
+            - type: heading
+              heading: Activation Wizard
+              heading_style: title
+              icon: mdi:wizard-hat
+
+            - type: grid
+              columns: 2
+              square: false
+              cards:
+                - type: tile
+                  entity: sensor.demo_pool_activation_step
+                  name: Current Step
+                  icon: mdi:wizard-hat
+                - type: tile
+                  entity: select.demo_pool_pool_mode
+                  name: Pool Mode
+                  icon: mdi:progress-wrench
+
+            - type: markdown
+              title: Activation Progress
+              content: >
+                {% set progress = state_attr('sensor.demo_pool_activation_step', 'progress') %}
+                {% set completed = state_attr('sensor.demo_pool_activation_step', 'completed_steps') %}
+                {% set pending = state_attr('sensor.demo_pool_activation_step', 'pending_steps') %}
+                **Progress:** {{ progress if progress else '0/5' }}
+
+                {% if completed %}
+                {% for step in completed %}
+                - ✅ {{ step | replace('_', ' ') | title }}
+                {% endfor %}
+                {% endif %}
+                {% if pending %}
+                {% for step in pending %}
+                - ⬜ {{ step | replace('_', ' ') | title }}
+                {% endfor %}
+                {% endif %}
+
+            - type: grid
+              columns: 3
+              square: false
+              cards:
+                - type: button
+                  name: Remove Cover
+                  icon: mdi:umbrella-beach
+                  show_name: true
+                  show_icon: true
+                  tap_action:
+                    action: perform-action
+                    perform_action: poolman.confirm_activation_step
+                    data:
+                      device_id: this
+                      step: remove_cover
+                    target: {}
+                - type: button
+                  name: Raise Water
+                  icon: mdi:water-plus
+                  show_name: true
+                  show_icon: true
+                  tap_action:
+                    action: perform-action
+                    perform_action: poolman.confirm_activation_step
+                    data:
+                      device_id: this
+                      step: raise_water_level
+                    target: {}
+                - type: button
+                  name: Clean Pool
+                  icon: mdi:broom
+                  show_name: true
+                  show_icon: true
+                  tap_action:
+                    action: perform-action
+                    perform_action: poolman.confirm_activation_step
+                    data:
+                      device_id: this
+                      step: clean_pool_and_filter
+                    target: {}
+
+      # ── Quick Actions ───────────────────────────────────────────
+      - type: heading
+        heading: Quick Actions
+        heading_style: title
+        icon: mdi:lightning-bolt
+
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          - type: button
+            name: Record Measure
+            icon: mdi:test-tube
+            show_name: true
+            show_icon: true
+            tap_action:
+              action: perform-action
+              perform_action: poolman.record_measure
+              data:
+                device_id: this
+                parameter: ph
+                value: 7.2
+              target: {}
+              confirmation:
+                text: >-
+                  Record a pH measurement of 7.2?
+                  Edit the value in the action data if needed.
+          - type: button
+            name: Add Treatment
+            icon: mdi:bottle-tonic-plus
+            show_name: true
+            show_icon: true
+            tap_action:
+              action: perform-action
+              perform_action: poolman.add_treatment
+              data:
+                device_id: this
+                product: galet_chlore
+                quantity_g: 200
+              target: {}
+              confirmation:
+                text: >-
+                  Add a chlorine tablet treatment (200g)?
+                  Edit the action data to change product or quantity.
+
+      # ── Fake Sensor Controls (Demo Only) ─────────────────────────
+      - type: heading
+        heading: Sensor Controls (Demo)
+        heading_style: title
+        icon: mdi:tune
+
+      - type: entities
+        title: Adjust Simulated Values
+        entities:
+          - entity: number.fake_pool_sensor_water_temperature_target
+            name: Water Temperature Target
+          - entity: number.fake_pool_sensor_ph_target
+            name: pH Target
+          - entity: number.fake_pool_sensor_orp_target
+            name: ORP Target
+          - entity: number.fake_pool_sensor_total_alkalinity_target
+            name: TAC Target
+          - entity: number.fake_pool_sensor_cyanuric_acid_target
+            name: CYA Target
+          - entity: number.fake_pool_sensor_calcium_hardness_target
+            name: Hardness Target
+          - entity: number.fake_pool_sensor_outdoor_temperature_target
+            name: Outdoor Temperature Target
+
+      - type: tile
+        entity: switch.fake_pool_sensor_pump
+        name: Pump (Simulated)
+        icon: mdi:pump

--- a/demo/dashboards/pool-custom.yaml
+++ b/demo/dashboards/pool-custom.yaml
@@ -1,0 +1,881 @@
+title: "Pool (Custom Cards)"
+views:
+  - title: Pool
+    icon: mdi:pool
+    cards:
+      # ── Header ──────────────────────────────────────────────────
+      - type: custom:bubble-card
+        card_type: separator
+        name: Pool Manager
+        icon: mdi:pool
+
+      # ── Pool Status & Mode ──────────────────────────────────────
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          # Pool mode selector with styled button-card
+          - type: custom:button-card
+            name: Pool Mode
+            icon: mdi:pool
+            entity: select.demo_pool_pool_mode
+            show_state: true
+            state:
+              - value: active
+                icon: mdi:white-balance-sunny
+                styles:
+                  img_cell:
+                    - background: var(--green-color, #4caf50)
+              - value: hibernating
+                icon: mdi:snowflake
+                styles:
+                  img_cell:
+                    - background: var(--blue-color, #2196f3)
+              - value: winter_active
+                icon: mdi:sun-snowflake-variant
+                styles:
+                  img_cell:
+                    - background: var(--blue-color, #2196f3)
+              - value: winter_passive
+                icon: mdi:snowflake-alert
+                styles:
+                  img_cell:
+                    - background: var(--info-color, #039be5)
+              - value: activating
+                icon: mdi:progress-wrench
+                styles:
+                  img_cell:
+                    - background: var(--warning-color, #ff9800)
+            styles:
+              grid:
+                - grid-template-areas: '"n" "s" "i"'
+                - grid-template-rows: min-content min-content 1fr
+              img_cell:
+                - justify-content: center
+                - width: 80px
+                - height: 80px
+                - margin: 8px auto
+                - background: var(--primary-color)
+                - border-radius: 50%
+              icon:
+                - width: 40px
+                - color: white
+              card:
+                - height: 100%
+                - padding: 16px
+              name:
+                - font-size: 16px
+                - font-weight: 500
+              state:
+                - font-size: 14px
+                - opacity: "0.7"
+                - text-transform: capitalize
+            tap_action:
+              action: more-info
+
+          # Action required indicator
+          - type: custom:button-card
+            name: Actions Required
+            icon: mdi:check-circle-outline
+            entity: binary_sensor.demo_pool_action_required
+            show_state: true
+            state:
+              - value: "off"
+                icon: mdi:check-circle-outline
+                styles:
+                  img_cell:
+                    - background: var(--green-color, #4caf50)
+              - value: "on"
+                icon: mdi:alert-circle
+                styles:
+                  img_cell:
+                    - background: var(--error-color, #db4437)
+            styles:
+              grid:
+                - grid-template-areas: '"n" "s" "i"'
+                - grid-template-rows: min-content min-content 1fr
+              img_cell:
+                - justify-content: center
+                - width: 80px
+                - height: 80px
+                - margin: 8px auto
+                - background: var(--green-color, #4caf50)
+                - border-radius: 50%
+              icon:
+                - width: 40px
+                - color: white
+              card:
+                - height: 100%
+                - padding: 16px
+              name:
+                - font-size: 16px
+                - font-weight: 500
+              state:
+                - font-size: 14px
+                - opacity: "0.7"
+                - text-transform: capitalize
+            tap_action:
+              action: more-info
+
+      # ── Water Quality Score ──────────────────────────────────────
+      - type: custom:bubble-card
+        card_type: button
+        button_type: state
+        entity: sensor.demo_pool_water_quality
+        name: Water Quality Score
+        icon: mdi:water-check
+        show_state: true
+
+      # ── Safety Status ────────────────────────────────────────────
+      - type: custom:bubble-card
+        card_type: sub-buttons
+        hide_main_background: true
+        sub_button:
+          - entity: binary_sensor.demo_pool_water_quality
+            name: Water OK
+            icon: mdi:water-check
+            show_state: true
+            show_name: true
+          - entity: binary_sensor.demo_pool_swimming_safe
+            name: Swimming
+            icon: mdi:swim
+            show_state: true
+            show_name: true
+          - entity: sensor.demo_pool_active_treatments
+            name: Treatments
+            icon: mdi:bottle-tonic
+            show_state: true
+            show_name: true
+
+      # ── Temperature Graph ────────────────────────────────────────
+      - type: custom:mini-graph-card
+        entities:
+          - entity: sensor.demo_pool_water_temperature
+            name: Water Temperature
+        hours_to_show: 48
+        animate: true
+        line_width: 4
+        group_by: hour
+        hour24: true
+        decimals: 1
+        show:
+          extrema: true
+          average: true
+          labels: false
+        color_thresholds:
+          - value: 18
+            color: "#2196f3"
+          - value: 24
+            color: "#4caf50"
+          - value: 28
+            color: "#ff9800"
+          - value: 32
+            color: "#f44336"
+
+      # ── Pool Monitor Card (Chemistry Gauges) ─────────────────────
+      - type: custom:pool-monitor-card
+        title: Water Chemistry
+        display:
+          show_labels: true
+          show_last_updated: true
+          gradient: true
+          language: en
+        sensors:
+          temperature:
+            - entity: sensor.demo_pool_water_temperature
+              setpoint: 27
+              step: 4
+          ph:
+            - entity: sensor.demo_pool_ph
+              setpoint: 7.2
+              step: 0.3
+          orp:
+            - entity: sensor.demo_pool_orp
+              setpoint: 750
+              step: 75
+
+      # ── Chemistry Status ─────────────────────────────────────────
+      - type: grid
+        columns: 5
+        square: false
+        cards:
+          - type: custom:bubble-card
+            card_type: button
+            button_type: state
+            entity: sensor.demo_pool_ph_status
+            name: pH
+            icon: mdi:ph
+            show_state: true
+          - type: custom:bubble-card
+            card_type: button
+            button_type: state
+            entity: sensor.demo_pool_orp_status
+            name: ORP
+            icon: mdi:flash-triangle-outline
+            show_state: true
+          - type: custom:bubble-card
+            card_type: button
+            button_type: state
+            entity: sensor.demo_pool_tac_status
+            name: TAC
+            icon: mdi:beaker-outline
+            show_state: true
+          - type: custom:bubble-card
+            card_type: button
+            button_type: state
+            entity: sensor.demo_pool_cya_status
+            name: CYA
+            icon: mdi:shield-sun-outline
+            show_state: true
+          - type: custom:bubble-card
+            card_type: button
+            button_type: state
+            entity: sensor.demo_pool_hardness_status
+            name: Hardness
+            icon: mdi:water-opacity
+            show_state: true
+
+      # ── Recommendations ──────────────────────────────────────────
+      - type: custom:bubble-card
+        card_type: button
+        button_type: state
+        entity: sensor.demo_pool_recommendations
+        name: Recommendations
+        icon: mdi:clipboard-check
+        show_state: true
+        button_action:
+          tap_action:
+            action: more-info
+
+      - type: markdown
+        content: >
+          {% set recs = state_attr('sensor.demo_pool_recommendations', 'actions') %}
+          {% if recs and recs | length > 0 %}
+          {% for action in recs %}
+          - {{ action }}
+          {% endfor %}
+          {% else %}
+          *No recommendations at this time.*
+          {% endif %}
+
+      # ── Filtration Control ───────────────────────────────────────
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          # Pump toggle
+          - type: custom:button-card
+            entity: switch.demo_pool_filtration_control
+            name: Filtration
+            icon: mdi:pump
+            show_state: true
+            tap_action:
+              action: toggle
+            state:
+              - value: "on"
+                icon: mdi:pump
+                styles:
+                  card:
+                    - background: var(--green-color, #4caf50)
+                  icon:
+                    - color: white
+                  name:
+                    - color: white
+                  state:
+                    - color: white
+              - value: "off"
+                icon: mdi:pump-off
+                styles:
+                  card:
+                    - background: var(--error-color, #db4437)
+                  icon:
+                    - color: white
+                  name:
+                    - color: white
+                  state:
+                    - color: white
+            styles:
+              card:
+                - padding: 16px
+                - height: 100%
+              icon:
+                - width: 36px
+              name:
+                - font-size: 16px
+                - font-weight: 500
+              state:
+                - font-size: 14px
+                - text-transform: capitalize
+
+          # Filtration info
+          - type: vertical-stack
+            cards:
+              - type: custom:bubble-card
+                card_type: button
+                button_type: state
+                entity: sensor.demo_pool_recommended_filtration
+                name: Recommended
+                icon: mdi:clock-outline
+                show_state: true
+              - type: custom:bubble-card
+                card_type: button
+                button_type: state
+                entity: time.demo_pool_filtration_start_time
+                name: Start Time
+                icon: mdi:clock-start
+                show_state: true
+              - type: custom:bubble-card
+                card_type: button
+                button_type: state
+                entity: select.demo_pool_filtration_duration_mode
+                name: Mode
+                icon: mdi:cog
+                show_state: true
+
+      # ── Filtration Boost (sub-buttons) ───────────────────────────
+      - type: custom:bubble-card
+        card_type: button
+        button_type: state
+        entity: select.demo_pool_filtration_boost
+        name: Filtration Boost
+        icon: mdi:rocket-launch
+        show_state: true
+        sub_button:
+          - name: "Off"
+            icon: mdi:cancel
+            tap_action:
+              action: call-service
+              service: select.select_option
+              data:
+                option: "none"
+              target:
+                entity_id: select.demo_pool_filtration_boost
+          - name: "+2h"
+            icon: mdi:numeric-2
+            tap_action:
+              action: call-service
+              service: select.select_option
+              data:
+                option: "2"
+              target:
+                entity_id: select.demo_pool_filtration_boost
+          - name: "+4h"
+            icon: mdi:numeric-4
+            tap_action:
+              action: call-service
+              service: select.select_option
+              data:
+                option: "4"
+              target:
+                entity_id: select.demo_pool_filtration_boost
+          - name: "+8h"
+            icon: mdi:numeric-8
+            tap_action:
+              action: call-service
+              service: select.select_option
+              data:
+                option: "8"
+              target:
+                entity_id: select.demo_pool_filtration_boost
+          - name: "24h"
+            icon: mdi:hours-24
+            tap_action:
+              action: call-service
+              service: select.select_option
+              data:
+                option: "24"
+              target:
+                entity_id: select.demo_pool_filtration_boost
+
+      - type: history-graph
+        title: Filtration History (24h)
+        hours_to_show: 24
+        entities:
+          - entity: switch.demo_pool_filtration_control
+            name: Filtration
+
+      # ── Treatments ──────────────────────────────────────────────
+      - type: custom:bubble-card
+        card_type: button
+        button_type: state
+        entity: sensor.demo_pool_active_treatments
+        name: Active Treatments
+        icon: mdi:bottle-tonic-plus
+        show_state: true
+        button_action:
+          tap_action:
+            action: more-info
+
+      # ── Activity Log ─────────────────────────────────────────────
+      - type: custom:bubble-card
+        card_type: separator
+        name: Activity Log
+        icon: mdi:history
+
+      - type: logbook
+        hours_to_show: 48
+        entities:
+          - event.demo_pool_ph_measurement
+          - event.demo_pool_orp_measurement
+          - event.demo_pool_tac_measurement
+          - event.demo_pool_cya_measurement
+          - event.demo_pool_hardness_measurement
+          - event.demo_pool_temperature_measurement
+          - event.demo_pool_ph_minus_treatment
+          - event.demo_pool_ph_plus_treatment
+          - event.demo_pool_shock_chlorine_treatment
+          - event.demo_pool_chlorine_tablet_treatment
+          - event.demo_pool_filtration
+
+      # ── Activation Wizard (visible only in activating mode) ─────
+      - type: conditional
+        conditions:
+          - condition: state
+            entity: select.demo_pool_pool_mode
+            state: activating
+        card:
+          type: vertical-stack
+          cards:
+            - type: custom:bubble-card
+              card_type: separator
+              name: Activation Wizard
+              icon: mdi:wizard-hat
+
+            - type: custom:bubble-card
+              card_type: button
+              button_type: state
+              entity: sensor.demo_pool_activation_step
+              name: Current Step
+              icon: mdi:wizard-hat
+              show_state: true
+              button_action:
+                tap_action:
+                  action: more-info
+
+            - type: markdown
+              content: >
+                {% set completed = state_attr('sensor.demo_pool_activation_step', 'completed_steps') %}
+                {% set pending = state_attr('sensor.demo_pool_activation_step', 'pending_steps') %}
+                {% if completed %}
+                {% for step in completed %}
+                - ✅ {{ step | replace('_', ' ') | title }}
+                {% endfor %}
+                {% endif %}
+                {% if pending %}
+                {% for step in pending %}
+                - ⬜ {{ step | replace('_', ' ') | title }}
+                {% endfor %}
+                {% endif %}
+
+            - type: grid
+              columns: 3
+              square: true
+              cards:
+                - type: custom:button-card
+                  name: Remove Cover
+                  icon: mdi:umbrella-beach
+                  tap_action:
+                    action: perform-action
+                    perform_action: poolman.confirm_activation_step
+                    data:
+                      device_id: this
+                      step: remove_cover
+                  styles:
+                    card:
+                      - padding: 12px
+                    icon:
+                      - width: 32px
+                    name:
+                      - font-size: 12px
+
+                - type: custom:button-card
+                  name: Raise Water
+                  icon: mdi:water-plus
+                  tap_action:
+                    action: perform-action
+                    perform_action: poolman.confirm_activation_step
+                    data:
+                      device_id: this
+                      step: raise_water_level
+                  styles:
+                    card:
+                      - padding: 12px
+                    icon:
+                      - width: 32px
+                    name:
+                      - font-size: 12px
+
+                - type: custom:button-card
+                  name: Clean Pool
+                  icon: mdi:broom
+                  tap_action:
+                    action: perform-action
+                    perform_action: poolman.confirm_activation_step
+                    data:
+                      device_id: this
+                      step: clean_pool_and_filter
+                  styles:
+                    card:
+                      - padding: 12px
+                    icon:
+                      - width: 32px
+                    name:
+                      - font-size: 12px
+
+      # ── Quick Actions ───────────────────────────────────────────
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          - type: custom:bubble-card
+            card_type: button
+            button_type: name
+            name: Record Measure
+            icon: mdi:test-tube
+            button_action:
+              tap_action:
+                action: navigate
+                navigation_path: "#record-measure"
+
+          - type: custom:bubble-card
+            card_type: button
+            button_type: name
+            name: Add Treatment
+            icon: mdi:bottle-tonic-plus
+            button_action:
+              tap_action:
+                action: navigate
+                navigation_path: "#add-treatment"
+
+      # ── Fake Sensor Controls (Demo Only) ─────────────────────────
+      - type: custom:bubble-card
+        card_type: separator
+        name: Sensor Controls (Demo)
+        icon: mdi:tune
+
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          - type: vertical-stack
+            cards:
+              - type: tile
+                entity: number.fake_pool_sensor_water_temperature_target
+                name: Temperature
+                icon: mdi:thermometer-water
+              - type: tile
+                entity: number.fake_pool_sensor_ph_target
+                name: pH
+                icon: mdi:ph
+              - type: tile
+                entity: number.fake_pool_sensor_orp_target
+                name: ORP
+                icon: mdi:flash-triangle-outline
+              - type: tile
+                entity: number.fake_pool_sensor_outdoor_temperature_target
+                name: Outdoor Temp
+                icon: mdi:thermometer
+          - type: vertical-stack
+            cards:
+              - type: tile
+                entity: number.fake_pool_sensor_total_alkalinity_target
+                name: TAC
+                icon: mdi:beaker-outline
+              - type: tile
+                entity: number.fake_pool_sensor_cyanuric_acid_target
+                name: CYA
+                icon: mdi:shield-sun-outline
+              - type: tile
+                entity: number.fake_pool_sensor_calcium_hardness_target
+                name: Hardness
+                icon: mdi:water-opacity
+              - type: tile
+                entity: switch.fake_pool_sensor_pump
+                name: Pump
+                icon: mdi:pump
+
+      # ── Popups ──────────────────────────────────────────────────
+
+      # Record Measure popup
+      - type: vertical-stack
+        cards:
+          - type: custom:bubble-card
+            card_type: pop-up
+            hash: "#record-measure"
+            name: Record Measure
+            icon: mdi:test-tube
+          - type: grid
+            columns: 2
+            square: false
+            cards:
+              - type: custom:button-card
+                name: pH (7.2)
+                icon: mdi:ph
+                tap_action:
+                  action: perform-action
+                  perform_action: poolman.record_measure
+                  data:
+                    device_id: this
+                    parameter: ph
+                    value: 7.2
+                  confirmation:
+                    text: "Record a pH measurement of 7.2?"
+                styles:
+                  card:
+                    - padding: 12px
+                  icon:
+                    - width: 32px
+                  name:
+                    - font-size: 14px
+              - type: custom:button-card
+                name: ORP (750 mV)
+                icon: mdi:flash-triangle-outline
+                tap_action:
+                  action: perform-action
+                  perform_action: poolman.record_measure
+                  data:
+                    device_id: this
+                    parameter: orp
+                    value: 750
+                  confirmation:
+                    text: "Record an ORP measurement of 750 mV?"
+                styles:
+                  card:
+                    - padding: 12px
+                  icon:
+                    - width: 32px
+                  name:
+                    - font-size: 14px
+              - type: custom:button-card
+                name: TAC (150)
+                icon: mdi:beaker-outline
+                tap_action:
+                  action: perform-action
+                  perform_action: poolman.record_measure
+                  data:
+                    device_id: this
+                    parameter: tac
+                    value: 150
+                  confirmation:
+                    text: "Record an alkalinity (TAC) measurement of 150 ppm?"
+                styles:
+                  card:
+                    - padding: 12px
+                  icon:
+                    - width: 32px
+                  name:
+                    - font-size: 14px
+              - type: custom:button-card
+                name: CYA (30)
+                icon: mdi:shield-sun-outline
+                tap_action:
+                  action: perform-action
+                  perform_action: poolman.record_measure
+                  data:
+                    device_id: this
+                    parameter: cya
+                    value: 30
+                  confirmation:
+                    text: "Record a cyanuric acid (CYA) measurement of 30 ppm?"
+                styles:
+                  card:
+                    - padding: 12px
+                  icon:
+                    - width: 32px
+                  name:
+                    - font-size: 14px
+              - type: custom:button-card
+                name: Hardness (250)
+                icon: mdi:water-opacity
+                tap_action:
+                  action: perform-action
+                  perform_action: poolman.record_measure
+                  data:
+                    device_id: this
+                    parameter: hardness
+                    value: 250
+                  confirmation:
+                    text: "Record a calcium hardness measurement of 250 ppm?"
+                styles:
+                  card:
+                    - padding: 12px
+                  icon:
+                    - width: 32px
+                  name:
+                    - font-size: 14px
+              - type: custom:button-card
+                name: Temp (27°C)
+                icon: mdi:thermometer-water
+                tap_action:
+                  action: perform-action
+                  perform_action: poolman.record_measure
+                  data:
+                    device_id: this
+                    parameter: temperature
+                    value: 27
+                  confirmation:
+                    text: "Record a water temperature of 27°C?"
+                styles:
+                  card:
+                    - padding: 12px
+                  icon:
+                    - width: 32px
+                  name:
+                    - font-size: 14px
+
+      # Add Treatment popup
+      - type: vertical-stack
+        cards:
+          - type: custom:bubble-card
+            card_type: pop-up
+            hash: "#add-treatment"
+            name: Add Treatment
+            icon: mdi:bottle-tonic-plus
+          - type: grid
+            columns: 2
+            square: false
+            cards:
+              - type: custom:button-card
+                name: Chlorine Tablet
+                icon: mdi:circle-outline
+                label: "200 g"
+                show_label: true
+                tap_action:
+                  action: perform-action
+                  perform_action: poolman.add_treatment
+                  data:
+                    device_id: this
+                    product: galet_chlore
+                    quantity_g: 200
+                  confirmation:
+                    text: "Add a chlorine tablet treatment (200 g)?"
+                styles:
+                  card:
+                    - padding: 12px
+                  icon:
+                    - width: 32px
+                  name:
+                    - font-size: 14px
+                  label:
+                    - font-size: 12px
+                    - opacity: "0.7"
+              - type: custom:button-card
+                name: Shock Chlorine
+                icon: mdi:flash
+                label: "300 g"
+                show_label: true
+                tap_action:
+                  action: perform-action
+                  perform_action: poolman.add_treatment
+                  data:
+                    device_id: this
+                    product: chlore_choc
+                    quantity_g: 300
+                  confirmation:
+                    text: "Add a shock chlorine treatment (300 g)?"
+                styles:
+                  card:
+                    - padding: 12px
+                  icon:
+                    - width: 32px
+                  name:
+                    - font-size: 14px
+                  label:
+                    - font-size: 12px
+                    - opacity: "0.7"
+              - type: custom:button-card
+                name: pH Minus
+                icon: mdi:arrow-down-bold
+                label: "100 g"
+                show_label: true
+                tap_action:
+                  action: perform-action
+                  perform_action: poolman.add_treatment
+                  data:
+                    device_id: this
+                    product: ph_minus
+                    quantity_g: 100
+                  confirmation:
+                    text: "Add a pH minus treatment (100 g)?"
+                styles:
+                  card:
+                    - padding: 12px
+                  icon:
+                    - width: 32px
+                  name:
+                    - font-size: 14px
+                  label:
+                    - font-size: 12px
+                    - opacity: "0.7"
+              - type: custom:button-card
+                name: pH Plus
+                icon: mdi:arrow-up-bold
+                label: "100 g"
+                show_label: true
+                tap_action:
+                  action: perform-action
+                  perform_action: poolman.add_treatment
+                  data:
+                    device_id: this
+                    product: ph_plus
+                    quantity_g: 100
+                  confirmation:
+                    text: "Add a pH plus treatment (100 g)?"
+                styles:
+                  card:
+                    - padding: 12px
+                  icon:
+                    - width: 32px
+                  name:
+                    - font-size: 14px
+                  label:
+                    - font-size: 12px
+                    - opacity: "0.7"
+              - type: custom:button-card
+                name: Anti-algae
+                icon: mdi:leaf-off
+                label: "200 ml"
+                show_label: true
+                tap_action:
+                  action: perform-action
+                  perform_action: poolman.add_treatment
+                  data:
+                    device_id: this
+                    product: anti_algae
+                    quantity_g: 200
+                  confirmation:
+                    text: "Add an anti-algae treatment (200 ml)?"
+                styles:
+                  card:
+                    - padding: 12px
+                  icon:
+                    - width: 32px
+                  name:
+                    - font-size: 14px
+                  label:
+                    - font-size: 12px
+                    - opacity: "0.7"
+              - type: custom:button-card
+                name: Flocculant
+                icon: mdi:filter-outline
+                label: "100 ml"
+                show_label: true
+                tap_action:
+                  action: perform-action
+                  perform_action: poolman.add_treatment
+                  data:
+                    device_id: this
+                    product: flocculant
+                    quantity_g: 100
+                  confirmation:
+                    text: "Add a flocculant treatment (100 ml)?"
+                styles:
+                  card:
+                    - padding: 12px
+                  icon:
+                    - width: 32px
+                  name:
+                    - font-size: 14px
+                  label:
+                    - font-size: 12px
+                    - opacity: "0.7"

--- a/demo/setup.py
+++ b/demo/setup.py
@@ -1,8 +1,19 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "niquests[ws]",
+#     "pyyaml",
+# ]
+# ///
 """Automated setup for the Home Assistant dev instance.
 
-Onboards HA with a test user, creates a Fake Pool Sensor device,
-and configures Pool Manager to use it. Fully idempotent.
+Downloads custom card JS bundles, waits for HA to start, onboards a
+test user, creates storage-mode dashboards via WebSocket API, and
+configures Pool Manager.  Fully idempotent.
+
+Run with ``uv run /demo/setup.py`` (dependencies are declared inline
+via PEP 723).
 
 Credentials: admin / admin
 """
@@ -10,11 +21,13 @@ Credentials: admin / admin
 from __future__ import annotations
 
 import json
+import logging
+import os
 import sys
 import time
-import urllib.error
-import urllib.parse
-import urllib.request
+
+import niquests
+import yaml
 
 HA_URL = "http://homeassistant:8123"
 CLIENT_ID = f"{HA_URL}/"
@@ -37,63 +50,62 @@ FAKE_FILTRATION_SENSORS = {
     "outdoor_temperature_entity": "sensor.fake_pool_sensor_outdoor_temperature",
 }
 
+# Custom card JS bundles to download for the custom dashboard.
+# Each entry maps a local JS filename to the GitHub repository
+# (owner/repo) that publishes it.  The latest release is resolved
+# dynamically via the GitHub API at startup.
+CUSTOM_CARDS: dict[str, str] = {
+    "bubble-card.js": "Clooos/Bubble-Card",
+    "button-card.js": "custom-cards/button-card",
+    "mini-graph-card-bundle.js": "kalkih/mini-graph-card",
+    "pool-monitor-card.js": "wilsto/pool-monitor-card",
+    "mushroom.js": "piitaya/lovelace-mushroom",
+}
+
 
 # ---------------------------------------------------------------------------
-# HTTP helpers (stdlib only, no external dependencies)
+# HTTP helpers (using niquests)
 # ---------------------------------------------------------------------------
-
-
-def _request(
-    method: str,
-    url: str,
-    *,
-    json_data: dict | None = None,
-    form_data: dict | None = None,
-    token: str | None = None,
-) -> dict:
-    """Send an HTTP request and return parsed JSON."""
-    headers: dict[str, str] = {}
-    body: bytes | None = None
-
-    if json_data is not None:
-        headers["Content-Type"] = "application/json"
-        body = json.dumps(json_data).encode()
-    elif form_data is not None:
-        headers["Content-Type"] = "application/x-www-form-urlencoded"
-        body = urllib.parse.urlencode(form_data).encode()
-
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
-
-    req = urllib.request.Request(url, data=body, headers=headers, method=method)  # noqa: S310
-    with urllib.request.urlopen(req) as resp:  # noqa: S310
-        raw = resp.read()
-        return json.loads(raw) if raw else {}
 
 
 def get(url: str, *, token: str | None = None) -> dict | list:
-    """HTTP GET, return parsed JSON."""
+    """HTTP GET, return parsed JSON.  Raises on non-2xx status."""
     headers: dict[str, str] = {}
     if token:
         headers["Authorization"] = f"Bearer {token}"
-    req = urllib.request.Request(url, headers=headers)  # noqa: S310
-    with urllib.request.urlopen(req) as resp:  # noqa: S310
-        return json.loads(resp.read())
+    resp = niquests.get(url, headers=headers, timeout=10)
+    resp.raise_for_status()
+    return resp.json()
 
 
-def post(url: str, *, token: str | None = None, **kwargs: dict) -> dict:
-    """HTTP POST, return parsed JSON."""
-    return _request("POST", url, token=token, **kwargs)
+def post(
+    url: str,
+    *,
+    token: str | None = None,
+    json_data: dict | None = None,
+    form_data: dict | None = None,
+) -> dict:
+    """HTTP POST, return parsed JSON.  Raises on non-2xx status."""
+    headers: dict[str, str] = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    resp = niquests.post(
+        url,
+        headers=headers,
+        json=json_data,
+        data=form_data,
+        timeout=10,
+    )
+    resp.raise_for_status()
+    return resp.json()
 
 
 # ---------------------------------------------------------------------------
 # Logging
 # ---------------------------------------------------------------------------
 
-
-def log(msg: str) -> None:
-    """Print a timestamped log message."""
-    print(f"[setup] {msg}", flush=True)  # noqa: T201
+logging.basicConfig(level=logging.INFO, format="[%(levelname)s]  %(message)s")
+log = logging.getLogger("setup")
 
 
 # ---------------------------------------------------------------------------
@@ -104,24 +116,19 @@ def log(msg: str) -> None:
 def wait_for_ha(timeout: int = 120) -> None:
     """Block until HA is responding on its HTTP port."""
     deadline = time.monotonic() + timeout
-    log("Waiting for Home Assistant to be ready...")
+    log.info("Waiting for Home Assistant to be ready...")
     last_err = ""
     while time.monotonic() < deadline:
         try:
-            get(f"{HA_URL}/api/")
-            # 200 means HA is fully ready (unlikely without auth, but fine)
-            log("Home Assistant is ready.")
-            return
-        except urllib.error.HTTPError as exc:
-            if exc.code == 401:
-                log("Home Assistant is ready.")
+            resp = niquests.get(f"{HA_URL}/api/", timeout=5)
+            if resp.status_code in (200, 401):
+                log.info("Home Assistant is ready.")
                 return
-            last_err = f"HTTP {exc.code}"
-            time.sleep(2)
-        except (urllib.error.URLError, OSError) as exc:
+            last_err = f"HTTP {resp.status_code}"
+        except niquests.RequestException as exc:
             last_err = str(exc)
-            time.sleep(2)
-    log(f"ERROR: Home Assistant did not become ready in time. Last error: {last_err}")
+        time.sleep(2)
+    log.fatal("Home Assistant did not become ready in time. Last error: %s", last_err)
     sys.exit(1)
 
 
@@ -134,15 +141,14 @@ def needs_onboarding() -> bool:
     """Return True if the user onboarding step is pending.
 
     Checks the /api/onboarding endpoint. Returns False if 404 (already
-    onboarded — views are unregistered after completion).
+    onboarded -- views are unregistered after completion).
     """
-    try:
-        steps = get(f"{HA_URL}/api/onboarding")
-        return any(s["step"] == "user" and not s["done"] for s in steps)
-    except urllib.error.HTTPError as exc:
-        if exc.code == 404:
-            return False
-        raise
+    resp = niquests.get(f"{HA_URL}/api/onboarding", timeout=10)
+    if resp.status_code == 404:
+        return False
+    resp.raise_for_status()
+    steps = resp.json()
+    return any(s["step"] == "user" and not s["done"] for s in steps)
 
 
 def exchange_code(auth_code: str) -> str:
@@ -163,33 +169,33 @@ def onboard(timeout: int = 60) -> str:
 
     Retries if the onboarding views are not yet registered (404).
     """
-    log("Running onboarding (creating admin user)...")
+    log.info("Running onboarding (creating admin user)...")
 
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        try:
-            resp = post(
-                f"{HA_URL}/api/onboarding/users",
-                json_data={
-                    "client_id": CLIENT_ID,
-                    "name": "Admin",
-                    "username": USERNAME,
-                    "password": PASSWORD,
-                    "language": "en",
-                },
-            )
-            break
-        except urllib.error.HTTPError as exc:
-            if exc.code == 404:
-                log("Onboarding views not ready yet, retrying...")
-                time.sleep(2)
-                continue
-            raise
+        resp = niquests.post(
+            f"{HA_URL}/api/onboarding/users",
+            json={
+                "client_id": CLIENT_ID,
+                "name": "Admin",
+                "username": USERNAME,
+                "password": PASSWORD,
+                "language": "en",
+            },
+            timeout=10,
+        )
+        if resp.status_code == 404:
+            log.info("Onboarding views not ready yet, retrying...")
+            time.sleep(2)
+            continue
+        resp.raise_for_status()
+        data = resp.json()
+        break
     else:
-        log("ERROR: Onboarding endpoint never became available.")
+        log.fatal("Onboarding endpoint never became available.")
         sys.exit(1)
 
-    token = exchange_code(resp["auth_code"])
+    token = exchange_code(data["auth_code"])
 
     # Step 2-4: complete remaining onboarding steps
     post(f"{HA_URL}/api/onboarding/core_config", token=token, json_data={})
@@ -200,13 +206,13 @@ def onboard(timeout: int = 60) -> str:
         json_data={"client_id": CLIENT_ID, "redirect_uri": CLIENT_ID},
     )
 
-    log("Onboarding complete.")
+    log.info("Onboarding complete.")
     return token
 
 
 def login() -> str:
     """Login to an already-onboarded HA instance, return an access token."""
-    log("Already onboarded, logging in...")
+    log.info("Already onboarded, logging in...")
 
     # Start login flow
     resp = post(
@@ -230,11 +236,11 @@ def login() -> str:
     )
 
     if resp.get("type") != "create_entry":
-        log(f"ERROR: Login failed: {resp}")
+        log.fatal("Login failed: %s", resp)
         sys.exit(1)
 
     token = exchange_code(resp["result"])
-    log("Logged in.")
+    log.info("Logged in.")
     return token
 
 
@@ -268,7 +274,7 @@ def create_config_entry(token: str, handler: str, steps: list[dict]) -> dict:
     )
 
     if resp.get("type") == "abort":
-        log(f"  Config flow for {handler} aborted: {resp.get('reason')}")
+        log.info("Config flow for %s aborted: %s", handler, resp.get("reason"))
         return resp
 
     flow_id = resp["flow_id"]
@@ -282,14 +288,14 @@ def create_config_entry(token: str, handler: str, steps: list[dict]) -> dict:
         )
 
         if resp.get("type") == "create_entry":
-            log(f"  Created config entry: {resp['title']}")
+            log.info("Created config entry: %s", resp["title"])
             return resp
 
         if resp.get("type") == "abort":
-            log(f"  Config flow for {handler} aborted at step: {resp.get('reason')}")
+            log.info("Config flow for %s aborted at step: %s", handler, resp.get("reason"))
             return resp
 
-    log(f"  Unexpected flow result for {handler}: {resp}")
+    log.warning("Unexpected flow result for %s: %s", handler, resp)
     return resp
 
 
@@ -305,21 +311,242 @@ def wait_for_entities(
     timeout: int = 60,
 ) -> list[str]:
     """Wait until at least `expected_count` entities with the given prefix exist."""
-    log(f"Waiting for {expected_count} entities matching '{prefix}*'...")
+    log.info("Waiting for %d entities matching '%s*'...", expected_count, prefix)
     matches = []
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         states = get(f"{HA_URL}/api/states", token=token)
         matches = [s["entity_id"] for s in states if s["entity_id"].startswith(prefix)]
         if len(matches) >= expected_count:
-            log(f"  Found {len(matches)} entities: {', '.join(sorted(matches))}")
+            log.info("Found %d entities: %s", len(matches), ", ".join(sorted(matches)))
             return sorted(matches)
         time.sleep(2)
-    log(
-        f"ERROR: Only found {len(matches)} entities matching '{prefix}*'"
-        f" (expected {expected_count}): {', '.join(sorted(matches))}"
+    log.fatal(
+        "Only found %d entities matching '%s*' (expected %d): %s",
+        len(matches),
+        prefix,
+        expected_count,
+        ", ".join(sorted(matches)),
     )
     sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Custom card installation
+# ---------------------------------------------------------------------------
+
+GITHUB_API = "https://api.github.com"
+
+
+def resolve_card_url(filename: str, repo: str) -> str | None:
+    """Resolve the download URL for a custom card JS bundle.
+
+    Queries the GitHub API for the latest release of *repo*
+    (``owner/repo``) and returns the ``browser_download_url`` of the
+    asset whose name matches *filename*.
+
+    Some projects (e.g. Bubble Card) ship their JS bundle in the
+    repository ``dist/`` directory instead of as release assets.  When
+    no matching asset is found the function falls back to the raw
+    ``dist/<filename>`` URL for the tagged release.
+
+    Returns ``None`` when the release or file cannot be found.
+    """
+    url = f"{GITHUB_API}/repos/{repo}/releases/latest"
+    try:
+        resp = niquests.get(url, timeout=15)
+        resp.raise_for_status()
+        release = resp.json()
+    except niquests.RequestException as exc:
+        log.warning("GitHub API request failed for %s: %s", repo, exc)
+        return None
+
+    tag = release.get("tag_name", "")
+
+    # Try release assets first
+    for asset in release.get("assets", []):
+        if asset.get("name") == filename:
+            download_url: str = asset["browser_download_url"]
+            log.info("Resolved %s → %s (%s)", filename, tag, download_url)
+            return download_url
+
+    # Fallback: try dist/ directory for the tagged version
+    if tag:
+        dist_url = f"https://raw.githubusercontent.com/{repo}/refs/tags/{tag}/dist/{filename}"
+        try:
+            head = niquests.head(dist_url, timeout=10)
+            if head.status_code == 200:
+                log.info("Resolved %s → %s (dist/, %s)", filename, tag, dist_url)
+                return dist_url
+        except niquests.RequestException:
+            pass
+
+    log.warning(
+        "Asset %s not found in latest release of %s (%s)",
+        filename,
+        repo,
+        tag or "unknown",
+    )
+    return None
+
+
+def download_custom_cards(dest_dir: str = "/config/www") -> None:
+    """Download custom card JS bundles to the HA www directory.
+
+    Resolves the latest release for each card from GitHub and downloads
+    the matching JS asset.  Files are served by HA at
+    ``/local/<filename>``.  Skips files that already exist so the step
+    is idempotent.
+    """
+    os.makedirs(dest_dir, exist_ok=True)
+    for filename, repo in CUSTOM_CARDS.items():
+        path = os.path.join(dest_dir, filename)
+        if os.path.exists(path):
+            log.info("%s already downloaded, skipping.", filename)
+            continue
+        url = resolve_card_url(filename, repo)
+        if url is None:
+            log.warning("Skipping %s (could not resolve download URL).", filename)
+            continue
+        log.info("Downloading %s...", filename)
+        try:
+            resp = niquests.get(url, timeout=30)
+            resp.raise_for_status()
+            with open(path, "wb") as fh:
+                fh.write(resp.content)
+            log.info("%s OK (%d bytes)", filename, len(resp.content))
+        except niquests.RequestException as exc:
+            log.warning("Failed to download %s: %s", filename, exc)
+
+
+# ---------------------------------------------------------------------------
+# Dashboard seeding (storage mode via WebSocket API)
+# ---------------------------------------------------------------------------
+
+# Dashboards to create.  The YAML file is resolved relative to the
+# ``yaml_dir`` argument of :func:`seed_dashboards`.
+DASHBOARDS = [
+    {
+        "url_path": "pool-builtin",
+        "title": "Pool (Built-in)",
+        "icon": "mdi:pool",
+        "yaml_file": "pool-builtin.yaml",
+    },
+    {
+        "url_path": "pool-custom",
+        "title": "Pool (Custom Cards)",
+        "icon": "mdi:pool-thermometer",
+        "yaml_file": "pool-custom.yaml",
+    },
+]
+
+
+def seed_dashboards(token: str, yaml_dir: str = "/demo/dashboards") -> None:
+    """Create storage-mode dashboards via the HA WebSocket API.
+
+    For each entry in :data:`DASHBOARDS`, creates a new dashboard and
+    populates its configuration from the corresponding YAML file.
+
+    Also registers custom card JS bundles as Lovelace resources so that
+    storage-mode dashboards can load them.
+
+    Idempotent: dashboards and resources that already exist are skipped
+    so that edits made via the HA UI survive container restarts.  Reset
+    with ``docker compose up -V``.
+    """
+    ws_url = HA_URL.replace("http://", "ws://") + "/api/websocket"
+    msg_id = 0
+
+    with niquests.Session() as session:
+        resp = session.get(ws_url, timeout=10)
+        if resp.status_code != 101 or resp.extension is None:
+            log.error("WebSocket connection failed: HTTP %d", resp.status_code)
+            return
+
+        ws = resp.extension
+
+        def ws_command(cmd_type: str, **kwargs: object) -> dict:
+            """Send a WebSocket command and return the response."""
+            nonlocal msg_id
+            msg_id += 1
+            ws.send_payload(json.dumps({"id": msg_id, "type": cmd_type, **kwargs}))
+            raw = ws.next_payload()
+            if raw is None:
+                return {"success": False, "error": "connection closed"}
+            return json.loads(raw)
+
+        try:
+            # Authenticate
+            ws.next_payload()  # auth_required
+            ws.send_payload(json.dumps({"type": "auth", "access_token": token}))
+            raw = ws.next_payload()
+            auth_resp = json.loads(raw) if raw else {}
+            if auth_resp.get("type") != "auth_ok":
+                log.error("WebSocket auth failed: %s", auth_resp)
+                return
+
+            # Register custom card JS bundles as Lovelace resources
+            result = ws_command("lovelace/resources/list")
+            existing_resources = {r["url"] for r in result.get("result", [])}
+            for filename in CUSTOM_CARDS:
+                resource_url = f"/local/{filename}"
+                if resource_url in existing_resources:
+                    log.info("Resource %s already registered, skipping.", resource_url)
+                    continue
+                result = ws_command(
+                    "lovelace/resources/create",
+                    url=resource_url,
+                    res_type="module",
+                )
+                if result.get("success"):
+                    log.info("Registered resource: %s", resource_url)
+                else:
+                    log.warning("Failed to register %s: %s", resource_url, result)
+
+            # List existing dashboards to skip duplicates
+            result = ws_command("lovelace/dashboards/list")
+            existing = {d["url_path"] for d in result.get("result", [])}
+
+            for dash in DASHBOARDS:
+                url_path = dash["url_path"]
+                if url_path in existing:
+                    log.info("Dashboard %s already exists, skipping.", url_path)
+                    continue
+
+                # Create the dashboard
+                result = ws_command(
+                    "lovelace/dashboards/create",
+                    url_path=url_path,
+                    title=dash["title"],
+                    icon=dash["icon"],
+                    require_admin=False,
+                    show_in_sidebar=True,
+                )
+                if not result.get("success"):
+                    log.warning("Failed to create dashboard %s: %s", url_path, result)
+                    continue
+                log.info("Created dashboard: %s", dash["title"])
+
+                # Load YAML config and push it
+                yaml_path = os.path.join(yaml_dir, dash["yaml_file"])
+                if not os.path.exists(yaml_path):
+                    log.warning("%s not found, skipping config.", yaml_path)
+                    continue
+
+                with open(yaml_path) as fh:
+                    config = yaml.safe_load(fh)
+
+                result = ws_command(
+                    "lovelace/config/save",
+                    url_path=url_path,
+                    config=config,
+                )
+                if result.get("success"):
+                    log.info("Saved config for %s.", url_path)
+                else:
+                    log.warning("Failed to save config for %s: %s", url_path, result)
+        finally:
+            ws.close()
 
 
 # ---------------------------------------------------------------------------
@@ -329,6 +556,11 @@ def wait_for_entities(
 
 def main() -> None:
     """Run the automated HA setup."""
+    # Download custom card JS bundles (runs while HA is still booting)
+    log.info("Installing custom dashboard cards...")
+    download_custom_cards()
+
+    # Wait for HA to be ready
     wait_for_ha()
 
     # Authenticate
@@ -339,9 +571,9 @@ def main() -> None:
 
     # Set up Fake Pool Sensor
     if has_integration(entries, "fake_pool_sensor"):
-        log("Fake Pool Sensor already configured, skipping.")
+        log.info("Fake Pool Sensor already configured, skipping.")
     else:
-        log("Setting up Fake Pool Sensor...")
+        log.info("Setting up Fake Pool Sensor...")
         create_config_entry(
             token,
             "fake_pool_sensor",
@@ -354,9 +586,9 @@ def main() -> None:
 
     # Set up Pool Manager (three-step flow: pool basics, chemistry, filtration)
     if has_integration(entries, "poolman"):
-        log("Pool Manager already configured, skipping.")
+        log.info("Pool Manager already configured, skipping.")
     else:
-        log("Setting up Pool Manager...")
+        log.info("Setting up Pool Manager...")
         create_config_entry(
             token,
             "poolman",
@@ -382,7 +614,13 @@ def main() -> None:
             ],
         )
 
-    log("All done! HA is ready at http://localhost:8123 (admin/admin)")
+    # Create storage-mode dashboards (editable from the HA UI)
+    log.info("Seeding dashboards...")
+    seed_dashboards(token)
+
+    log.info("All done! HA is ready at http://localhost:8123 (admin/admin)")
+    log.info("  Built-in dashboard: http://localhost:8123/pool-builtin/0")
+    log.info("  Custom dashboard:   http://localhost:8123/pool-custom/0")
 
 
 if __name__ == "__main__":

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,8 +3,10 @@ services:
     image: ghcr.io/home-assistant/home-assistant:stable
     volumes:
       - /config
+      - card-assets:/config/www
       - ./custom_components/poolman:/config/custom_components/poolman:ro
       - ./demo/fake_pool_sensor:/config/custom_components/fake_pool_sensor:ro
+      - ./demo/configuration.yaml:/config/configuration.yaml
     ports:
       - "8123:8123"
     environment:
@@ -16,11 +18,18 @@ services:
       retries: 30
       start_period: 30s
 
+  # All-in-one setup: downloads custom card JS bundles, waits for HA,
+  # onboards a test user, creates storage-mode dashboards via WebSocket
+  # API, and configures Pool Manager.
+  # Dashboards can be edited from the HA UI after creation. To reset
+  # everything: docker compose up -V
   setup:
-    image: python:3.14-alpine
+    image: ghcr.io/astral-sh/uv:python3.14-alpine
     volumes:
+      - card-assets:/config/www
       - ./demo/setup.py:/demo/setup.py:ro
-    command: python /demo/setup.py
-    depends_on:
-      homeassistant:
-        condition: service_healthy
+      - ./demo/dashboards:/demo/dashboards:ro
+    command: uv run /demo/setup.py
+
+volumes:
+  card-assets:

--- a/docs/sample-dashboards.md
+++ b/docs/sample-dashboards.md
@@ -1,0 +1,1407 @@
+---
+icon: lucide/layout-dashboard
+---
+
+# Sample Dashboards
+
+This page provides two ready-to-use dashboard configurations for
+Pool Manager. Copy the YAML into a
+[manual Lovelace dashboard](https://www.home-assistant.io/dashboards/)
+and replace every occurrence of `{pool}` with your pool's entity name
+slug (e.g. `my_pool`).
+
+Both dashboards are included in the [demo environment](../README.md) and
+can be tested with `docker compose up`.
+
+## Built-in Cards Dashboard
+
+This dashboard uses **only standard Home Assistant cards** -- no custom
+cards or HACS installations required.
+
+### Built-in Sections
+
+| Section | Cards used | What it shows |
+| --- | --- | --- |
+| Pool Status | `tile`, `gauge` | Pool mode, water quality, swimming safe, action required, quality score |
+| Chemistry Readings | `sensor` (with graph), `tile` (status grid), `history-graph` | Temperature, pH, ORP readings with colored status indicators |
+| Recommendations | `entities`, `markdown` | Active recommendation count and detailed action list |
+| Filtration Control | `entities`, `tile`, `button`, `history-graph` | Filtration switch, duration, start time, mode, boost presets, pump history |
+| Treatments | `tile`, `markdown` | Active treatments, safe-to-swim time, treatment details table |
+| Activity Log | `logbook` | Recent measurements, treatments, and filtration events |
+| Activation Wizard | `conditional`, `tile`, `markdown`, `button` | Activation step progress and confirm buttons (only visible in activating mode) |
+| Quick Actions | `button` | Record measures, add treatments |
+
+### Built-in YAML
+
+??? example "Full YAML -- click to expand"
+
+    Replace `{pool}` with your pool name slug (e.g. `my_pool`).
+
+    ```yaml
+    title: Pool Manager
+    views:
+      - title: Pool
+        icon: mdi:pool
+        cards:
+          # ── Pool Status ──────────────────────────────────────────
+          - type: heading
+            heading: Pool Status
+            heading_style: title
+            icon: mdi:pool
+
+          - type: grid
+            columns: 2
+            square: false
+            cards:
+              - type: tile
+                entity: select.{pool}_pool_mode
+                name: Pool Mode
+                icon: mdi:pool
+              - type: tile
+                entity: binary_sensor.{pool}_action_required
+                name: Action Required
+
+          - type: grid
+            columns: 2
+            square: false
+            cards:
+              - type: tile
+                entity: binary_sensor.{pool}_water_quality
+                name: Water Quality
+                color: green
+              - type: tile
+                entity: binary_sensor.{pool}_swimming_safe
+                name: Swimming Safe
+                color: cyan
+
+          - type: gauge
+            entity: sensor.{pool}_water_quality
+            name: Water Quality Score
+            min: 0
+            max: 100
+            needle: true
+            severity:
+              green: 80
+              yellow: 50
+              red: 0
+
+          # ── Chemistry Readings ───────────────────────────────────
+          - type: heading
+            heading: Chemistry Readings
+            heading_style: title
+            icon: mdi:flask
+
+          - type: grid
+            columns: 3
+            square: false
+            cards:
+              - type: sensor
+                entity: sensor.{pool}_water_temperature
+                name: Temperature
+                graph: line
+              - type: sensor
+                entity: sensor.{pool}_ph
+                name: pH
+                graph: line
+              - type: sensor
+                entity: sensor.{pool}_orp
+                name: ORP
+                graph: line
+
+          - type: grid
+            columns: 5
+            square: false
+            cards:
+              - type: tile
+                entity: sensor.{pool}_ph_status
+                name: pH
+                vertical: true
+              - type: tile
+                entity: sensor.{pool}_orp_status
+                name: ORP
+                vertical: true
+              - type: tile
+                entity: sensor.{pool}_tac_status
+                name: TAC
+                vertical: true
+              - type: tile
+                entity: sensor.{pool}_cya_status
+                name: CYA
+                vertical: true
+              - type: tile
+                entity: sensor.{pool}_hardness_status
+                name: Hardness
+                vertical: true
+
+          - type: history-graph
+            title: Chemistry History (24h)
+            hours_to_show: 24
+            entities:
+              - entity: sensor.{pool}_water_temperature
+                name: Temperature
+              - entity: sensor.{pool}_ph
+                name: pH
+              - entity: sensor.{pool}_orp
+                name: ORP
+
+          # ── Recommendations ──────────────────────────────────────
+          - type: heading
+            heading: Recommendations
+            heading_style: title
+            icon: mdi:clipboard-check
+
+          - type: entities
+            entities:
+              - entity: sensor.{pool}_recommendations
+                name: Active Recommendations
+                icon: mdi:clipboard-list
+              - entity: sensor.{pool}_chemistry_actions
+                name: Chemistry Actions
+                icon: mdi:beaker-check
+              - entity: binary_sensor.{pool}_action_required
+                name: Action Required
+
+          - type: markdown
+            title: Current Recommendations
+            content: >
+              {% set recs = state_attr('sensor.{pool}_recommendations', 'actions') %}
+              {% if recs and recs | length > 0 %}
+              {% for action in recs %}
+              - {{ action }}
+              {% endfor %}
+              {% else %}
+              No recommendations at this time.
+              {% endif %}
+
+          # ── Filtration Control ───────────────────────────────────
+          - type: heading
+            heading: Filtration Control
+            heading_style: title
+            icon: mdi:pump
+
+          - type: entities
+            entities:
+              - entity: switch.{pool}_filtration_control
+                name: Automatic Filtration
+              - entity: sensor.{pool}_recommended_filtration
+                name: Recommended Duration
+              - entity: select.{pool}_filtration_duration_mode
+                name: Duration Mode
+              - entity: number.{pool}_filtration_duration
+                name: Duration Setting
+              - entity: time.{pool}_filtration_start_time
+                name: Start Time
+
+          - type: grid
+            columns: 2
+            square: false
+            cards:
+              - type: tile
+                entity: select.{pool}_filtration_boost
+                name: Boost
+                icon: mdi:rocket-launch
+              - type: tile
+                entity: sensor.{pool}_filtration_boost_remaining
+                name: Boost Remaining
+
+          - type: grid
+            columns: 5
+            square: false
+            cards:
+              - type: button
+                name: Cancel
+                icon: mdi:cancel
+                show_name: true
+                show_icon: true
+                tap_action:
+                  action: perform-action
+                  perform_action: select.select_option
+                  target:
+                    entity_id: select.{pool}_filtration_boost
+                  data:
+                    option: "none"
+              - type: button
+                name: +2h
+                icon: mdi:numeric-2
+                show_name: true
+                show_icon: true
+                tap_action:
+                  action: perform-action
+                  perform_action: select.select_option
+                  target:
+                    entity_id: select.{pool}_filtration_boost
+                  data:
+                    option: "2"
+              - type: button
+                name: +4h
+                icon: mdi:numeric-4
+                show_name: true
+                show_icon: true
+                tap_action:
+                  action: perform-action
+                  perform_action: select.select_option
+                  target:
+                    entity_id: select.{pool}_filtration_boost
+                  data:
+                    option: "4"
+              - type: button
+                name: +8h
+                icon: mdi:numeric-8
+                show_name: true
+                show_icon: true
+                tap_action:
+                  action: perform-action
+                  perform_action: select.select_option
+                  target:
+                    entity_id: select.{pool}_filtration_boost
+                  data:
+                    option: "8"
+              - type: button
+                name: +24h
+                icon: mdi:hours-24
+                show_name: true
+                show_icon: true
+                tap_action:
+                  action: perform-action
+                  perform_action: select.select_option
+                  target:
+                    entity_id: select.{pool}_filtration_boost
+                  data:
+                    option: "24"
+
+          - type: history-graph
+            title: Filtration History (24h)
+            hours_to_show: 24
+            entities:
+              - entity: switch.{pool}_filtration_control
+                name: Filtration
+
+          # ── Treatments ──────────────────────────────────────────
+          - type: heading
+            heading: Treatments
+            heading_style: title
+            icon: mdi:bottle-tonic-plus
+
+          - type: grid
+            columns: 2
+            square: false
+            cards:
+              - type: tile
+                entity: sensor.{pool}_active_treatments
+                name: Active Treatments
+                icon: mdi:bottle-tonic
+              - type: tile
+                entity: sensor.{pool}_safe_to_swim_at
+                name: Safe to Swim At
+                icon: mdi:clock-check
+
+          - type: markdown
+            title: Active Treatments
+            content: >
+              {% set treats = state_attr('sensor.{pool}_active_treatments', 'treatments') %}
+              {% if treats and treats | length > 0 %}
+              | Product | Applied | Safe at | Quantity |
+              | ------- | ------- | ------- | -------- |
+              {% for t in treats %}
+              | {{ t.product }} | {{ t.applied_at }} | {{ t.safe_at }} | {{ t.quantity_g }}g |
+              {% endfor %}
+              {% else %}
+              No active treatments.
+              {% endif %}
+
+          # ── Activity Log ─────────────────────────────────────────
+          - type: heading
+            heading: Activity Log
+            heading_style: title
+            icon: mdi:history
+
+          - type: logbook
+            hours_to_show: 48
+            entities:
+              - event.{pool}_ph_measurement
+              - event.{pool}_orp_measurement
+              - event.{pool}_tac_measurement
+              - event.{pool}_cya_measurement
+              - event.{pool}_hardness_measurement
+              - event.{pool}_temperature_measurement
+              - event.{pool}_ph_minus_treatment
+              - event.{pool}_ph_plus_treatment
+              - event.{pool}_shock_chlorine_treatment
+              - event.{pool}_chlorine_tablet_treatment
+              - event.{pool}_filtration
+
+          # ── Activation Wizard (visible only in activating mode) ─
+          - type: conditional
+            conditions:
+              - condition: state
+                entity: select.{pool}_pool_mode
+                state: activating
+            card:
+              type: vertical-stack
+              cards:
+                - type: heading
+                  heading: Activation Wizard
+                  heading_style: title
+                  icon: mdi:wizard-hat
+
+                - type: grid
+                  columns: 2
+                  square: false
+                  cards:
+                    - type: tile
+                      entity: sensor.{pool}_activation_step
+                      name: Current Step
+                      icon: mdi:wizard-hat
+                    - type: tile
+                      entity: select.{pool}_pool_mode
+                      name: Pool Mode
+                      icon: mdi:progress-wrench
+
+                - type: markdown
+                  title: Activation Progress
+                  content: >
+                    {% set progress = state_attr('sensor.{pool}_activation_step', 'progress') %}
+                    {% set completed = state_attr('sensor.{pool}_activation_step', 'completed_steps') %}
+                    {% set pending = state_attr('sensor.{pool}_activation_step', 'pending_steps') %}
+                    **Progress:** {{ progress if progress else '0/5' }}
+
+                    {% if completed %}
+                    {% for step in completed %}
+                    - ✅ {{ step | replace('_', ' ') | title }}
+                    {% endfor %}
+                    {% endif %}
+                    {% if pending %}
+                    {% for step in pending %}
+                    - ⬜ {{ step | replace('_', ' ') | title }}
+                    {% endfor %}
+                    {% endif %}
+
+                - type: grid
+                  columns: 3
+                  square: false
+                  cards:
+                    - type: button
+                      name: Remove Cover
+                      icon: mdi:umbrella-beach
+                      show_name: true
+                      show_icon: true
+                      tap_action:
+                        action: perform-action
+                        perform_action: poolman.confirm_activation_step
+                        data:
+                          device_id: this
+                          step: remove_cover
+                        target: {}
+                    - type: button
+                      name: Raise Water
+                      icon: mdi:water-plus
+                      show_name: true
+                      show_icon: true
+                      tap_action:
+                        action: perform-action
+                        perform_action: poolman.confirm_activation_step
+                        data:
+                          device_id: this
+                          step: raise_water_level
+                        target: {}
+                    - type: button
+                      name: Clean Pool
+                      icon: mdi:broom
+                      show_name: true
+                      show_icon: true
+                      tap_action:
+                        action: perform-action
+                        perform_action: poolman.confirm_activation_step
+                        data:
+                          device_id: this
+                          step: clean_pool_and_filter
+                        target: {}
+
+          # ── Quick Actions ───────────────────────────────────────
+          - type: heading
+            heading: Quick Actions
+            heading_style: title
+            icon: mdi:lightning-bolt
+
+          - type: grid
+            columns: 2
+            square: false
+            cards:
+              - type: button
+                name: Record Measure
+                icon: mdi:test-tube
+                show_name: true
+                show_icon: true
+                tap_action:
+                  action: perform-action
+                  perform_action: poolman.record_measure
+                  data:
+                    device_id: this
+                    parameter: ph
+                    value: 7.2
+                  target: {}
+                  confirmation:
+                    text: >-
+                      Record a pH measurement of 7.2?
+                      Edit the value in the action data if needed.
+              - type: button
+                name: Add Treatment
+                icon: mdi:bottle-tonic-plus
+                show_name: true
+                show_icon: true
+                tap_action:
+                  action: perform-action
+                  perform_action: poolman.add_treatment
+                  data:
+                    device_id: this
+                    product: galet_chlore
+                    quantity_g: 200
+                  target: {}
+                  confirmation:
+                    text: >-
+                      Add a chlorine tablet treatment (200g)?
+                      Edit the action data to change product or quantity.
+    ```
+
+!!! tip "Adapting the quick actions"
+
+    The button cards call services with pre-filled sample parameters
+    (pH 7.2 for measurement, chlorine tablet 200g for treatment) and
+    show a confirmation dialog before executing. Edit the `data`
+    section of each button's `tap_action` to change the default
+    parameter, value, product, or quantity to match your workflow.
+
+---
+
+## Custom Cards Dashboard
+
+This dashboard uses community custom cards for a more polished look,
+inspired by the
+[iopool custom card](https://docs.page/mguyard/hass-iopool/integration/custom-card).
+
+### Prerequisites
+
+Install the following custom cards via [HACS](https://hacs.xyz/):
+
+| Card | Repository | Purpose |
+| ---- | ---------- | ------- |
+| [Bubble Card](https://github.com/Clooos/Bubble-Card) | `Clooos/Bubble-Card` | Entity display, separators, sub-buttons (chips), pop-up overlays |
+| [button-card](https://github.com/custom-cards/button-card) | `custom-cards/button-card` | Highly customizable buttons with conditional styling |
+| [mini-graph-card](https://github.com/kalkih/mini-graph-card) | `kalkih/mini-graph-card` | Animated line charts with color thresholds |
+| [Pool Monitor Card](https://github.com/wilsto/pool-monitor-card) | `wilsto/pool-monitor-card` | Chemistry gauge display with setpoints |
+
+### Custom Card Sections
+
+| Section | Cards used | What it shows |
+| ------- | ---------- | ------------- |
+| Header | Bubble separator | Dashboard title |
+| Pool Status | button-card, Bubble sub-buttons | Pool mode with colored icons, action required indicator, safety status chips |
+| Water Quality | Bubble button, Pool Monitor Card | Quality score, chemistry gauges with setpoints |
+| Temperature | mini-graph-card | 48h animated temperature graph with color thresholds |
+| Chemistry Status | Bubble button (grid) | 5 status indicators |
+| Recommendations | Bubble button, markdown | Recommendation count, detailed list |
+| Filtration | button-card, Bubble button/sub-buttons, history-graph | Pump toggle, duration, mode, boost presets as sub-buttons, pump history |
+| Treatments | Bubble button | Active treatment count |
+| Activity Log | logbook | Recent measurements, treatments, and filtration events |
+| Activation Wizard | `conditional`, Bubble separator/button, markdown, button-card | Activation step progress and confirm buttons (only visible in activating mode) |
+| Quick Actions | Bubble button (grid) | Open Record Measure and Add Treatment pop-ups |
+| Record Measure | Bubble pop-up, button-card (grid) | Pop-up with buttons for each measurement parameter (pH, ORP, TAC, CYA, hardness, temperature) |
+| Add Treatment | Bubble pop-up, button-card (grid) | Pop-up with buttons for common treatments (chlorine, pH, anti-algae, flocculant) |
+
+### Custom Card YAML
+
+??? example "Full YAML -- click to expand"
+
+    Replace `{pool}` with your pool name slug (e.g. `my_pool`).
+
+    ```yaml
+    title: Pool Manager
+    views:
+      - title: Pool
+        icon: mdi:pool
+        cards:
+          # ── Header ──────────────────────────────────────────────
+          - type: custom:bubble-card
+            card_type: separator
+            name: Pool Manager
+            icon: mdi:pool
+
+          # ── Pool Status & Mode ──────────────────────────────────
+          - type: grid
+            columns: 2
+            square: false
+            cards:
+              - type: custom:button-card
+                name: Pool Mode
+                icon: mdi:pool
+                entity: select.{pool}_pool_mode
+                show_state: true
+                state:
+                  - value: active
+                    icon: mdi:white-balance-sunny
+                    styles:
+                      img_cell:
+                        - background: var(--green-color, #4caf50)
+                  - value: hibernating
+                    icon: mdi:snowflake
+                    styles:
+                      img_cell:
+                        - background: var(--blue-color, #2196f3)
+                  - value: winter_active
+                    icon: mdi:sun-snowflake-variant
+                    styles:
+                      img_cell:
+                        - background: var(--blue-color, #2196f3)
+                  - value: winter_passive
+                    icon: mdi:snowflake-alert
+                    styles:
+                      img_cell:
+                        - background: var(--info-color, #039be5)
+                  - value: activating
+                    icon: mdi:progress-wrench
+                    styles:
+                      img_cell:
+                        - background: var(--warning-color, #ff9800)
+                styles:
+                  grid:
+                    - grid-template-areas: '"n" "s" "i"'
+                    - grid-template-rows: min-content min-content 1fr
+                  img_cell:
+                    - justify-content: center
+                    - width: 80px
+                    - height: 80px
+                    - margin: 8px auto
+                    - background: var(--primary-color)
+                    - border-radius: 50%
+                  icon:
+                    - width: 40px
+                    - color: white
+                  card:
+                    - height: 100%
+                    - padding: 16px
+                  name:
+                    - font-size: 16px
+                    - font-weight: 500
+                  state:
+                    - font-size: 14px
+                    - opacity: "0.7"
+                    - text-transform: capitalize
+                tap_action:
+                  action: more-info
+
+              - type: custom:button-card
+                name: Actions Required
+                icon: mdi:check-circle-outline
+                entity: binary_sensor.{pool}_action_required
+                show_state: true
+                state:
+                  - value: "off"
+                    icon: mdi:check-circle-outline
+                    styles:
+                      img_cell:
+                        - background: var(--green-color, #4caf50)
+                  - value: "on"
+                    icon: mdi:alert-circle
+                    styles:
+                      img_cell:
+                        - background: var(--error-color, #db4437)
+                styles:
+                  grid:
+                    - grid-template-areas: '"n" "s" "i"'
+                    - grid-template-rows: min-content min-content 1fr
+                  img_cell:
+                    - justify-content: center
+                    - width: 80px
+                    - height: 80px
+                    - margin: 8px auto
+                    - background: var(--green-color, #4caf50)
+                    - border-radius: 50%
+                  icon:
+                    - width: 40px
+                    - color: white
+                  card:
+                    - height: 100%
+                    - padding: 16px
+                  name:
+                    - font-size: 16px
+                    - font-weight: 500
+                  state:
+                    - font-size: 14px
+                    - opacity: "0.7"
+                    - text-transform: capitalize
+                tap_action:
+                  action: more-info
+
+          # ── Water Quality Score ──────────────────────────────────
+          - type: custom:bubble-card
+            card_type: button
+            button_type: state
+            entity: sensor.{pool}_water_quality
+            name: Water Quality Score
+            icon: mdi:water-check
+            show_state: true
+
+          # ── Safety Status ────────────────────────────────────────
+          - type: custom:bubble-card
+            card_type: sub-buttons
+            hide_main_background: true
+            sub_button:
+              - entity: binary_sensor.{pool}_water_quality
+                name: Water OK
+                icon: mdi:water-check
+                show_state: true
+                show_name: true
+              - entity: binary_sensor.{pool}_swimming_safe
+                name: Swimming
+                icon: mdi:swim
+                show_state: true
+                show_name: true
+              - entity: sensor.{pool}_active_treatments
+                name: Treatments
+                icon: mdi:bottle-tonic
+                show_state: true
+                show_name: true
+
+          # ── Temperature Graph ────────────────────────────────────
+          - type: custom:mini-graph-card
+            entities:
+              - entity: sensor.{pool}_water_temperature
+                name: Water Temperature
+            hours_to_show: 48
+            animate: true
+            line_width: 4
+            group_by: hour
+            hour24: true
+            decimals: 1
+            show:
+              extrema: true
+              average: true
+              labels: false
+            color_thresholds:
+              - value: 18
+                color: "#2196f3"
+              - value: 24
+                color: "#4caf50"
+              - value: 28
+                color: "#ff9800"
+              - value: 32
+                color: "#f44336"
+
+          # ── Pool Monitor Card (Chemistry Gauges) ─────────────────
+          - type: custom:pool-monitor-card
+            title: Water Chemistry
+            display:
+              show_labels: true
+              show_last_updated: true
+              gradient: true
+              language: en
+            sensors:
+              temperature:
+                - entity: sensor.{pool}_water_temperature
+                  setpoint: 27
+                  step: 4
+              ph:
+                - entity: sensor.{pool}_ph
+                  setpoint: 7.2
+                  step: 0.3
+              orp:
+                - entity: sensor.{pool}_orp
+                  setpoint: 750
+                  step: 75
+
+          # ── Chemistry Status ─────────────────────────────────────
+          - type: grid
+            columns: 5
+            square: false
+            cards:
+              - type: custom:bubble-card
+                card_type: button
+                button_type: state
+                entity: sensor.{pool}_ph_status
+                name: pH
+                icon: mdi:ph
+                show_state: true
+              - type: custom:bubble-card
+                card_type: button
+                button_type: state
+                entity: sensor.{pool}_orp_status
+                name: ORP
+                icon: mdi:flash-triangle-outline
+                show_state: true
+              - type: custom:bubble-card
+                card_type: button
+                button_type: state
+                entity: sensor.{pool}_tac_status
+                name: TAC
+                icon: mdi:beaker-outline
+                show_state: true
+              - type: custom:bubble-card
+                card_type: button
+                button_type: state
+                entity: sensor.{pool}_cya_status
+                name: CYA
+                icon: mdi:shield-sun-outline
+                show_state: true
+              - type: custom:bubble-card
+                card_type: button
+                button_type: state
+                entity: sensor.{pool}_hardness_status
+                name: Hardness
+                icon: mdi:water-opacity
+                show_state: true
+
+          # ── Recommendations ──────────────────────────────────────
+          - type: custom:bubble-card
+            card_type: button
+            button_type: state
+            entity: sensor.{pool}_recommendations
+            name: Recommendations
+            icon: mdi:clipboard-check
+            show_state: true
+            button_action:
+              tap_action:
+                action: more-info
+
+          - type: markdown
+            content: >
+              {% set recs = state_attr('sensor.{pool}_recommendations', 'actions') %}
+              {% if recs and recs | length > 0 %}
+              {% for action in recs %}
+              - {{ action }}
+              {% endfor %}
+              {% else %}
+              *No recommendations at this time.*
+              {% endif %}
+
+          # ── Filtration Control ───────────────────────────────────
+          - type: grid
+            columns: 2
+            square: false
+            cards:
+              - type: custom:button-card
+                entity: switch.{pool}_filtration_control
+                name: Filtration
+                icon: mdi:pump
+                show_state: true
+                tap_action:
+                  action: toggle
+                state:
+                  - value: "on"
+                    icon: mdi:pump
+                    styles:
+                      card:
+                        - background: var(--green-color, #4caf50)
+                      icon:
+                        - color: white
+                      name:
+                        - color: white
+                      state:
+                        - color: white
+                  - value: "off"
+                    icon: mdi:pump-off
+                    styles:
+                      card:
+                        - background: var(--error-color, #db4437)
+                      icon:
+                        - color: white
+                      name:
+                        - color: white
+                      state:
+                        - color: white
+                styles:
+                  card:
+                    - padding: 16px
+                    - height: 100%
+                  icon:
+                    - width: 36px
+                  name:
+                    - font-size: 16px
+                    - font-weight: 500
+                  state:
+                    - font-size: 14px
+                    - text-transform: capitalize
+
+              - type: vertical-stack
+                cards:
+                  - type: custom:bubble-card
+                    card_type: button
+                    button_type: state
+                    entity: sensor.{pool}_recommended_filtration
+                    name: Recommended
+                    icon: mdi:clock-outline
+                    show_state: true
+                  - type: custom:bubble-card
+                    card_type: button
+                    button_type: state
+                    entity: time.{pool}_filtration_start_time
+                    name: Start Time
+                    icon: mdi:clock-start
+                    show_state: true
+                  - type: custom:bubble-card
+                    card_type: button
+                    button_type: state
+                    entity: select.{pool}_filtration_duration_mode
+                    name: Mode
+                    icon: mdi:cog
+                    show_state: true
+
+          # ── Filtration Boost (sub-buttons) ───────────────────────
+          - type: custom:bubble-card
+            card_type: button
+            button_type: state
+            entity: select.{pool}_filtration_boost
+            name: Filtration Boost
+            icon: mdi:rocket-launch
+            show_state: true
+            sub_button:
+              - name: "Off"
+                icon: mdi:cancel
+                tap_action:
+                  action: call-service
+                  service: select.select_option
+                  data:
+                    option: "none"
+                  target:
+                    entity_id: select.{pool}_filtration_boost
+              - name: "+2h"
+                icon: mdi:numeric-2
+                tap_action:
+                  action: call-service
+                  service: select.select_option
+                  data:
+                    option: "2"
+                  target:
+                    entity_id: select.{pool}_filtration_boost
+              - name: "+4h"
+                icon: mdi:numeric-4
+                tap_action:
+                  action: call-service
+                  service: select.select_option
+                  data:
+                    option: "4"
+                  target:
+                    entity_id: select.{pool}_filtration_boost
+              - name: "+8h"
+                icon: mdi:numeric-8
+                tap_action:
+                  action: call-service
+                  service: select.select_option
+                  data:
+                    option: "8"
+                  target:
+                    entity_id: select.{pool}_filtration_boost
+              - name: "24h"
+                icon: mdi:hours-24
+                tap_action:
+                  action: call-service
+                  service: select.select_option
+                  data:
+                    option: "24"
+                  target:
+                    entity_id: select.{pool}_filtration_boost
+
+          - type: history-graph
+            title: Filtration History (24h)
+            hours_to_show: 24
+            entities:
+              - entity: switch.{pool}_filtration_control
+                name: Filtration
+
+          # ── Treatments ──────────────────────────────────────────
+          - type: custom:bubble-card
+            card_type: button
+            button_type: state
+            entity: sensor.{pool}_active_treatments
+            name: Active Treatments
+            icon: mdi:bottle-tonic-plus
+            show_state: true
+            button_action:
+              tap_action:
+                action: more-info
+
+          # ── Activity Log ─────────────────────────────────────────
+          - type: custom:bubble-card
+            card_type: separator
+            name: Activity Log
+            icon: mdi:history
+
+          - type: logbook
+            hours_to_show: 48
+            entities:
+              - event.{pool}_ph_measurement
+              - event.{pool}_orp_measurement
+              - event.{pool}_tac_measurement
+              - event.{pool}_cya_measurement
+              - event.{pool}_hardness_measurement
+              - event.{pool}_temperature_measurement
+              - event.{pool}_ph_minus_treatment
+              - event.{pool}_ph_plus_treatment
+              - event.{pool}_shock_chlorine_treatment
+              - event.{pool}_chlorine_tablet_treatment
+              - event.{pool}_filtration
+
+          # ── Activation Wizard (visible only in activating mode) ─
+          - type: conditional
+            conditions:
+              - condition: state
+                entity: select.{pool}_pool_mode
+                state: activating
+            card:
+              type: vertical-stack
+              cards:
+                - type: custom:bubble-card
+                  card_type: separator
+                  name: Activation Wizard
+                  icon: mdi:wizard-hat
+
+                - type: custom:bubble-card
+                  card_type: button
+                  button_type: state
+                  entity: sensor.{pool}_activation_step
+                  name: Current Step
+                  icon: mdi:wizard-hat
+                  show_state: true
+                  button_action:
+                    tap_action:
+                      action: more-info
+
+                - type: markdown
+                  content: >
+                    {% set completed = state_attr('sensor.{pool}_activation_step', 'completed_steps') %}
+                    {% set pending = state_attr('sensor.{pool}_activation_step', 'pending_steps') %}
+                    {% if completed %}
+                    {% for step in completed %}
+                    - ✅ {{ step | replace('_', ' ') | title }}
+                    {% endfor %}
+                    {% endif %}
+                    {% if pending %}
+                    {% for step in pending %}
+                    - ⬜ {{ step | replace('_', ' ') | title }}
+                    {% endfor %}
+                    {% endif %}
+
+                - type: grid
+                  columns: 3
+                  square: true
+                  cards:
+                    - type: custom:button-card
+                      name: Remove Cover
+                      icon: mdi:umbrella-beach
+                      tap_action:
+                        action: perform-action
+                        perform_action: poolman.confirm_activation_step
+                        data:
+                          device_id: this
+                          step: remove_cover
+                      styles:
+                        card:
+                          - padding: 12px
+                        icon:
+                          - width: 32px
+                        name:
+                          - font-size: 12px
+
+                    - type: custom:button-card
+                      name: Raise Water
+                      icon: mdi:water-plus
+                      tap_action:
+                        action: perform-action
+                        perform_action: poolman.confirm_activation_step
+                        data:
+                          device_id: this
+                          step: raise_water_level
+                      styles:
+                        card:
+                          - padding: 12px
+                        icon:
+                          - width: 32px
+                        name:
+                          - font-size: 12px
+
+                    - type: custom:button-card
+                      name: Clean Pool
+                      icon: mdi:broom
+                      tap_action:
+                        action: perform-action
+                        perform_action: poolman.confirm_activation_step
+                        data:
+                          device_id: this
+                          step: clean_pool_and_filter
+                      styles:
+                        card:
+                          - padding: 12px
+                        icon:
+                          - width: 32px
+                        name:
+                          - font-size: 12px
+
+          # ── Quick Actions ───────────────────────────────────────
+          - type: grid
+            columns: 2
+            square: false
+            cards:
+              - type: custom:bubble-card
+                card_type: button
+                button_type: name
+                name: Record Measure
+                icon: mdi:test-tube
+                button_action:
+                  tap_action:
+                    action: navigate
+                    navigation_path: "#record-measure"
+
+              - type: custom:bubble-card
+                card_type: button
+                button_type: name
+                name: Add Treatment
+                icon: mdi:bottle-tonic-plus
+                button_action:
+                  tap_action:
+                    action: navigate
+                    navigation_path: "#add-treatment"
+
+          # ── Popups ──────────────────────────────────────────────
+
+          # Record Measure popup
+          - type: vertical-stack
+            cards:
+              - type: custom:bubble-card
+                card_type: pop-up
+                hash: "#record-measure"
+                name: Record Measure
+                icon: mdi:test-tube
+              - type: grid
+                columns: 2
+                square: false
+                cards:
+                  - type: custom:button-card
+                    name: pH (7.2)
+                    icon: mdi:ph
+                    tap_action:
+                      action: perform-action
+                      perform_action: poolman.record_measure
+                      data:
+                        device_id: this
+                        parameter: ph
+                        value: 7.2
+                      confirmation:
+                        text: "Record a pH measurement of 7.2?"
+                    styles:
+                      card:
+                        - padding: 12px
+                      icon:
+                        - width: 32px
+                      name:
+                        - font-size: 14px
+                  - type: custom:button-card
+                    name: ORP (750 mV)
+                    icon: mdi:flash-triangle-outline
+                    tap_action:
+                      action: perform-action
+                      perform_action: poolman.record_measure
+                      data:
+                        device_id: this
+                        parameter: orp
+                        value: 750
+                      confirmation:
+                        text: "Record an ORP measurement of 750 mV?"
+                    styles:
+                      card:
+                        - padding: 12px
+                      icon:
+                        - width: 32px
+                      name:
+                        - font-size: 14px
+                  - type: custom:button-card
+                    name: TAC (150)
+                    icon: mdi:beaker-outline
+                    tap_action:
+                      action: perform-action
+                      perform_action: poolman.record_measure
+                      data:
+                        device_id: this
+                        parameter: tac
+                        value: 150
+                      confirmation:
+                        text: "Record an alkalinity (TAC) measurement of 150 ppm?"
+                    styles:
+                      card:
+                        - padding: 12px
+                      icon:
+                        - width: 32px
+                      name:
+                        - font-size: 14px
+                  - type: custom:button-card
+                    name: CYA (30)
+                    icon: mdi:shield-sun-outline
+                    tap_action:
+                      action: perform-action
+                      perform_action: poolman.record_measure
+                      data:
+                        device_id: this
+                        parameter: cya
+                        value: 30
+                      confirmation:
+                        text: "Record a cyanuric acid (CYA) measurement of 30 ppm?"
+                    styles:
+                      card:
+                        - padding: 12px
+                      icon:
+                        - width: 32px
+                      name:
+                        - font-size: 14px
+                  - type: custom:button-card
+                    name: Hardness (250)
+                    icon: mdi:water-opacity
+                    tap_action:
+                      action: perform-action
+                      perform_action: poolman.record_measure
+                      data:
+                        device_id: this
+                        parameter: hardness
+                        value: 250
+                      confirmation:
+                        text: "Record a calcium hardness measurement of 250 ppm?"
+                    styles:
+                      card:
+                        - padding: 12px
+                      icon:
+                        - width: 32px
+                      name:
+                        - font-size: 14px
+                  - type: custom:button-card
+                    name: Temp (27°C)
+                    icon: mdi:thermometer-water
+                    tap_action:
+                      action: perform-action
+                      perform_action: poolman.record_measure
+                      data:
+                        device_id: this
+                        parameter: temperature
+                        value: 27
+                      confirmation:
+                        text: "Record a water temperature of 27°C?"
+                    styles:
+                      card:
+                        - padding: 12px
+                      icon:
+                        - width: 32px
+                      name:
+                        - font-size: 14px
+
+          # Add Treatment popup
+          - type: vertical-stack
+            cards:
+              - type: custom:bubble-card
+                card_type: pop-up
+                hash: "#add-treatment"
+                name: Add Treatment
+                icon: mdi:bottle-tonic-plus
+              - type: grid
+                columns: 2
+                square: false
+                cards:
+                  - type: custom:button-card
+                    name: Chlorine Tablet
+                    icon: mdi:circle-outline
+                    label: "200 g"
+                    show_label: true
+                    tap_action:
+                      action: perform-action
+                      perform_action: poolman.add_treatment
+                      data:
+                        device_id: this
+                        product: galet_chlore
+                        quantity_g: 200
+                      confirmation:
+                        text: "Add a chlorine tablet treatment (200 g)?"
+                    styles:
+                      card:
+                        - padding: 12px
+                      icon:
+                        - width: 32px
+                      name:
+                        - font-size: 14px
+                      label:
+                        - font-size: 12px
+                        - opacity: "0.7"
+                  - type: custom:button-card
+                    name: Shock Chlorine
+                    icon: mdi:flash
+                    label: "300 g"
+                    show_label: true
+                    tap_action:
+                      action: perform-action
+                      perform_action: poolman.add_treatment
+                      data:
+                        device_id: this
+                        product: chlore_choc
+                        quantity_g: 300
+                      confirmation:
+                        text: "Add a shock chlorine treatment (300 g)?"
+                    styles:
+                      card:
+                        - padding: 12px
+                      icon:
+                        - width: 32px
+                      name:
+                        - font-size: 14px
+                      label:
+                        - font-size: 12px
+                        - opacity: "0.7"
+                  - type: custom:button-card
+                    name: pH Minus
+                    icon: mdi:arrow-down-bold
+                    label: "100 g"
+                    show_label: true
+                    tap_action:
+                      action: perform-action
+                      perform_action: poolman.add_treatment
+                      data:
+                        device_id: this
+                        product: ph_minus
+                        quantity_g: 100
+                      confirmation:
+                        text: "Add a pH minus treatment (100 g)?"
+                    styles:
+                      card:
+                        - padding: 12px
+                      icon:
+                        - width: 32px
+                      name:
+                        - font-size: 14px
+                      label:
+                        - font-size: 12px
+                        - opacity: "0.7"
+                  - type: custom:button-card
+                    name: pH Plus
+                    icon: mdi:arrow-up-bold
+                    label: "100 g"
+                    show_label: true
+                    tap_action:
+                      action: perform-action
+                      perform_action: poolman.add_treatment
+                      data:
+                        device_id: this
+                        product: ph_plus
+                        quantity_g: 100
+                      confirmation:
+                        text: "Add a pH plus treatment (100 g)?"
+                    styles:
+                      card:
+                        - padding: 12px
+                      icon:
+                        - width: 32px
+                      name:
+                        - font-size: 14px
+                      label:
+                        - font-size: 12px
+                        - opacity: "0.7"
+                  - type: custom:button-card
+                    name: Anti-algae
+                    icon: mdi:leaf-off
+                    label: "200 ml"
+                    show_label: true
+                    tap_action:
+                      action: perform-action
+                      perform_action: poolman.add_treatment
+                      data:
+                        device_id: this
+                        product: anti_algae
+                        quantity_g: 200
+                      confirmation:
+                        text: "Add an anti-algae treatment (200 ml)?"
+                    styles:
+                      card:
+                        - padding: 12px
+                      icon:
+                        - width: 32px
+                      name:
+                        - font-size: 14px
+                      label:
+                        - font-size: 12px
+                        - opacity: "0.7"
+                  - type: custom:button-card
+                    name: Flocculant
+                    icon: mdi:filter-outline
+                    label: "100 ml"
+                    show_label: true
+                    tap_action:
+                      action: perform-action
+                      perform_action: poolman.add_treatment
+                      data:
+                        device_id: this
+                        product: flocculant
+                        quantity_g: 100
+                      confirmation:
+                        text: "Add a flocculant treatment (100 ml)?"
+                    styles:
+                      card:
+                        - padding: 12px
+                      icon:
+                        - width: 32px
+                      name:
+                        - font-size: 14px
+                      label:
+                        - font-size: 12px
+                        - opacity: "0.7"
+    ```
+
+!!! note "Custom card versions in the demo"
+
+    The demo environment automatically downloads the **latest release**
+    of each custom card from GitHub at startup.  To pin a specific
+    version, edit the `CUSTOM_CARDS` mapping in `demo/setup.py`.
+
+---
+
+## Using the Demo
+
+The [demo environment](../README.md) includes both dashboards
+pre-configured. To try them out:
+
+```bash
+docker compose up
+```
+
+Once the setup completes, open:
+
+- **Built-in dashboard:** <http://localhost:8123/pool-builtin/0>
+- **Custom dashboard:** <http://localhost:8123/pool-custom/0>
+
+Credentials: `admin` / `admin`
+
+The demo also includes a **Sensor Controls** section at the bottom of
+each dashboard where you can adjust the simulated sensor values
+(temperature, pH, ORP, etc.) to see how the dashboard reacts in
+real time.
+
+## Customization Tips
+
+- **Entity IDs:** Entity IDs are derived from the **translated entity
+  name** in `strings.json`, not the internal `key`. For example, the
+  temperature sensor's entity ID is `sensor.{pool}_water_temperature`
+  (from the translated name "Water temperature"), not
+  `sensor.{pool}_temperature`. See [Entities](entities.md) for the
+  full list of available entities and their attributes.
+
+- **Recommendations detail:** The `recommendations` sensor exposes an
+  `actions` attribute (list of strings) that you can render with a
+  `markdown` card using Jinja templates.
+
+- **Chemistry status colors:** Each chemistry status sensor
+  (`ph_status`, `orp_status`, etc.) returns `good`, `warning`, or `bad`.
+  Use conditional styling to display green/orange/red indicators.
+
+- **Filtration boost presets:** The `filtration_boost` select entity
+  accepts `none`, `2`, `4`, `8`, and `24`. Wire these to
+  Bubble Card sub-buttons or action cards for quick access.
+
+- **Pop-ups:** Use Bubble Card's `pop-up` card type to create overlay
+  forms for recording measures or adding treatments. Define the pop-up
+  at the end of the view and trigger it with `navigation_path: "#hash"`.
+
+- **Services:** Use the `poolman.record_measure`,
+  `poolman.add_treatment`, `poolman.boost_filtration`, and
+  `poolman.confirm_activation_step` services in button tap actions.
+  See [Entities -- Services](entities.md#events) for required fields.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,11 @@ line-length = 100
 respect-gitignore = true
 show-fixes = true
 
+[tool.ty.src]
+# demo/setup.py uses PEP 723 inline script dependencies resolved by
+# ``uv run`` — they are not in the project venv.
+exclude = ["demo/"]
+
 [tool.ruff.lint]
 select = [
     "A",     # flake8-builtins

--- a/zensical.toml
+++ b/zensical.toml
@@ -58,6 +58,7 @@ nav = [
   { "Filtration Control" = "filtration-control.md" },
   { "Water Chemistry" = "water-chemistry.md" },
   { "Rules & Recommendations" = "rules-and-recommendations.md" },
+  { "Sample Dashboards" = "sample-dashboards.md" },
   { "Contributing" = "contributing.md" },
 ]
 


### PR DESCRIPTION
## Summary

- Add two ready-to-use Lovelace dashboard configurations: one using only built-in HA cards, one using custom HACS cards (Mushroom, button-card, mini-graph-card, Pool Monitor Card)
- Both dashboards cover: pool status, chemistry readings, recommendations, filtration control, treatments, activation wizard (conditional), and quick actions
- Add `docs/sample-dashboards.md` documentation page with full YAML, prerequisites, and customization tips
- Wire both dashboards into the demo environment with automatic custom card JS download

## Dashboard Sections

| Section | Description |
| --- | --- |
| Pool Status | Mode selector, action required, water quality, swimming safe |
| Chemistry Readings | Temperature, pH, ORP graphs and 5 chemistry statuses |
| Recommendations | Active recommendation count and detailed action list |
| Filtration Control | Pump toggle, duration, mode, boost presets |
| Treatments | Active treatments and safe-to-swim time |
| Activation Wizard | Conditional section (activating mode only): step progress checklist and confirm buttons |
| Quick Actions | Record measures, add treatments, boost filtration |

## Files Changed

- **New:** `docs/sample-dashboards.md`, `demo/dashboards/pool-builtin.yaml`, `demo/dashboards/pool-custom.yaml`, `demo/configuration.yaml`
- **Modified:** `demo/setup.py` (custom card download), `docker-compose.yaml` (volume mounts), `zensical.toml` (nav entry)

Closes #35