### PR TITLE
feat(spoon): add measuring spoon size support

### DIFF
--- a/custom_components/poolman/__init__.py
+++ b/custom_components/poolman/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.helpers import device_registry as dr
 from .const import (
     CONF_COMPLETED_AT,
     CONF_FILTRATION_KIND,
+    CONF_SPOON_SIZES,
     CONF_STARTED_AT,
     CONF_STEPS,
     CONF_TREATMENT,
@@ -29,7 +30,7 @@ from .const import (
 )
 from .coordinator import PoolmanCoordinator
 from .domain.activation import ActivationChecklist, ActivationStep
-from .domain.model import ChemicalProduct, MeasureParameter, PoolMode
+from .domain.model import PRODUCT_DENSITY_G_PER_ML, ChemicalProduct, MeasureParameter, PoolMode
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -40,6 +41,8 @@ SERVICE_ADD_TREATMENT_SCHEMA = vol.Schema(
         vol.Required("device_id"): str,
         vol.Required("product"): vol.In([p.value for p in ChemicalProduct]),
         vol.Optional("quantity_g"): vol.All(vol.Coerce(float), vol.Range(min=0)),
+        vol.Optional("spoons"): vol.All(vol.Coerce(float), vol.Range(min=0)),
+        vol.Optional("spoon_name"): str,
         vol.Optional("notes"): str,
     }
 )
@@ -144,6 +147,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: PoolmanConfigEntry) ->
 
     Handles migration from v1.1 to v1.2: adds filtration_kind with a default value.
     Handles migration from v1.2 to v1.3: adds treatment with a default value.
+    Handles migration from v1.3 to v1.4: adds spoon_sizes with an empty default.
     """
     if entry.version == 1 and entry.minor_version < 2:
         new_data = {**entry.data}
@@ -157,7 +161,51 @@ async def async_migrate_entry(hass: HomeAssistant, entry: PoolmanConfigEntry) ->
             new_data[CONF_TREATMENT] = DEFAULT_TREATMENT
         hass.config_entries.async_update_entry(entry, data=new_data, minor_version=3)
 
+    if entry.version == 1 and entry.minor_version < 4:
+        new_data = {**entry.data}
+        if CONF_SPOON_SIZES not in new_data:
+            new_data[CONF_SPOON_SIZES] = []
+        hass.config_entries.async_update_entry(entry, data=new_data, minor_version=4)
+
     return True
+
+
+def _resolve_spoon_quantity(
+    coordinator: PoolmanCoordinator,
+    product: ChemicalProduct,
+    spoons: float,
+    spoon_name: str,
+) -> float | None:
+    """Convert a spoon-based quantity to grams.
+
+    Looks up the named spoon in the coordinator's pool configuration,
+    computes the volume in mL, then converts to grams using the product's
+    bulk density.
+
+    Args:
+        coordinator: The pool coordinator with pool configuration.
+        product: Chemical product being applied.
+        spoons: Number of spoons.
+        spoon_name: Name of the spoon size to use.
+
+    Returns:
+        Quantity in grams, or ``None`` if the spoon name is not found
+        or the product has no known density.
+    """
+    pool = coordinator.pool
+    matching = [s for s in pool.spoon_sizes if s.name == spoon_name]
+    if not matching:
+        _LOGGER.warning("Spoon name '%s' not found in pool configuration", spoon_name)
+        return None
+
+    spoon = matching[0]
+    density = PRODUCT_DENSITY_G_PER_ML.get(product)
+    if density is None or density <= 0:
+        _LOGGER.warning("No density defined for product %s", product)
+        return None
+
+    volume_ml = spoons * spoon.size_ml
+    return volume_ml * density
 
 
 def _async_register_services(hass: HomeAssistant) -> None:
@@ -170,9 +218,15 @@ def _async_register_services(hass: HomeAssistant) -> None:
 
         Resolves the target device to find the corresponding coordinator,
         then records the treatment on the appropriate event entity.
+
+        When ``spoons`` and ``spoon_name`` are provided instead of
+        ``quantity_g``, the spoon count is converted to grams using the
+        configured spoon volume and the product's bulk density.
         """
         product = ChemicalProduct(call.data["product"])
         quantity_g: float | None = call.data.get("quantity_g")
+        spoons: float | None = call.data.get("spoons")
+        spoon_name: str | None = call.data.get("spoon_name")
         notes: str | None = call.data.get("notes")
         device_id: str = call.data["device_id"]
 
@@ -186,6 +240,11 @@ def _async_register_services(hass: HomeAssistant) -> None:
             entry = hass.config_entries.async_get_entry(entry_id)
             if entry and entry.domain == DOMAIN:
                 coordinator: PoolmanCoordinator = entry.runtime_data
+
+                # Resolve spoon-based input to quantity_g
+                if quantity_g is None and spoons is not None and spoon_name is not None:
+                    quantity_g = _resolve_spoon_quantity(coordinator, product, spoons, spoon_name)
+
                 await coordinator.async_add_treatment(product, quantity_g, notes)
 
     hass.services.async_register(

--- a/custom_components/poolman/config_flow.py
+++ b/custom_components/poolman/config_flow.py
@@ -26,6 +26,8 @@ from homeassistant.helpers.selector import (
     SelectSelector,
     SelectSelectorConfig,
     SelectSelectorMode,
+    TextSelector,
+    TextSelectorConfig,
 )
 from homeassistant.util.dt import utcnow
 
@@ -45,6 +47,7 @@ from .const import (
     CONF_PUMP_FLOW_M3H,
     CONF_SALT_ENTITY,
     CONF_SHAPE,
+    CONF_SPOON_SIZES,
     CONF_STARTED_AT,
     CONF_STEPS,
     CONF_TAC_ENTITY,
@@ -61,6 +64,7 @@ from .const import (
     FILTRATION_KINDS,
     HIBERNATION_TARGET_MODES,
     SHAPES,
+    SPOON_PAIRS,
     SUBENTRY_ACTIVATION,
     SUBENTRY_HIBERNATION,
     TREATMENTS,
@@ -218,6 +222,85 @@ def _filtration_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
     )
 
 
+def _spoon_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
+    """Build the schema for spoon size configuration.
+
+    Provides up to 3 optional name/size pairs. Each pair consists of a
+    text field for the spoon name and a number field for its volume in mL.
+    Empty name fields are ignored.
+
+    Args:
+        defaults: Optional default values to pre-populate the form.
+
+    Returns:
+        A voluptuous schema for the spoon configuration step.
+    """
+    defaults = defaults or {}
+    fields: dict[vol.Optional, Any] = {}
+    for name_key, size_key in SPOON_PAIRS:
+        fields[vol.Optional(name_key, default=defaults.get(name_key, ""))] = TextSelector(
+            TextSelectorConfig()
+        )
+        fields[vol.Optional(size_key, default=defaults.get(size_key, 0))] = NumberSelector(
+            NumberSelectorConfig(
+                min=0,
+                max=1000,
+                step=1,
+                unit_of_measurement="mL",
+                mode=NumberSelectorMode.BOX,
+            )
+        )
+    return vol.Schema(fields)
+
+
+def _parse_spoon_sizes(user_input: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract valid spoon size pairs from form data.
+
+    Iterates over the configured spoon name/size pairs and returns a list
+    of dictionaries with ``name`` and ``size_ml`` keys for each pair where
+    the name is non-empty and the size is positive.
+
+    Args:
+        user_input: Form data from the spoon configuration step.
+
+    Returns:
+        List of spoon size dicts suitable for storage in config entry data.
+    """
+    spoons: list[dict[str, Any]] = []
+    for name_key, size_key in SPOON_PAIRS:
+        name = user_input.get(name_key, "").strip()
+        size = user_input.get(size_key, 0)
+        if name and size and float(size) > 0:
+            spoons.append({"name": name, "size_ml": float(size)})
+    return spoons
+
+
+def _spoon_defaults_from_config(
+    current: dict[str, Any],
+) -> dict[str, Any]:
+    """Build spoon form defaults from stored spoon_sizes config data.
+
+    Converts the stored list of ``{"name": ..., "size_ml": ...}`` dicts
+    back into flat form field defaults for the spoon schema.
+
+    Args:
+        current: Current config data containing ``spoon_sizes`` key.
+
+    Returns:
+        Dictionary of form field defaults for ``_spoon_schema``.
+    """
+    defaults: dict[str, Any] = {}
+    spoon_list = current.get(CONF_SPOON_SIZES, [])
+    for i, (name_key, size_key) in enumerate(SPOON_PAIRS):
+        if i < len(spoon_list):
+            defaults[name_key] = spoon_list[i].get("name", "")
+            defaults[size_key] = spoon_list[i].get("size_ml", 0)
+        else:
+            defaults[name_key] = ""
+            defaults[size_key] = 0
+    return defaults
+
+
 class PoolmanConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Pool Manager."""
 
@@ -261,11 +344,27 @@ class PoolmanConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle the chemistry configuration step (treatment + sensors)."""
         if user_input is not None:
             self._user_input.update(user_input)
-            return await self.async_step_filtration()
+            return await self.async_step_spoons()
 
         return self.async_show_form(
             step_id="chemistry",
             data_schema=_chemistry_schema(),
+        )
+
+    async def async_step_spoons(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Handle the spoon size configuration step.
+
+        Optional step that lets users configure up to 3 named measuring
+        spoons. Dosage recommendations will include spoon equivalents
+        when spoon sizes are configured.
+        """
+        if user_input is not None:
+            self._user_input[CONF_SPOON_SIZES] = _parse_spoon_sizes(user_input)
+            return await self.async_step_filtration()
+
+        return self.async_show_form(
+            step_id="spoons",
+            data_schema=_spoon_schema(),
         )
 
     async def async_step_filtration(
@@ -301,7 +400,7 @@ class PoolmanOptionsFlowHandler(OptionsFlowWithConfigEntry):
         """Handle the options flow init step (chemistry settings)."""
         if user_input is not None:
             self._options.update(user_input)
-            return await self.async_step_filtration()
+            return await self.async_step_spoons()
 
         # Pre-populate with current values from options (fallback to data)
         current = {**self.config_entry.data, **self.config_entry.options}
@@ -309,6 +408,21 @@ class PoolmanOptionsFlowHandler(OptionsFlowWithConfigEntry):
         return self.async_show_form(
             step_id="init",
             data_schema=_chemistry_schema(defaults=current),
+        )
+
+    async def async_step_spoons(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Handle the spoon size options step."""
+        if user_input is not None:
+            self._options[CONF_SPOON_SIZES] = _parse_spoon_sizes(user_input)
+            return await self.async_step_filtration()
+
+        # Pre-populate with current spoon sizes
+        current = {**self.config_entry.data, **self.config_entry.options}
+        defaults = _spoon_defaults_from_config(current)
+
+        return self.async_show_form(
+            step_id="spoons",
+            data_schema=_spoon_schema(defaults=defaults),
         )
 
     async def async_step_filtration(

--- a/custom_components/poolman/const.py
+++ b/custom_components/poolman/const.py
@@ -15,6 +15,22 @@ CONF_SHAPE: Final = "shape"
 CONF_TREATMENT: Final = "treatment"
 CONF_FILTRATION_KIND: Final = "filtration_kind"
 CONF_PUMP_FLOW_M3H: Final = "pump_flow_m3h"
+CONF_SPOON_SIZES: Final = "spoon_sizes"
+
+# Spoon config flow field keys (3 optional pairs)
+CONF_SPOON_NAME_1: Final = "spoon_name_1"
+CONF_SPOON_SIZE_1: Final = "spoon_size_1"
+CONF_SPOON_NAME_2: Final = "spoon_name_2"
+CONF_SPOON_SIZE_2: Final = "spoon_size_2"
+CONF_SPOON_NAME_3: Final = "spoon_name_3"
+CONF_SPOON_SIZE_3: Final = "spoon_size_3"
+
+# Ordered pairs of spoon config keys
+SPOON_PAIRS: Final = [
+    (CONF_SPOON_NAME_1, CONF_SPOON_SIZE_1),
+    (CONF_SPOON_NAME_2, CONF_SPOON_SIZE_2),
+    (CONF_SPOON_NAME_3, CONF_SPOON_SIZE_3),
+]
 
 # Sensor entity config keys
 CONF_PH_ENTITY: Final = "ph_entity"

--- a/custom_components/poolman/coordinator.py
+++ b/custom_components/poolman/coordinator.py
@@ -28,6 +28,7 @@ from .const import (
     CONF_PUMP_FLOW_M3H,
     CONF_SALT_ENTITY,
     CONF_SHAPE,
+    CONF_SPOON_SIZES,
     CONF_STEPS,
     CONF_TAC_ENTITY,
     CONF_TEMPERATURE_ENTITY,
@@ -58,7 +59,10 @@ from .domain.model import (
     PoolReading,
     PoolShape,
     PoolState,
+    Recommendation,
+    SpoonSize,
     TreatmentType,
+    compute_spoon_equivalent,
     compute_status_changes,
 )
 from .domain.rules import RuleEngine
@@ -149,6 +153,12 @@ class PoolmanCoordinator(DataUpdateCoordinator[PoolState]):
             A Pool instance reflecting the current configuration.
         """
         data = self.config_entry.data
+        spoon_data = self._get_config(CONF_SPOON_SIZES, [])
+        spoon_sizes = [
+            SpoonSize(name=s["name"], size_ml=s["size_ml"])
+            for s in spoon_data
+            if isinstance(s, dict) and s.get("name") and s.get("size_ml")
+        ]
         return Pool(
             volume_m3=data[CONF_VOLUME_M3],
             shape=PoolShape(data[CONF_SHAPE]),
@@ -157,7 +167,45 @@ class PoolmanCoordinator(DataUpdateCoordinator[PoolState]):
                 self._get_config(CONF_FILTRATION_KIND, DEFAULT_FILTRATION_KIND)
             ),
             pump_flow_m3h=self._get_config(CONF_PUMP_FLOW_M3H),
+            spoon_sizes=spoon_sizes,
         )
+
+    def _enrich_recommendations_with_spoons(
+        self, recommendations: list[Recommendation]
+    ) -> list[Recommendation]:
+        """Add spoon equivalents to recommendations that have a dosage.
+
+        For each recommendation with a ``quantity_g`` and ``product``,
+        computes the equivalent number of configured measuring spoons
+        and returns a new list with enriched recommendations.
+
+        Args:
+            recommendations: Original recommendations from the rule engine.
+
+        Returns:
+            List of recommendations with ``spoon_count`` and ``spoon_name``
+            populated where applicable.
+        """
+        if not self.pool.spoon_sizes:
+            return recommendations
+
+        enriched: list[Recommendation] = []
+        for rec in recommendations:
+            if rec.quantity_g and rec.product:
+                try:
+                    product = ChemicalProduct(rec.product)
+                except ValueError:
+                    enriched.append(rec)
+                    continue
+
+                result = compute_spoon_equivalent(rec.quantity_g, product, self.pool.spoon_sizes)
+                if result is not None:
+                    count, spoon = result
+                    rec = rec.model_copy(
+                        update={"spoon_count": int(count), "spoon_name": spoon.name}
+                    )
+            enriched.append(rec)
+        return enriched
 
     @property
     def mode(self) -> PoolMode:
@@ -736,6 +784,7 @@ class PoolmanCoordinator(DataUpdateCoordinator[PoolState]):
         recommendations = self.engine.evaluate(
             self.pool, sensor_reading, self._mode, manual_measures=manual_measures
         )
+        recommendations = self._enrich_recommendations_with_spoons(recommendations)
         filtration_hours = compute_filtration_duration(self.pool, reading, self._mode)
         water_quality_score = compute_water_quality_score(reading)
         chemistry_report = compute_chemistry_report(reading)

--- a/custom_components/poolman/domain/model.py
+++ b/custom_components/poolman/domain/model.py
@@ -118,6 +118,40 @@ class ChemicalProduct(StrEnum):
     WINTERIZING_PRODUCT = "winterizing_product"
 
 
+# Products that come as tablets and cannot be measured with a spoon
+TABLET_PRODUCTS: frozenset[ChemicalProduct] = frozenset(
+    {
+        ChemicalProduct.GALET_CHLORE,
+        ChemicalProduct.BROMINE_TABLET,
+        ChemicalProduct.ACTIVE_OXYGEN_TABLET,
+    }
+)
+
+# Approximate bulk density (g/mL) for each chemical product.
+# Used to convert gram-based dosages to volume (mL) for spoon equivalents.
+# Sources: typical pool chemical product data sheets.
+PRODUCT_DENSITY_G_PER_ML: dict[ChemicalProduct, float] = {
+    ChemicalProduct.PH_MINUS: 1.1,  # Sodium bisulfate, dense granules
+    ChemicalProduct.PH_PLUS: 0.55,  # Sodium carbonate (soda ash), light powder
+    ChemicalProduct.CHLORE_CHOC: 0.9,  # Calcium hypochlorite / dichlor granules
+    ChemicalProduct.GALET_CHLORE: 1.0,  # Pressed tablets (not spoon-measured)
+    ChemicalProduct.NEUTRALIZER: 1.1,  # Sodium thiosulfate granules
+    ChemicalProduct.TAC_PLUS: 0.9,  # Sodium bicarbonate powder
+    ChemicalProduct.SALT: 1.2,  # NaCl crystals
+    ChemicalProduct.BROMINE_TABLET: 1.0,  # Pressed tablets (not spoon-measured)
+    ChemicalProduct.BROMINE_SHOCK: 0.8,  # Bromine granules
+    ChemicalProduct.ACTIVE_OXYGEN_TABLET: 1.0,  # Pressed tablets (not spoon-measured)
+    ChemicalProduct.ACTIVE_OXYGEN_ACTIVATOR: 1.0,  # Liquid
+    ChemicalProduct.FLOCCULANT: 1.0,  # Liquid
+    ChemicalProduct.ANTI_ALGAE: 1.0,  # Liquid
+    ChemicalProduct.STABILIZER: 0.75,  # Cyanuric acid granules, low density
+    ChemicalProduct.CLARIFIER: 1.0,  # Liquid
+    ChemicalProduct.METAL_SEQUESTRANT: 1.1,  # Liquid, slightly dense
+    ChemicalProduct.CALCIUM_HARDNESS_INCREASER: 0.85,  # CaCl2 flakes/powder
+    ChemicalProduct.WINTERIZING_PRODUCT: 1.0,  # Liquid
+}
+
+
 class ChemistryStatus(StrEnum):
     """Status levels for individual chemistry parameters."""
 
@@ -206,6 +240,22 @@ class ChemistryReport(BaseModel, frozen=True):
     hardness: ParameterReport | None = None
 
 
+class SpoonSize(BaseModel, frozen=True):
+    """A named measuring spoon with a known volume.
+
+    Spoon sizes are global (not per-product) and are used to express
+    dosage recommendations as a number of scoops/spoons alongside the
+    native gram-based quantity.
+
+    Attributes:
+        name: Human-readable label for the spoon (e.g. "Small", "Large").
+        size_ml: Volume of the spoon in milliliters.
+    """
+
+    name: str
+    size_ml: float = Field(gt=0, description="Volume of the spoon in milliliters")
+
+
 class Pool(BaseModel):
     """Physical characteristics of a pool."""
 
@@ -215,11 +265,81 @@ class Pool(BaseModel):
     treatment: TreatmentType = TreatmentType.CHLORINE
     filtration_kind: FiltrationKind = FiltrationKind.SAND
     pump_flow_m3h: float = Field(gt=0, description="Pump flow rate in m3/h")
+    spoon_sizes: list[SpoonSize] = Field(
+        default_factory=list,
+        description="Configured measuring spoon sizes for dosage display",
+    )
 
     @property
     def turnovers_per_day(self) -> float:
         """Calculate how many full water turnovers per day at 24h operation."""
         return (self.pump_flow_m3h * 24) / self.volume_m3
+
+
+def compute_spoon_equivalent(
+    quantity_g: float,
+    product: ChemicalProduct,
+    spoon_sizes: list[SpoonSize],
+) -> tuple[float, SpoonSize] | None:
+    """Convert a gram-based dosage to a spoon count using the best-fit spoon.
+
+    Converts the gram quantity to milliliters using the product's bulk density,
+    then selects the spoon size that produces the smallest relative rounding
+    error when rounded to the nearest whole number of spoons.
+
+    Args:
+        quantity_g: Dosage amount in grams.
+        product: The chemical product (used for density lookup).
+        spoon_sizes: Available measuring spoon sizes.
+
+    Returns:
+        A tuple of ``(spoon_count, spoon)`` where ``spoon_count`` is the
+        rounded number of spoons, or ``None`` if no spoon sizes are
+        configured, the product is a tablet, the quantity is zero,
+        or the density is unknown.
+    """
+    if not spoon_sizes or product in TABLET_PRODUCTS or quantity_g <= 0:
+        return None
+
+    density = PRODUCT_DENSITY_G_PER_ML.get(product)
+    if density is None or density <= 0:
+        return None
+
+    quantity_ml = quantity_g / density
+
+    best_spoon: SpoonSize | None = None
+    best_count: float = 0
+    best_error: float = float("inf")
+
+    for spoon in spoon_sizes:
+        exact_count = quantity_ml / spoon.size_ml
+        rounded_count = max(1, round(exact_count))
+        # Relative error: how far the rounded count is from the exact count
+        error = abs(rounded_count - exact_count) / exact_count if exact_count > 0 else float("inf")
+        if error < best_error:
+            best_error = error
+            best_count = rounded_count
+            best_spoon = spoon
+
+    if best_spoon is None:
+        return None
+
+    return (best_count, best_spoon)
+
+
+def format_spoon_text(spoon_count: float, spoon_name: str) -> str:
+    """Format a spoon count and name into a human-readable string.
+
+    Args:
+        spoon_count: Number of spoons (typically a whole number).
+        spoon_name: Name of the spoon size.
+
+    Returns:
+        Formatted string like ``"6 Large spoons"`` or ``"1 Small spoon"``.
+    """
+    count_int = int(spoon_count)
+    unit = "spoon" if count_int == 1 else "spoons"
+    return f"{count_int} {spoon_name} {unit}"
 
 
 class PoolReading(BaseModel):
@@ -249,12 +369,25 @@ class Recommendation(BaseModel):
     message: str
     product: str | None = None
     quantity_g: float | None = Field(None, ge=0, description="Quantity in grams")
+    spoon_count: int | None = Field(None, ge=0, description="Equivalent number of spoons")
+    spoon_name: str | None = Field(
+        None, description="Name of the spoon size used for the equivalent"
+    )
 
     def __str__(self) -> str:
         """Return human-readable recommendation."""
+        base = self.message
         if self.quantity_g and self.product:
-            return f"{self.message} ({self.quantity_g:.0f}g of {self.product})"
-        return self.message
+            base = f"{base} ({self.quantity_g:.0f}g of {self.product})"
+        if self.spoon_count is not None and self.spoon_name is not None:
+            spoon_text = format_spoon_text(self.spoon_count, self.spoon_name)
+            if self.quantity_g and self.product:
+                # Append spoon info after the gram info: "msg (300g of ph_minus, 6 Large spoons)"
+                # Replace last ')' with ', spoon_text)'
+                base = base[:-1] + f", {spoon_text})"
+            else:
+                base = f"{base} ({spoon_text})"
+        return base
 
 
 class ManualMeasure(BaseModel, frozen=True):

--- a/custom_components/poolman/sensor.py
+++ b/custom_components/poolman/sensor.py
@@ -192,6 +192,8 @@ SENSOR_DESCRIPTIONS: tuple[PoolmanSensorEntityDescription, ...] = (
                     "message": r.message,
                     "product": r.product,
                     "quantity_g": r.quantity_g,
+                    "spoon_count": r.spoon_count,
+                    "spoon_name": r.spoon_name,
                 }
                 for r in state.chemistry_actions
             ],

--- a/custom_components/poolman/services.yaml
+++ b/custom_components/poolman/services.yaml
@@ -44,6 +44,19 @@ add_treatment:
           step: 1
           unit_of_measurement: g
           mode: box
+    spoons:
+      name: Spoons
+      description: Number of measuring spoons used. Requires spoon_name to be set.
+      selector:
+        number:
+          min: 0
+          step: 0.5
+          mode: box
+    spoon_name:
+      name: Spoon name
+      description: Name of the configured measuring spoon to use.
+      selector:
+        text:
     notes:
       name: Notes
       description: Optional notes about the treatment.

--- a/custom_components/poolman/strings.json
+++ b/custom_components/poolman/strings.json
@@ -57,6 +57,26 @@
           "outdoor_temperature_entity": "Optional. Outdoor temperature sensor for heat stress adjustment.",
           "weather_entity": "Optional. Weather integration entity (temperature attribute is used as fallback for outdoor temperature)."
         }
+      },
+      "spoons": {
+        "title": "Measuring spoons",
+        "description": "Optional. Configure your measuring spoons to display dosage recommendations as a number of scoops alongside grams. You can define up to 3 spoon sizes.",
+        "data": {
+          "spoon_name_1": "Spoon 1 name",
+          "spoon_size_1": "Spoon 1 volume",
+          "spoon_name_2": "Spoon 2 name",
+          "spoon_size_2": "Spoon 2 volume",
+          "spoon_name_3": "Spoon 3 name",
+          "spoon_size_3": "Spoon 3 volume"
+        },
+        "data_description": {
+          "spoon_name_1": "Name of the first measuring spoon (e.g. Small, Large).",
+          "spoon_size_1": "Volume in milliliters.",
+          "spoon_name_2": "Name of the second measuring spoon.",
+          "spoon_size_2": "Volume in milliliters.",
+          "spoon_name_3": "Name of the third measuring spoon.",
+          "spoon_size_3": "Volume in milliliters."
+        }
       }
     },
     "error": {
@@ -177,6 +197,26 @@
           "pump_entity": "Optional. Switch entity to control the pump.",
           "outdoor_temperature_entity": "Optional. Outdoor temperature sensor for heat stress adjustment.",
           "weather_entity": "Optional. Weather integration entity (temperature attribute is used as fallback for outdoor temperature)."
+        }
+      },
+      "spoons": {
+        "title": "Measuring spoons",
+        "description": "Optional. Configure your measuring spoons to display dosage recommendations as a number of scoops alongside grams.",
+        "data": {
+          "spoon_name_1": "Spoon 1 name",
+          "spoon_size_1": "Spoon 1 volume",
+          "spoon_name_2": "Spoon 2 name",
+          "spoon_size_2": "Spoon 2 volume",
+          "spoon_name_3": "Spoon 3 name",
+          "spoon_size_3": "Spoon 3 volume"
+        },
+        "data_description": {
+          "spoon_name_1": "Name of the first measuring spoon (e.g. Small, Large).",
+          "spoon_size_1": "Volume in milliliters.",
+          "spoon_name_2": "Name of the second measuring spoon.",
+          "spoon_size_2": "Volume in milliliters.",
+          "spoon_name_3": "Name of the third measuring spoon.",
+          "spoon_size_3": "Volume in milliliters."
         }
       }
     }
@@ -730,6 +770,14 @@
         "quantity_g": {
           "name": "Quantity (g)",
           "description": "Amount of product used in grams."
+        },
+        "spoons": {
+          "name": "Spoons",
+          "description": "Number of measuring spoons used. Requires spoon name to be set."
+        },
+        "spoon_name": {
+          "name": "Spoon name",
+          "description": "Name of the configured measuring spoon to use."
         },
         "notes": {
           "name": "Notes",

--- a/custom_components/poolman/translations/en.json
+++ b/custom_components/poolman/translations/en.json
@@ -57,6 +57,26 @@
           "outdoor_temperature_entity": "Optional. Outdoor temperature sensor for heat stress adjustment.",
           "weather_entity": "Optional. Weather integration entity (temperature attribute is used as fallback for outdoor temperature)."
         }
+      },
+      "spoons": {
+        "title": "Measuring spoons",
+        "description": "Optional. Configure your measuring spoons to display dosage recommendations as a number of scoops alongside grams. You can define up to 3 spoon sizes.",
+        "data": {
+          "spoon_name_1": "Spoon 1 name",
+          "spoon_size_1": "Spoon 1 volume",
+          "spoon_name_2": "Spoon 2 name",
+          "spoon_size_2": "Spoon 2 volume",
+          "spoon_name_3": "Spoon 3 name",
+          "spoon_size_3": "Spoon 3 volume"
+        },
+        "data_description": {
+          "spoon_name_1": "Name of the first measuring spoon (e.g. Small, Large).",
+          "spoon_size_1": "Volume in milliliters.",
+          "spoon_name_2": "Name of the second measuring spoon.",
+          "spoon_size_2": "Volume in milliliters.",
+          "spoon_name_3": "Name of the third measuring spoon.",
+          "spoon_size_3": "Volume in milliliters."
+        }
       }
     },
     "error": {
@@ -177,6 +197,26 @@
           "pump_entity": "Optional. Switch entity to control the pump.",
           "outdoor_temperature_entity": "Optional. Outdoor temperature sensor for heat stress adjustment.",
           "weather_entity": "Optional. Weather integration entity (temperature attribute is used as fallback for outdoor temperature)."
+        }
+      },
+      "spoons": {
+        "title": "Measuring spoons",
+        "description": "Optional. Configure your measuring spoons to display dosage recommendations as a number of scoops alongside grams.",
+        "data": {
+          "spoon_name_1": "Spoon 1 name",
+          "spoon_size_1": "Spoon 1 volume",
+          "spoon_name_2": "Spoon 2 name",
+          "spoon_size_2": "Spoon 2 volume",
+          "spoon_name_3": "Spoon 3 name",
+          "spoon_size_3": "Spoon 3 volume"
+        },
+        "data_description": {
+          "spoon_name_1": "Name of the first measuring spoon (e.g. Small, Large).",
+          "spoon_size_1": "Volume in milliliters.",
+          "spoon_name_2": "Name of the second measuring spoon.",
+          "spoon_size_2": "Volume in milliliters.",
+          "spoon_name_3": "Name of the third measuring spoon.",
+          "spoon_size_3": "Volume in milliliters."
         }
       }
     }
@@ -730,6 +770,14 @@
         "quantity_g": {
           "name": "Quantity (g)",
           "description": "Amount of product used in grams."
+        },
+        "spoons": {
+          "name": "Spoons",
+          "description": "Number of measuring spoons used. Requires spoon name to be set."
+        },
+        "spoon_name": {
+          "name": "Spoon name",
+          "description": "Name of the configured measuring spoon to use."
         },
         "notes": {
           "name": "Notes",

--- a/custom_components/poolman/translations/fr.json
+++ b/custom_components/poolman/translations/fr.json
@@ -57,6 +57,26 @@
           "outdoor_temperature_entity": "Optionnel. Capteur de temp\u00e9rature ext\u00e9rieure pour l'ajustement canicule.",
           "weather_entity": "Optionnel. Entit\u00e9 d'int\u00e9gration m\u00e9t\u00e9o (l'attribut temp\u00e9rature est utilis\u00e9 comme alternative pour la temp\u00e9rature ext\u00e9rieure)."
         }
+      },
+      "spoons": {
+        "title": "Cuill\u00e8res doseuses",
+        "description": "Optionnel. Configurez vos cuill\u00e8res doseuses pour afficher les recommandations de dosage en nombre de cuill\u00e8res en plus des grammes. Vous pouvez d\u00e9finir jusqu'\u00e0 3 tailles de cuill\u00e8res.",
+        "data": {
+          "spoon_name_1": "Nom cuill\u00e8re 1",
+          "spoon_size_1": "Volume cuill\u00e8re 1",
+          "spoon_name_2": "Nom cuill\u00e8re 2",
+          "spoon_size_2": "Volume cuill\u00e8re 2",
+          "spoon_name_3": "Nom cuill\u00e8re 3",
+          "spoon_size_3": "Volume cuill\u00e8re 3"
+        },
+        "data_description": {
+          "spoon_name_1": "Nom de la premi\u00e8re cuill\u00e8re doseuse (ex. Petite, Grande).",
+          "spoon_size_1": "Volume en millilitres.",
+          "spoon_name_2": "Nom de la deuxi\u00e8me cuill\u00e8re doseuse.",
+          "spoon_size_2": "Volume en millilitres.",
+          "spoon_name_3": "Nom de la troisi\u00e8me cuill\u00e8re doseuse.",
+          "spoon_size_3": "Volume en millilitres."
+        }
       }
     },
     "error": {
@@ -177,6 +197,26 @@
           "pump_entity": "Optionnel. Interrupteur pour contr\u00f4ler la pompe.",
           "outdoor_temperature_entity": "Optionnel. Capteur de temp\u00e9rature ext\u00e9rieure pour l'ajustement canicule.",
           "weather_entity": "Optionnel. Entit\u00e9 d'int\u00e9gration m\u00e9t\u00e9o (l'attribut temp\u00e9rature est utilis\u00e9 comme alternative pour la temp\u00e9rature ext\u00e9rieure)."
+        }
+      },
+      "spoons": {
+        "title": "Cuill\u00e8res doseuses",
+        "description": "Optionnel. Configurez vos cuill\u00e8res doseuses pour afficher les recommandations de dosage en nombre de cuill\u00e8res en plus des grammes.",
+        "data": {
+          "spoon_name_1": "Nom cuill\u00e8re 1",
+          "spoon_size_1": "Volume cuill\u00e8re 1",
+          "spoon_name_2": "Nom cuill\u00e8re 2",
+          "spoon_size_2": "Volume cuill\u00e8re 2",
+          "spoon_name_3": "Nom cuill\u00e8re 3",
+          "spoon_size_3": "Volume cuill\u00e8re 3"
+        },
+        "data_description": {
+          "spoon_name_1": "Nom de la premi\u00e8re cuill\u00e8re doseuse (ex. Petite, Grande).",
+          "spoon_size_1": "Volume en millilitres.",
+          "spoon_name_2": "Nom de la deuxi\u00e8me cuill\u00e8re doseuse.",
+          "spoon_size_2": "Volume en millilitres.",
+          "spoon_name_3": "Nom de la troisi\u00e8me cuill\u00e8re doseuse.",
+          "spoon_size_3": "Volume en millilitres."
         }
       }
     }
@@ -730,6 +770,14 @@
         "quantity_g": {
           "name": "Quantit\u00e9 (g)",
           "description": "Quantit\u00e9 de produit utilis\u00e9e en grammes."
+        },
+        "spoons": {
+          "name": "Cuill\u00e8res",
+          "description": "Nombre de cuill\u00e8res doseuses utilis\u00e9es. N\u00e9cessite de sp\u00e9cifier le nom de la cuill\u00e8re."
+        },
+        "spoon_name": {
+          "name": "Nom de la cuill\u00e8re",
+          "description": "Nom de la cuill\u00e8re doseuse configur\u00e9e \u00e0 utiliser."
         },
         "notes": {
           "name": "Notes",

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -58,9 +58,20 @@ state attributes:
 
 | Attribute | Type | Description |
 | --- | --- | --- |
-| `actions` | list of objects | Each action includes `kind` (suggestion/requirement), `message`, `product`, and `quantity_g` |
+| `actions` | list of objects | Each action includes `kind` (suggestion/requirement), `message`, `product`, `quantity_g`, `spoon_count`, and `spoon_name` |
 | `suggestion_count` | integer | Number of actions classified as suggestions |
 | `requirement_count` | integer | Number of actions classified as requirements |
+
+When [measuring spoon sizes](getting-started.md#step-3-measuring-spoons) are
+configured, each action object also includes:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `spoon_count` | integer or null | Number of spoons equivalent to the gram dosage (null for tablet products or when no spoons are configured) |
+| `spoon_name` | string or null | Name of the selected spoon size (null when spoon_count is null) |
+
+See [Spoon Equivalents](water-chemistry.md#spoon-equivalents) for details on
+how spoon counts are calculated.
 
 Actions are classified as either **suggestions** (optional improvements)
 or **requirements** (needed to keep the pool safe).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -80,7 +80,7 @@ Or manually add as a custom repository:
 
 Or go to **Settings > Devices & Services > Add Integration** and search for **Pool Manager**.
 
-The integration is configured through a three-step UI flow. No YAML configuration is needed.
+The integration is configured through a four-step UI flow. No YAML configuration is needed.
 
 ### Step 1: Pool basics
 
@@ -122,9 +122,39 @@ bromine-treated pool will receive bromine tablet recommendations.
 | CYA entity | entity (sensor) | Cyanuric Acid / Stabilizer sensor |
 | Hardness entity | entity (sensor) | Calcium Hardness sensor |
 
-### Step 3: Filtration
+### Step 3: Measuring spoons
 
-The third step configures your filtration system.
+The third step lets you configure up to three named measuring spoon sizes.
+When spoon sizes are defined, dosage recommendations will include an
+approximate number of spoons alongside the gram-based quantity
+(see [Spoon Equivalents](water-chemistry.md#spoon-equivalents)).
+
+This step is entirely optional -- you can skip it by submitting the form
+without filling in any spoon names.
+
+#### Optional parameters (up to 3 pairs)
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| Spoon name | text | Label for the spoon (e.g. "Small", "Large", "Tablespoon") |
+| Spoon size | number (mL) | Volume of the spoon in milliliters |
+
+Only pairs where both the name is non-empty and the size is greater than
+zero are saved.
+
+!!! tip "Common spoon sizes"
+
+    | Spoon | Approximate volume |
+    | --- | --- |
+    | Teaspoon | 5 mL |
+    | Dessertspoon | 10 mL |
+    | Tablespoon | 15 mL |
+    | Pool scoop (small) | 25 mL |
+    | Pool scoop (large) | 50 mL |
+
+### Step 4: Filtration
+
+The fourth step configures your filtration system.
 
 #### Required parameters
 
@@ -162,8 +192,9 @@ through the integration's options:
 
 1. Go to **Settings > Devices & Services**
 2. Find **Pool Manager** and click **Configure**
-3. Update the treatment type, chemistry sensors, filtration type, pump flow rate,
-   temperature sensor, outdoor temperature sensor, weather entity, or pump entity
+3. Update the treatment type, chemistry sensors, spoon sizes, filtration type,
+   pump flow rate, temperature sensor, outdoor temperature sensor, weather entity,
+   or pump entity
 
 Changes take effect immediately -- the integration reloads automatically.
 

--- a/docs/water-chemistry.md
+++ b/docs/water-chemistry.md
@@ -270,3 +270,83 @@ Where **3 kg of salt per m³** raises salt level by **1000 ppm**.
     The salt rule only activates when the pool treatment type is set to
     **Salt electrolysis**. For other treatment types, salt level is still
     tracked if a sensor is configured, but no recommendations are generated.
+
+## Spoon Equivalents
+
+When [measuring spoon sizes](getting-started.md#step-3-measuring-spoons) are
+configured, dosage recommendations include an approximate number of spoons
+alongside the gram-based quantity. This makes it easier to measure products
+in practice without a scale.
+
+### How it works
+
+Each chemical product has an approximate bulk density (g/mL) that is used to
+convert grams to milliliters. The volume is then divided by the spoon size
+to determine the number of spoons.
+
+$$
+\text{spoons} = \frac{\text{quantity\_g} / \text{density}}{\text{spoon\_size\_ml}}
+$$
+
+When multiple spoon sizes are configured, the integration selects the one
+that minimizes rounding error when rounded to a whole number of spoons
+(the **best-fit** strategy).
+
+### Product density table
+
+| Product | Density (g/mL) | Notes |
+| --- | --- | --- |
+| pH- (sodium bisulfate) | 1.1 | Dense granules |
+| pH+ (sodium carbonate) | 0.55 | Light powder |
+| Shock chlorine (dichlor) | 0.9 | Granules |
+| Neutralizer (sodium thiosulfate) | 1.1 | Granules |
+| TAC+ (sodium bicarbonate) | 0.9 | Powder |
+| Salt (NaCl) | 1.2 | Crystals |
+| Bromine shock | 0.8 | Granules |
+| Stabilizer (cyanuric acid) | 0.75 | Low density granules |
+| Calcium hardness increaser (CaCl₂) | 0.85 | Flakes / powder |
+| Active oxygen activator | 1.0 | Liquid |
+| Flocculant | 1.0 | Liquid |
+| Anti-algae | 1.0 | Liquid |
+| Clarifier | 1.0 | Liquid |
+| Metal sequestrant | 1.1 | Liquid |
+| Winterizing product | 1.0 | Liquid |
+
+### Tablet products
+
+Tablet products (chlorine tablets, bromine tablets, active oxygen tablets) are
+excluded from spoon equivalents because they are not measured with spoons.
+
+### Recommendation display
+
+When spoon equivalents are available, the recommendation message format is:
+
+```text
+Add 300g of ph_minus (300g of ph_minus, 18 Large spoons)
+```
+
+The `spoon_count` and `spoon_name` values are also available as
+[sensor attributes](entities.md#chemistry-actions-sensor-attributes)
+for use in dashboards and automations.
+
+### Service input
+
+The `poolman.add_treatment` service accepts spoon-based input as an
+alternative to grams:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `spoons` | float | Number of spoons used |
+| `spoon_name` | string | Name of the configured spoon size |
+
+When `spoons` and `spoon_name` are provided (and `quantity_g` is omitted),
+the service converts the spoon count to grams using the product's density
+and the named spoon's volume.
+
+??? example "Spoon equivalent example"
+
+    With a "Large" spoon (15 mL) and pH- (density 1.1 g/mL):
+
+    - Dosage: 300 g
+    - Volume: 300 / 1.1 = 272.7 mL
+    - Spoons: 272.7 / 15 = 18.2, rounded to **18 Large spoons**

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ from custom_components.poolman.const import (
     CONF_PUMP_ENTITY,
     CONF_PUMP_FLOW_M3H,
     CONF_SHAPE,
+    CONF_SPOON_SIZES,
     CONF_TEMPERATURE_ENTITY,
     CONF_TREATMENT,
     CONF_VOLUME_M3,
@@ -35,6 +36,7 @@ MOCK_CONFIG_DATA: dict[str, Any] = {
     CONF_ORP_ENTITY: "sensor.pool_orp",
     CONF_TEMPERATURE_ENTITY: "sensor.pool_temperature",
     CONF_PUMP_ENTITY: "switch.pool_pump",
+    CONF_SPOON_SIZES: [],
 }
 
 

--- a/tests/domain/test_model.py
+++ b/tests/domain/test_model.py
@@ -7,7 +7,10 @@ from datetime import UTC, datetime
 import pytest
 
 from custom_components.poolman.domain.model import (
+    PRODUCT_DENSITY_G_PER_ML,
+    TABLET_PRODUCTS,
     ActionKind,
+    ChemicalProduct,
     ChemistryReport,
     ChemistryStatus,
     ManualMeasure,
@@ -18,8 +21,11 @@ from custom_components.poolman.domain.model import (
     Recommendation,
     RecommendationPriority,
     RecommendationType,
+    SpoonSize,
     StatusChange,
+    compute_spoon_equivalent,
     compute_status_changes,
+    format_spoon_text,
 )
 
 
@@ -496,3 +502,189 @@ class TestPoolStateManualMeasures:
         state = PoolState(reading_sources={"ph": "sensor", "orp": "manual"})
         assert state.reading_sources["ph"] == "sensor"
         assert state.reading_sources["orp"] == "manual"
+
+
+class TestSpoonSize:
+    """Tests for SpoonSize model."""
+
+    def test_creation(self) -> None:
+        spoon = SpoonSize(name="Small", size_ml=20.0)
+        assert spoon.name == "Small"
+        assert spoon.size_ml == 20.0
+
+    def test_frozen(self) -> None:
+        from pydantic import ValidationError
+
+        spoon = SpoonSize(name="Small", size_ml=20.0)
+        with pytest.raises(ValidationError):
+            spoon.name = "Large"  # type: ignore[misc]  # ty: ignore[invalid-assignment]
+
+    def test_size_must_be_positive(self) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            SpoonSize(name="Bad", size_ml=0)
+        with pytest.raises(ValidationError):
+            SpoonSize(name="Bad", size_ml=-5)
+
+    def test_equality(self) -> None:
+        s1 = SpoonSize(name="Small", size_ml=20.0)
+        s2 = SpoonSize(name="Small", size_ml=20.0)
+        assert s1 == s2
+
+
+class TestPoolSpoonSizes:
+    """Tests for Pool.spoon_sizes field."""
+
+    def test_default_empty(self) -> None:
+        pool = Pool(name="Test", volume_m3=50, pump_flow_m3h=10)
+        assert pool.spoon_sizes == []
+
+    def test_with_spoon_sizes(self) -> None:
+        spoons = [
+            SpoonSize(name="Small", size_ml=20),
+            SpoonSize(name="Large", size_ml=50),
+        ]
+        pool = Pool(name="Test", volume_m3=50, pump_flow_m3h=10, spoon_sizes=spoons)
+        assert len(pool.spoon_sizes) == 2
+        assert pool.spoon_sizes[0].name == "Small"
+        assert pool.spoon_sizes[1].name == "Large"
+
+
+class TestProductDensityTable:
+    """Tests for the product density table."""
+
+    def test_all_products_have_density(self) -> None:
+        """Every ChemicalProduct should have a density entry."""
+        for product in ChemicalProduct:
+            assert product in PRODUCT_DENSITY_G_PER_ML, f"Missing density for {product}"
+
+    def test_all_densities_positive(self) -> None:
+        for product, density in PRODUCT_DENSITY_G_PER_ML.items():
+            assert density > 0, f"Density for {product} must be positive"
+
+
+class TestTabletProducts:
+    """Tests for TABLET_PRODUCTS constant."""
+
+    def test_expected_tablet_products(self) -> None:
+        assert ChemicalProduct.GALET_CHLORE in TABLET_PRODUCTS
+        assert ChemicalProduct.BROMINE_TABLET in TABLET_PRODUCTS
+        assert ChemicalProduct.ACTIVE_OXYGEN_TABLET in TABLET_PRODUCTS
+
+    def test_non_tablet_products_excluded(self) -> None:
+        assert ChemicalProduct.PH_MINUS not in TABLET_PRODUCTS
+        assert ChemicalProduct.CHLORE_CHOC not in TABLET_PRODUCTS
+        assert ChemicalProduct.STABILIZER not in TABLET_PRODUCTS
+
+
+class TestComputeSpoonEquivalent:
+    """Tests for compute_spoon_equivalent."""
+
+    @pytest.fixture
+    def small_spoon(self) -> SpoonSize:
+        return SpoonSize(name="Small", size_ml=20.0)
+
+    @pytest.fixture
+    def large_spoon(self) -> SpoonSize:
+        return SpoonSize(name="Large", size_ml=50.0)
+
+    def test_no_spoon_sizes_returns_none(self) -> None:
+        result = compute_spoon_equivalent(300.0, ChemicalProduct.PH_MINUS, [])
+        assert result is None
+
+    def test_tablet_product_returns_none(self, small_spoon: SpoonSize) -> None:
+        result = compute_spoon_equivalent(300.0, ChemicalProduct.GALET_CHLORE, [small_spoon])
+        assert result is None
+
+    def test_zero_quantity_returns_none(self, small_spoon: SpoonSize) -> None:
+        result = compute_spoon_equivalent(0.0, ChemicalProduct.PH_MINUS, [small_spoon])
+        assert result is None
+
+    def test_negative_quantity_returns_none(self, small_spoon: SpoonSize) -> None:
+        result = compute_spoon_equivalent(-10.0, ChemicalProduct.PH_MINUS, [small_spoon])
+        assert result is None
+
+    def test_single_spoon_exact_fit(self, small_spoon: SpoonSize) -> None:
+        """pH- density is 1.1 g/mL. 220g = 200 mL = 10 small spoons (20mL each)."""
+        result = compute_spoon_equivalent(220.0, ChemicalProduct.PH_MINUS, [small_spoon])
+        assert result is not None
+        count, spoon = result
+        assert count == 10
+        assert spoon.name == "Small"
+
+    def test_single_spoon_rounded(self, large_spoon: SpoonSize) -> None:
+        """pH- density is 1.1 g/mL. 300g = 272.7 mL. 272.7/50 = 5.45 -> rounds to 5."""
+        result = compute_spoon_equivalent(300.0, ChemicalProduct.PH_MINUS, [large_spoon])
+        assert result is not None
+        count, spoon = result
+        assert count == 5
+        assert spoon.name == "Large"
+
+    def test_best_fit_picks_least_error(
+        self, small_spoon: SpoonSize, large_spoon: SpoonSize
+    ) -> None:
+        """Should pick the spoon that minimizes rounding error."""
+        # pH+ density is 0.55 g/mL. 55g ≈ 100 mL.
+        # Small (20mL): 100/20 = 5.0 -> near-exact fit
+        # Large (50mL): 100/50 = 2.0 -> near-exact fit
+        # Both are essentially exact; either is a valid result.
+        result = compute_spoon_equivalent(55.0, ChemicalProduct.PH_PLUS, [small_spoon, large_spoon])
+        assert result is not None
+        count, spoon = result
+        # Both spoons produce near-exact fits; verify a valid spoon was chosen
+        assert (count == 5 and spoon.name == "Small") or (count == 2 and spoon.name == "Large")
+
+    def test_best_fit_prefers_closer_match(self) -> None:
+        """Should pick the spoon that gives the closer rounded count."""
+        small = SpoonSize(name="Small", size_ml=15.0)
+        large = SpoonSize(name="Large", size_ml=40.0)
+        # TAC+ density is 0.9 g/mL. 180g = 200 mL.
+        # Small (15mL): 200/15 = 13.33 -> rounds to 13, error = 0.33/13.33 = 0.025
+        # Large (40mL): 200/40 = 5.0 -> rounds to 5, error = 0
+        result = compute_spoon_equivalent(180.0, ChemicalProduct.TAC_PLUS, [small, large])
+        assert result is not None
+        count, spoon = result
+        assert count == 5
+        assert spoon.name == "Large"
+
+    def test_minimum_one_spoon(self, large_spoon: SpoonSize) -> None:
+        """Very small quantities should still return at least 1 spoon."""
+        # pH- density 1.1 g/mL. 1g = 0.91 mL. 0.91/50 = 0.018 -> rounds to 0, clamped to 1
+        result = compute_spoon_equivalent(1.0, ChemicalProduct.PH_MINUS, [large_spoon])
+        assert result is not None
+        count, _ = result
+        assert count >= 1
+
+    def test_low_density_product(self, small_spoon: SpoonSize) -> None:
+        """pH+ has low density (0.55 g/mL), so same grams = more volume."""
+        # 110g pH+ = 200 mL = 10 small spoons
+        result = compute_spoon_equivalent(110.0, ChemicalProduct.PH_PLUS, [small_spoon])
+        assert result is not None
+        count, spoon = result
+        assert count == 10
+        assert spoon.name == "Small"
+
+    def test_all_tablet_products_return_none(self, small_spoon: SpoonSize) -> None:
+        """All tablet products should return None."""
+        for product in TABLET_PRODUCTS:
+            result = compute_spoon_equivalent(100.0, product, [small_spoon])
+            assert result is None, f"Expected None for tablet product {product}"
+
+
+class TestFormatSpoonText:
+    """Tests for format_spoon_text."""
+
+    def test_singular(self) -> None:
+        assert format_spoon_text(1, "Large") == "1 Large spoon"
+
+    def test_plural(self) -> None:
+        assert format_spoon_text(5, "Small") == "5 Small spoons"
+
+    def test_zero_spoons(self) -> None:
+        # Edge case: 0 spoons should say "spoons" (plural)
+        assert format_spoon_text(0, "Small") == "0 Small spoons"
+
+    def test_float_count_truncated(self) -> None:
+        # Float is truncated to int for display
+        assert format_spoon_text(3.7, "Medium") == "3 Medium spoons"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -18,6 +18,11 @@ from custom_components.poolman.const import (
     CONF_POOL_NAME,
     CONF_PUMP_FLOW_M3H,
     CONF_SHAPE,
+    CONF_SPOON_NAME_1,
+    CONF_SPOON_NAME_2,
+    CONF_SPOON_SIZE_1,
+    CONF_SPOON_SIZE_2,
+    CONF_SPOON_SIZES,
     CONF_STARTED_AT,
     CONF_STEPS,
     CONF_TARGET_MODE,
@@ -70,11 +75,20 @@ class TestConfigFlow:
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "chemistry"
 
-    async def test_filtration_step_shows_form(self, hass: HomeAssistant) -> None:
-        """After chemistry step, filtration form should be shown."""
+    async def test_spoons_step_shows_form(self, hass: HomeAssistant) -> None:
+        """After chemistry step, spoons form should be shown."""
         result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": SOURCE_USER})
         result = await hass.config_entries.flow.async_configure(result["flow_id"], POOL_INPUT)
         result = await hass.config_entries.flow.async_configure(result["flow_id"], CHEMISTRY_INPUT)
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "spoons"
+
+    async def test_filtration_step_shows_form(self, hass: HomeAssistant) -> None:
+        """After spoons step, filtration form should be shown."""
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": SOURCE_USER})
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], POOL_INPUT)
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], CHEMISTRY_INPUT)
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "filtration"
 
@@ -83,6 +97,7 @@ class TestConfigFlow:
         result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": SOURCE_USER})
         result = await hass.config_entries.flow.async_configure(result["flow_id"], POOL_INPUT)
         result = await hass.config_entries.flow.async_configure(result["flow_id"], CHEMISTRY_INPUT)
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
         with patch("custom_components.poolman.async_setup_entry", return_value=True):
             result = await hass.config_entries.flow.async_configure(
@@ -95,6 +110,68 @@ class TestConfigFlow:
         assert result["data"][CONF_SHAPE] == "round"
         assert result["data"][CONF_TREATMENT] == "chlorine"
         assert result["data"][CONF_FILTRATION_KIND] == "sand"
+
+    async def test_full_flow_stores_empty_spoons(self, hass: HomeAssistant) -> None:
+        """Skipping spoon configuration should store an empty spoon_sizes list."""
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": SOURCE_USER})
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], POOL_INPUT)
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], CHEMISTRY_INPUT)
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+        with patch("custom_components.poolman.async_setup_entry", return_value=True):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"], FILTRATION_INPUT
+            )
+
+        assert result["type"] is FlowResultType.CREATE_ENTRY
+        assert result["data"][CONF_SPOON_SIZES] == []
+
+    async def test_full_flow_stores_spoon_sizes(self, hass: HomeAssistant) -> None:
+        """Configuring spoon sizes should store them in config entry data."""
+        spoon_input = {
+            CONF_SPOON_NAME_1: "Small",
+            CONF_SPOON_SIZE_1: 5,
+            CONF_SPOON_NAME_2: "Large",
+            CONF_SPOON_SIZE_2: 15,
+        }
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": SOURCE_USER})
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], POOL_INPUT)
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], CHEMISTRY_INPUT)
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], spoon_input)
+
+        with patch("custom_components.poolman.async_setup_entry", return_value=True):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"], FILTRATION_INPUT
+            )
+
+        assert result["type"] is FlowResultType.CREATE_ENTRY
+        spoons = result["data"][CONF_SPOON_SIZES]
+        assert len(spoons) == 2
+        assert spoons[0] == {"name": "Small", "size_ml": 5.0}
+        assert spoons[1] == {"name": "Large", "size_ml": 15.0}
+
+    async def test_full_flow_ignores_empty_spoon_names(self, hass: HomeAssistant) -> None:
+        """Spoon pairs with empty names should be ignored."""
+        spoon_input = {
+            CONF_SPOON_NAME_1: "Small",
+            CONF_SPOON_SIZE_1: 5,
+            CONF_SPOON_NAME_2: "",
+            CONF_SPOON_SIZE_2: 15,
+        }
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": SOURCE_USER})
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], POOL_INPUT)
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], CHEMISTRY_INPUT)
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], spoon_input)
+
+        with patch("custom_components.poolman.async_setup_entry", return_value=True):
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"], FILTRATION_INPUT
+            )
+
+        assert result["type"] is FlowResultType.CREATE_ENTRY
+        spoons = result["data"][CONF_SPOON_SIZES]
+        assert len(spoons) == 1
+        assert spoons[0]["name"] == "Small"
 
     async def test_duplicate_unique_id_aborts(self, hass: HomeAssistant) -> None:
         """Setting up a pool with the same name should abort."""
@@ -109,6 +186,7 @@ class TestConfigFlow:
         result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": SOURCE_USER})
         result = await hass.config_entries.flow.async_configure(result["flow_id"], POOL_INPUT)
         result = await hass.config_entries.flow.async_configure(result["flow_id"], CHEMISTRY_INPUT)
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
         result = await hass.config_entries.flow.async_configure(result["flow_id"], FILTRATION_INPUT)
         assert result["type"] is FlowResultType.ABORT
         assert result["reason"] == "already_configured"
@@ -127,16 +205,30 @@ class TestOptionsFlow:
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "init"
 
-    async def test_options_flow_filtration_shows_form(
+    async def test_options_flow_spoons_shows_form(
         self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
     ) -> None:
-        """After init step, filtration form should be shown."""
+        """After init step, spoons form should be shown."""
         mock_config_entry.add_to_hass(hass)
 
         result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
         result = await hass.config_entries.options.async_configure(
             result["flow_id"], CHEMISTRY_INPUT
         )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "spoons"
+
+    async def test_options_flow_filtration_shows_form(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """After spoons step, filtration form should be shown."""
+        mock_config_entry.add_to_hass(hass)
+
+        result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], CHEMISTRY_INPUT
+        )
+        result = await hass.config_entries.options.async_configure(result["flow_id"], {})
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "filtration"
 
@@ -150,12 +242,36 @@ class TestOptionsFlow:
         result = await hass.config_entries.options.async_configure(
             result["flow_id"], CHEMISTRY_INPUT
         )
+        result = await hass.config_entries.options.async_configure(result["flow_id"], {})
         result = await hass.config_entries.options.async_configure(
             result["flow_id"], FILTRATION_INPUT
         )
         assert result["type"] is FlowResultType.CREATE_ENTRY
         assert result["data"][CONF_TREATMENT] == "chlorine"
         assert result["data"][CONF_FILTRATION_KIND] == "sand"
+
+    async def test_options_flow_stores_spoon_sizes(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Options flow should store configured spoon sizes."""
+        mock_config_entry.add_to_hass(hass)
+
+        spoon_input = {
+            CONF_SPOON_NAME_1: "Medium",
+            CONF_SPOON_SIZE_1: 10,
+        }
+        result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], CHEMISTRY_INPUT
+        )
+        result = await hass.config_entries.options.async_configure(result["flow_id"], spoon_input)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], FILTRATION_INPUT
+        )
+        assert result["type"] is FlowResultType.CREATE_ENTRY
+        spoons = result["data"][CONF_SPOON_SIZES]
+        assert len(spoons) == 1
+        assert spoons[0] == {"name": "Medium", "size_ml": 10.0}
 
 
 async def _setup_entry(hass: HomeAssistant, entry: MockConfigEntry) -> PoolmanCoordinator:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -12,6 +12,7 @@ from custom_components.poolman.const import (
     CONF_CYA_ENTITY,
     CONF_HARDNESS_ENTITY,
     CONF_OUTDOOR_TEMPERATURE_ENTITY,
+    CONF_SPOON_SIZES,
     CONF_STARTED_AT,
     CONF_STEPS,
     CONF_TAC_ENTITY,
@@ -1074,3 +1075,231 @@ class TestActivationSubentryPersistence:
         assert all(subentry.data[CONF_STEPS].values())
         assert "completed" in subentry.title.lower()
         assert coordinator.mode == PoolMode.ACTIVE
+
+
+class TestSpoonSizes:
+    """Tests for spoon size configuration in the coordinator."""
+
+    async def test_pool_has_no_spoons_by_default(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Pool should have empty spoon_sizes when none configured."""
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        assert coordinator.pool.spoon_sizes == []
+
+    async def test_pool_loads_spoon_sizes_from_config(self, hass: HomeAssistant) -> None:
+        """Pool should load spoon sizes from config entry data."""
+        data = MOCK_CONFIG_DATA.copy()
+        data[CONF_SPOON_SIZES] = [
+            {"name": "Small", "size_ml": 5.0},
+            {"name": "Large", "size_ml": 15.0},
+        ]
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=data,
+            version=1,
+            minor_version=4,
+        )
+        coordinator = await _setup_coordinator(hass, entry)
+        assert len(coordinator.pool.spoon_sizes) == 2
+        assert coordinator.pool.spoon_sizes[0].name == "Small"
+        assert coordinator.pool.spoon_sizes[0].size_ml == 5.0
+        assert coordinator.pool.spoon_sizes[1].name == "Large"
+        assert coordinator.pool.spoon_sizes[1].size_ml == 15.0
+
+    async def test_pool_ignores_invalid_spoon_entries(self, hass: HomeAssistant) -> None:
+        """Pool should skip malformed spoon entries in config data."""
+        data = MOCK_CONFIG_DATA.copy()
+        data[CONF_SPOON_SIZES] = [
+            {"name": "Good", "size_ml": 10.0},
+            {"name": "", "size_ml": 5.0},  # empty name
+            {"size_ml": 5.0},  # no name
+            {"name": "NoSize"},  # no size_ml
+            "not_a_dict",  # not a dict
+        ]
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=data,
+            version=1,
+            minor_version=4,
+        )
+        coordinator = await _setup_coordinator(hass, entry)
+        assert len(coordinator.pool.spoon_sizes) == 1
+        assert coordinator.pool.spoon_sizes[0].name == "Good"
+
+    async def test_spoon_sizes_from_options_override_data(self, hass: HomeAssistant) -> None:
+        """Spoon sizes in options should take precedence over data."""
+        data = MOCK_CONFIG_DATA.copy()
+        data[CONF_SPOON_SIZES] = [{"name": "Data", "size_ml": 5.0}]
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=data,
+            options={CONF_SPOON_SIZES: [{"name": "Options", "size_ml": 20.0}]},
+            version=1,
+            minor_version=4,
+        )
+        coordinator = await _setup_coordinator(hass, entry)
+        assert len(coordinator.pool.spoon_sizes) == 1
+        assert coordinator.pool.spoon_sizes[0].name == "Options"
+        assert coordinator.pool.spoon_sizes[0].size_ml == 20.0
+
+
+class TestEnrichRecommendationsWithSpoons:
+    """Tests for _enrich_recommendations_with_spoons."""
+
+    async def test_no_spoons_returns_unmodified(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """With no spoon sizes, recommendations should be returned unchanged."""
+        from custom_components.poolman.domain.model import (
+            Recommendation,
+            RecommendationPriority,
+            RecommendationType,
+        )
+
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        recs = [
+            Recommendation(
+                type=RecommendationType.CHEMICAL,
+                priority=RecommendationPriority.MEDIUM,
+                message="Add pH-",
+                product="ph_minus",
+                quantity_g=300.0,
+            )
+        ]
+        result = coordinator._enrich_recommendations_with_spoons(recs)
+        assert len(result) == 1
+        assert result[0].spoon_count is None
+        assert result[0].spoon_name is None
+
+    async def test_enriches_with_spoon_data(self, hass: HomeAssistant) -> None:
+        """With spoon sizes configured, recommendations should include spoon equivalents."""
+        from custom_components.poolman.domain.model import (
+            Recommendation,
+            RecommendationPriority,
+            RecommendationType,
+        )
+
+        data = MOCK_CONFIG_DATA.copy()
+        data[CONF_SPOON_SIZES] = [{"name": "Large", "size_ml": 15.0}]
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=data,
+            version=1,
+            minor_version=4,
+        )
+        coordinator = await _setup_coordinator(hass, entry)
+
+        recs = [
+            Recommendation(
+                type=RecommendationType.CHEMICAL,
+                priority=RecommendationPriority.MEDIUM,
+                message="Add pH-",
+                product="ph_minus",
+                quantity_g=300.0,
+            )
+        ]
+        result = coordinator._enrich_recommendations_with_spoons(recs)
+        assert len(result) == 1
+        assert result[0].spoon_count is not None
+        assert result[0].spoon_count > 0
+        assert result[0].spoon_name == "Large"
+
+    async def test_skips_tablet_products(self, hass: HomeAssistant) -> None:
+        """Tablet products should not get spoon equivalents."""
+        from custom_components.poolman.domain.model import (
+            Recommendation,
+            RecommendationPriority,
+            RecommendationType,
+        )
+
+        data = MOCK_CONFIG_DATA.copy()
+        data[CONF_SPOON_SIZES] = [{"name": "Large", "size_ml": 15.0}]
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=data,
+            version=1,
+            minor_version=4,
+        )
+        coordinator = await _setup_coordinator(hass, entry)
+
+        recs = [
+            Recommendation(
+                type=RecommendationType.CHEMICAL,
+                priority=RecommendationPriority.MEDIUM,
+                message="Add chlorine tablet",
+                product="galet_chlore",
+                quantity_g=200.0,
+            )
+        ]
+        result = coordinator._enrich_recommendations_with_spoons(recs)
+        assert len(result) == 1
+        assert result[0].spoon_count is None
+        assert result[0].spoon_name is None
+
+    async def test_skips_no_quantity(self, hass: HomeAssistant) -> None:
+        """Recommendations without quantity_g should not get spoon equivalents."""
+        from custom_components.poolman.domain.model import (
+            Recommendation,
+            RecommendationPriority,
+            RecommendationType,
+        )
+
+        data = MOCK_CONFIG_DATA.copy()
+        data[CONF_SPOON_SIZES] = [{"name": "Large", "size_ml": 15.0}]
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=data,
+            version=1,
+            minor_version=4,
+        )
+        coordinator = await _setup_coordinator(hass, entry)
+
+        recs = [
+            Recommendation(
+                type=RecommendationType.ALERT,
+                priority=RecommendationPriority.HIGH,
+                message="Check water level",
+            )
+        ]
+        result = coordinator._enrich_recommendations_with_spoons(recs)
+        assert len(result) == 1
+        assert result[0].spoon_count is None
+
+    async def test_skips_invalid_product(self, hass: HomeAssistant) -> None:
+        """Recommendations with an invalid product name should not crash."""
+        from custom_components.poolman.domain.model import (
+            Recommendation,
+            RecommendationPriority,
+            RecommendationType,
+        )
+
+        data = MOCK_CONFIG_DATA.copy()
+        data[CONF_SPOON_SIZES] = [{"name": "Large", "size_ml": 15.0}]
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=data,
+            version=1,
+            minor_version=4,
+        )
+        coordinator = await _setup_coordinator(hass, entry)
+
+        recs = [
+            Recommendation(
+                type=RecommendationType.CHEMICAL,
+                priority=RecommendationPriority.MEDIUM,
+                message="Add mystery product",
+                product="nonexistent_product",
+                quantity_g=100.0,
+            )
+        ]
+        result = coordinator._enrich_recommendations_with_spoons(recs)
+        assert len(result) == 1
+        assert result[0].spoon_count is None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -8,6 +8,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.poolman.const import (
     CONF_COMPLETED_AT,
     CONF_FILTRATION_KIND,
+    CONF_SPOON_SIZES,
     CONF_STARTED_AT,
     CONF_STEPS,
     CONF_TARGET_MODE,
@@ -400,13 +401,56 @@ class TestMigrateEntry:
     async def test_current_version_no_migration(
         self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
     ) -> None:
-        """Current version (v1.3) should not trigger any migration."""
+        """Current version (v1.4) should not trigger any migration."""
         mock_config_entry.add_to_hass(hass)
         setup_mock_states(hass)
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
         assert mock_config_entry.data == MOCK_CONFIG_DATA
+
+    async def test_migrate_v1_3_to_v1_4_adds_spoon_sizes(self, hass: HomeAssistant) -> None:
+        """Migration from v1.3 should add spoon_sizes."""
+        data = MOCK_CONFIG_DATA.copy()
+        data.pop(CONF_SPOON_SIZES, None)
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Old Pool",
+            data=data,
+            version=1,
+            minor_version=3,
+        )
+        entry.add_to_hass(hass)
+        setup_mock_states(hass)
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert entry.data[CONF_SPOON_SIZES] == []
+        assert entry.minor_version >= 4
+
+    async def test_migrate_v1_1_adds_all(self, hass: HomeAssistant) -> None:
+        """Migration from v1.1 should add filtration_kind, treatment, and spoon_sizes."""
+        data = MOCK_CONFIG_DATA.copy()
+        data.pop(CONF_FILTRATION_KIND, None)
+        data.pop(CONF_TREATMENT, None)
+        data.pop(CONF_SPOON_SIZES, None)
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Old Pool",
+            data=data,
+            version=1,
+            minor_version=1,
+        )
+        entry.add_to_hass(hass)
+        setup_mock_states(hass)
+
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert entry.data[CONF_FILTRATION_KIND] == DEFAULT_FILTRATION_KIND
+        assert entry.data[CONF_TREATMENT] == DEFAULT_TREATMENT
+        assert entry.data[CONF_SPOON_SIZES] == []
 
 
 class TestServiceHandler:
@@ -486,6 +530,72 @@ class TestServiceHandler:
                 "product": "flocculant",
                 "quantity_g": 50.0,
                 "notes": "Test note",
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    async def test_add_treatment_service_with_spoons(self, hass: HomeAssistant) -> None:
+        """Service call with spoons and spoon_name should resolve to quantity_g."""
+        data = MOCK_CONFIG_DATA.copy()
+        data[CONF_SPOON_SIZES] = [{"name": "Large", "size_ml": 15.0}]
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            title="Test Pool",
+            data=data,
+            version=1,
+            minor_version=4,
+        )
+        entry.add_to_hass(hass)
+        setup_mock_states(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        from homeassistant.helpers import device_registry as dr
+
+        device_registry = dr.async_get(hass)
+        device = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
+        assert device is not None
+
+        # ph_minus has density 1.1, so 2 spoons * 15 mL * 1.1 g/mL = 33g
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ADD_TREATMENT,
+            {
+                "device_id": device.id,
+                "product": "ph_minus",
+                "spoons": 2.0,
+                "spoon_name": "Large",
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    async def test_add_treatment_service_with_unknown_spoon_name(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Service call with unknown spoon_name should not crash."""
+        mock_config_entry.add_to_hass(hass)
+        setup_mock_states(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        from homeassistant.helpers import device_registry as dr
+
+        device_registry = dr.async_get(hass)
+        device = device_registry.async_get_device(
+            identifiers={(DOMAIN, mock_config_entry.entry_id)}
+        )
+        assert device is not None
+
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ADD_TREATMENT,
+            {
+                "device_id": device.id,
+                "product": "ph_minus",
+                "spoons": 2.0,
+                "spoon_name": "NonExistent",
             },
             blocking=True,
         )


### PR DESCRIPTION
## Summary

Implements #82 — allows users to configure named measuring spoon sizes (in mL) so dosage recommendations are expressed as both grams and a number of spoons.

- Configurable up to 3 spoon sizes via config flow and options flow (new step between chemistry and filtration)
- Recommendations enriched with best-fit spoon equivalents using per-product density table
- `add_treatment` service accepts `spoons`/`spoon_name` as alternative to `quantity_g`
- Tablet products (chlorine tablets, bromine tablets, active oxygen tablets) are excluded from spoon equivalents
- Config version bumped v1.3 → v1.4 with automatic migration

## Changes

### Source
- **`domain/model.py`**: `SpoonSize`, `PRODUCT_DENSITY_G_PER_ML`, `TABLET_PRODUCTS`, `compute_spoon_equivalent()`, `format_spoon_text()`, `Pool.spoon_sizes`, `Recommendation.spoon_count`/`spoon_name`
- **`const.py`**: `CONF_SPOON_SIZES`, spoon config keys, `SPOON_PAIRS`
- **`config_flow.py`**: `_spoon_schema()`, `_parse_spoon_sizes()`, `_spoon_defaults_from_config()`, spoon steps in both flows
- **`__init__.py`**: v1.4 migration, service schema with `spoons`/`spoon_name`, `_resolve_spoon_quantity()` helper
- **`coordinator.py`**: `_build_pool()` reads spoon sizes, `_enrich_recommendations_with_spoons()` 
- **`sensor.py`**: `chemistry_actions` extra attrs include `spoon_count`/`spoon_name`
- **`services.yaml`**, **`strings.json`**, **translations**: spoon fields and step strings

### Tests
- Fixed 6 existing tests for new spoon step in config/options flow
- Added domain model tests for `SpoonSize`, density table, `compute_spoon_equivalent`, `format_spoon_text`
- Added config flow tests for spoon data storage and parsing
- Added coordinator tests for spoon loading, options override, invalid entries, and recommendation enrichment
- Added service tests for spoon-based `add_treatment` input

### Documentation
- **`getting-started.md`**: New "Step 3: Measuring spoons" section with common sizes
- **`water-chemistry.md`**: New "Spoon Equivalents" section with formula, density table, display format
- **`entities.md`**: Updated chemistry_actions attributes to include `spoon_count`/`spoon_name`

Closes #82