### PR TITLE
fix(demo): use anonymous volume for ha-config

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
   homeassistant:
     image: ghcr.io/home-assistant/home-assistant:stable
     volumes:
-      - ha-config:/config
+      - /config
       - ./custom_components/poolman:/config/custom_components/poolman:ro
       - ./demo/fake_pool_sensor:/config/custom_components/fake_pool_sensor:ro
     ports:
@@ -24,6 +24,3 @@ services:
     depends_on:
       homeassistant:
         condition: service_healthy
-
-volumes:
-  ha-config:


### PR DESCRIPTION
## Summary

- Replace the named `ha-config` volume with an anonymous volume (`/config`) in `docker-compose.yaml`
- Remove the top-level `volumes:` declaration that is no longer needed

This fixes the issue where `docker compose up -V` would not recreate the Home Assistant config volume because named volumes are not affected by the `-V` flag — only anonymous volumes are.