### PR TITLE
refactor(rules): migrate rule engine to Problem-only pipeline

### DIFF
--- a/custom_components/poolman/coordinator.py
+++ b/custom_components/poolman/coordinator.py
@@ -755,7 +755,7 @@ class PoolmanCoordinator(DataUpdateCoordinator[PoolState]):
         # against manual measures, even when the effective reading uses
         # manual values as fallback.
         sensor_ec = self._read_sensor(CONF_EC_ENTITY)
-        sensor_reading = PoolReading(
+        raw_sensor_reading = PoolReading(
             ph=self._read_sensor(CONF_PH_ENTITY),
             orp=self._read_sensor(CONF_ORP_ENTITY),
             free_chlorine=self._read_sensor(CONF_FREE_CHLORINE_ENTITY),
@@ -775,7 +775,7 @@ class PoolmanCoordinator(DataUpdateCoordinator[PoolState]):
             mode=self._mode,
             pool=self.pool,
             reading=reading,
-            raw_sensor_reading=sensor_reading,
+            raw_sensor_reading=raw_sensor_reading,
             manual_measures=manual_measures,
         )
         self._analysis_result = analyze_pool(analysis_state)
@@ -796,7 +796,7 @@ class PoolmanCoordinator(DataUpdateCoordinator[PoolState]):
             mode=self._mode,
             pool=self.pool,
             reading=reading,
-            raw_sensor_reading=sensor_reading,
+            raw_sensor_reading=raw_sensor_reading,
             analysis_result=self._analysis_result,
             filtration_hours=filtration_hours,
             water_quality_score=water_quality_score,

--- a/custom_components/poolman/domain/analysis.py
+++ b/custom_components/poolman/domain/analysis.py
@@ -10,7 +10,10 @@ for:
   ``PoolState → AnalysisResult``.
 - :func:`generate_recommendations` -- derives
   :class:`~.recommendation.Recommendation` objects from a list of
-  :class:`~.problem.Problem` objects.
+  :class:`~.problem.Problem` objects.  Depends only on the problem list;
+  any required dosage information is carried on
+  :attr:`~.problem.Problem.treatment` by the rule that produced the
+  problem.
 
 Pipeline
 --------
@@ -21,9 +24,9 @@ Pipeline
         │
         ▼
     RuleEngine(ALL_RULES).evaluate(state)  ← domain/rules/
-        │  list[Problem]
+        │  list[Problem]  (each may carry a pre-computed Treatment)
         ▼
-    generate_recommendations(problems, reading, pool)
+    generate_recommendations(problems)
         │  list[Recommendation]
         ▼
     AnalysisResult(problems, recommendations, timestamp)
@@ -32,6 +35,8 @@ Design constraints
 ------------------
 - Pure functions only: stateless, deterministic, no side effects.
 - No Home Assistant dependency anywhere in this module.
+- :func:`generate_recommendations` depends **only** on
+  :class:`~.problem.Problem` instances — no sensor or pool data.
 - Resilient to missing / ``None`` sensor values — rules guard individually.
 
 Example::
@@ -47,31 +52,22 @@ Example::
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from .chemistry import (
-    compute_cya_adjustment,
-    compute_free_chlorine_adjustment,
-    compute_hardness_adjustment,
-    compute_ph_adjustment,
-    compute_salt_adjustment,
-    compute_tac_adjustment,
-)
 from .problem import Problem, Severity
 from .recommendation import (
     ActionKind,
     Recommendation,
     RecommendationPriority,
     RecommendationType,
-    Treatment,
 )
 from .rules import ALL_RULES, RuleEngine
 
 if TYPE_CHECKING:
-    from .model import DosageAdjustment, Pool, PoolReading, PoolState
+    from .model import PoolState
+
 
 # ---------------------------------------------------------------------------
 # Mapping helpers
@@ -91,161 +87,109 @@ _SEVERITY_TO_KIND: dict[Severity, ActionKind] = {
     Severity.CRITICAL: ActionKind.REQUIREMENT,
 }
 
-# Map problem code → (RecommendationType, title, description template, product_id, unit)
-# ``description`` may contain ``{value}`` placeholder.
-_PROBLEM_RECOMMENDATIONS: dict[
-    str,
-    tuple[RecommendationType, str, str, str | None, str | None],
-] = {
+# Map problem code → (RecommendationType, title, description template).
+# ``description`` may contain a ``{value}`` placeholder filled with
+# :attr:`~.problem.Problem.value`.  Treatment quantity / product is carried
+# on :attr:`~.problem.Problem.treatment`, **not** in this table.
+_PROBLEM_RECOMMENDATIONS: dict[str, tuple[RecommendationType, str, str]] = {
     "ph_too_high": (
         RecommendationType.CHEMISTRY,
         "Lower pH",
         "pH is too high ({value}). Add pH- to bring it back to the target range.",
-        "ph_minus",
-        "g",
     ),
     "ph_too_low": (
         RecommendationType.CHEMISTRY,
         "Raise pH",
         "pH is too low ({value}). Add pH+ to bring it back to the target range.",
-        "ph_plus",
-        "g",
     ),
     "orp_too_low": (
         RecommendationType.CHEMISTRY,
         "Increase sanitizer",
         "ORP is too low ({value} mV). Sanitizer effectiveness may be insufficient.",
-        None,
-        None,
     ),
     "orp_too_high": (
         RecommendationType.ALERT,
         "Reduce sanitizer",
         "ORP is too high ({value} mV). Reduce sanitizer dosage.",
-        "neutralizer",
-        "g",
     ),
     "chlorine_too_low": (
         RecommendationType.CHEMISTRY,
         "Add chlorine",
         "Free chlorine is too low ({value} ppm). Add shock chlorine.",
-        "chlore_choc",
-        "g",
     ),
     "chlorine_too_high": (
         RecommendationType.ALERT,
         "Reduce chlorine",
         "Free chlorine is too high ({value} ppm). Reduce chlorine dosage.",
-        "neutralizer",
-        "g",
     ),
     "alkalinity_too_low": (
         RecommendationType.CHEMISTRY,
         "Raise alkalinity",
         "Total alkalinity is too low ({value} ppm). Add TAC+ to raise it.",
-        "tac_plus",
-        "g",
     ),
     "alkalinity_too_high": (
         RecommendationType.ALERT,
         "Lower alkalinity",
         "Total alkalinity is too high ({value} ppm). pH- treatments will help lower it.",
-        "ph_minus",
-        "g",
     ),
     "cya_too_low": (
         RecommendationType.CHEMISTRY,
         "Add stabilizer",
         "Cyanuric acid is too low ({value} ppm). Add stabilizer to protect chlorine from UV.",
-        "stabilizer",
-        "g",
     ),
     "cya_too_high": (
         RecommendationType.ALERT,
         "Partial water drain required",
         "Cyanuric acid is too high ({value} ppm). No chemical can lower CYA; drain partially.",
-        None,
-        None,
     ),
     "hardness_too_low": (
         RecommendationType.CHEMISTRY,
         "Raise calcium hardness",
         "Calcium hardness is too low ({value} ppm). Add calcium hardness increaser.",
-        "calcium_hardness_increaser",
-        "g",
     ),
     "hardness_too_high": (
         RecommendationType.ALERT,
         "Partial water drain required",
         "Calcium hardness is too high ({value} ppm). No chemical can lower hardness;"
         " drain partially.",
-        None,
-        None,
     ),
     "salt_too_low": (
         RecommendationType.CHEMISTRY,
         "Add salt",
         "Salt level is too low ({value} ppm). Add pool salt to reach the target.",
-        "salt",
-        "g",
     ),
     "salt_too_high": (
         RecommendationType.ALERT,
         "Partial water drain required",
         "Salt level is too high ({value} ppm). Drain partially to dilute.",
-        None,
-        None,
     ),
     "tds_too_high": (
         RecommendationType.ALERT,
         "Partial water drain required",
         "TDS is too high ({value} ppm). Drain partially to reduce dissolved solids.",
-        None,
-        None,
     ),
     "tds_too_low": (
         RecommendationType.MAINTENANCE,
         "Verify EC sensor calibration",
         "TDS is unusually low ({value} ppm). Check EC sensor calibration.",
-        None,
-        None,
     ),
     "_calibration": (
         RecommendationType.MAINTENANCE,
         "Calibrate sensor",
         "Sensor reading differs significantly from last manual measurement ({value}). Recalibrate.",
-        None,
-        None,
     ),
     "filtration_required": (
         RecommendationType.FILTRATION,
         "Run filtration",
         "Filtration is required for {value} hours today.",
-        None,
-        None,
     ),
     "algae_risk": (
         RecommendationType.ALERT,
         "High algae risk",
         "Water temperature is high and ORP is low ({value} mV). Risk of algae growth.",
-        None,
-        None,
     ),
 }
 
-# Dosage functions keyed by problem code.
-# Each value is a callable(pool, reading) → DosageAdjustment | None.
-# Codes not listed here produce no treatment quantity.
-_DOSAGE_FUNCTIONS: dict[str, Callable[..., DosageAdjustment | None]] = {
-    "ph_too_high": compute_ph_adjustment,
-    "ph_too_low": compute_ph_adjustment,
-    "alkalinity_too_low": compute_tac_adjustment,
-    "cya_too_low": compute_cya_adjustment,
-    "hardness_too_low": compute_hardness_adjustment,
-    "salt_too_low": compute_salt_adjustment,
-}
-# chlorine_too_low only needs reading (no pool arg)
-_DOSAGE_READING_ONLY: frozenset[str] = frozenset({"chlorine_too_low"})
 
 _PRIORITY_ORDER: dict[RecommendationPriority, int] = {
     RecommendationPriority.CRITICAL: 0,
@@ -260,29 +204,29 @@ _PRIORITY_ORDER: dict[RecommendationPriority, int] = {
 # ---------------------------------------------------------------------------
 
 
-def generate_recommendations(
-    problems: list[Problem],
-    reading: PoolReading | None = None,
-    pool: Pool | None = None,
-) -> list[Recommendation]:
-    """Derive :class:`~.recommendation.Recommendation` objects from detected problems.
+def generate_recommendations(problems: list[Problem]) -> list[Recommendation]:
+    """Derive :class:`~.recommendation.Recommendation` objects from problems.
 
-    For each :class:`~.problem.Problem`, looks up the matching recommendation
-    template and produces a :class:`~.recommendation.Recommendation` with:
+    Pure :class:`~.problem.Problem` → :class:`~.recommendation.Recommendation`
+    mapping.  No sensor reading or pool configuration is consulted: any
+    dosage information must already be present on
+    :attr:`~.problem.Problem.treatment` (rules attach it when the dosage is
+    known).
 
-    - A :class:`~.recommendation.Treatment` step when a product is known,
-      with ``quantity`` populated from the chemistry module when ``reading``
-      and ``pool`` are provided.
-    - Priority derived from :attr:`~.problem.Problem.severity`.
-    - :attr:`~.recommendation.ActionKind` set based on severity
-      (``CRITICAL`` and ``MEDIUM`` → ``REQUIREMENT``, ``LOW`` → ``SUGGESTION``).
+    For each :class:`~.problem.Problem` the function:
+
+    - Looks up the matching template (type, title, description) by
+      :attr:`~.problem.Problem.code`.  Codes starting with ``"calibration_"``
+      share the generic ``_calibration`` template.
+    - Sets :class:`~.recommendation.RecommendationPriority` and
+      :class:`~.recommendation.ActionKind` from :attr:`~.problem.Problem.severity`
+      (``CRITICAL`` / ``MEDIUM`` → ``REQUIREMENT``, ``LOW`` → ``SUGGESTION``).
+    - Carries :attr:`~.problem.Problem.treatment` (when present) into the
+      :attr:`~.recommendation.Recommendation.treatments` list.
 
     Problems with no matching template are silently skipped (forward
     compatibility: new problem codes added before new templates exist will
     not crash the pipeline).
-
-    Calibration problem codes (``calibration_*``) share a single MAINTENANCE
-    template regardless of the specific parameter.
 
     Duplicate recommendations for the same problem code are deduplicated;
     only the highest-severity one is kept.
@@ -290,11 +234,6 @@ def generate_recommendations(
     Args:
         problems: List of :class:`~.problem.Problem` objects produced by the
             rule engine.
-        reading: Current pool readings, used to compute dosage quantities.
-            When ``None``, treatment quantities are left at ``0.0``.
-        pool: Pool physical config, used for volume-based dosage calculations.
-            When ``None``, treatments that require pool data have quantity
-            ``0.0``.
 
     Returns:
         List of :class:`~.recommendation.Recommendation` objects, sorted by
@@ -317,7 +256,7 @@ def generate_recommendations(
         if template is None:
             continue
 
-        rec_type, title, desc_template, product_id, unit = template
+        rec_type, title, desc_template = template
         priority = _SEVERITY_TO_PRIORITY[problem.severity]
         kind = _SEVERITY_TO_KIND[problem.severity]
 
@@ -325,31 +264,7 @@ def generate_recommendations(
             value=problem.value if problem.value is not None else "N/A",
         )
 
-        # Build treatment with computed dosage when possible
-        treatments: list[Treatment] = []
-        if product_id is not None and unit is not None:
-            quantity = 0.0
-            if reading is not None:
-                if code in _DOSAGE_READING_ONLY:
-                    dosage = compute_free_chlorine_adjustment(reading)
-                    if dosage is not None and dosage.quantity_g is not None:
-                        quantity = dosage.quantity_g
-                elif pool is not None and code in _DOSAGE_FUNCTIONS:
-                    dosage_fn = _DOSAGE_FUNCTIONS[code]
-                    dosage = dosage_fn(pool, reading)  # type: ignore[call-arg]
-                    if dosage is not None and dosage.quantity_g is not None:
-                        quantity = dosage.quantity_g
-
-            treatments.append(
-                Treatment(
-                    id=f"{code}_{product_id}",
-                    product_id=product_id,
-                    name=product_id.replace("_", " ").title(),
-                    quantity=quantity,
-                    unit=unit,
-                )
-            )
-
+        treatments = [problem.treatment] if problem.treatment is not None else []
         related = [problem.metric] if problem.metric is not None else []
 
         recommendations.append(
@@ -402,18 +317,18 @@ def analyze_pool(state: PoolState) -> AnalysisResult:
     Pipeline steps:
 
     1. Run :class:`~.rules.RuleEngine` with :data:`~.rules.ALL_RULES` to
-       produce a list of :class:`~.problem.Problem` objects.
+       produce a list of :class:`~.problem.Problem` objects.  Rules attach
+       pre-computed :class:`~.recommendation.Treatment` instances to
+       problems when a dosage is known.
     2. Call :func:`generate_recommendations` to derive a list of
-       :class:`~.recommendation.Recommendation` objects, including computed
-       dosage quantities.
+       :class:`~.recommendation.Recommendation` objects from the problems
+       alone (no sensor / pool re-reading).
     3. Return an :class:`AnalysisResult` with both lists and the current
        UTC timestamp.
 
     Args:
-        state: The current pool state snapshot.  ``state.pool`` and
-            ``state.reading`` are forwarded to :func:`generate_recommendations`
-            for dosage computation.  All sensor readings may be ``None``; the
-            rules handle missing data gracefully.
+        state: The current pool state snapshot.  All sensor readings may be
+            ``None``; the rules handle missing data gracefully.
 
     Returns:
         An :class:`AnalysisResult` with problems, recommendations, and
@@ -428,7 +343,7 @@ def analyze_pool(state: PoolState) -> AnalysisResult:
             print(f"  [{rec.priority}] {rec.title}: {rec.description}")
     """
     problems = RuleEngine(ALL_RULES).evaluate(state)
-    recommendations = generate_recommendations(problems, state.reading, state.pool)
+    recommendations = generate_recommendations(problems)
     return AnalysisResult(
         problems=problems,
         recommendations=recommendations,

--- a/custom_components/poolman/domain/problem.py
+++ b/custom_components/poolman/domain/problem.py
@@ -34,8 +34,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import StrEnum
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from .recommendation import Treatment
 
 # ---------------------------------------------------------------------------
 # Enums
@@ -161,11 +165,20 @@ class Problem:
         expected_range: ``(minimum, maximum)`` tuple representing the
             acceptable range for this parameter, or ``None`` when the range
             is unknown.
+        treatment: Optional pre-computed :class:`~.recommendation.Treatment`
+            attached by the rule when a specific dosage is known (e.g. pH-,
+            chlorine, alkalinity adjustments).  Used by
+            :func:`~.analysis.generate_recommendations` to build the
+            corresponding :class:`~.recommendation.Recommendation` without
+            re-reading sensor or pool data.  ``None`` for alert-only
+            problems (e.g. CYA too high, drain required) or rules that
+            have no associated product.
     """
 
     code: str
     message: str
     severity: Severity
-    metric: MetricName | None
-    value: float | None
-    expected_range: tuple[float, float] | None
+    metric: MetricName | None = None
+    value: float | None = None
+    expected_range: tuple[float, float] | None = None
+    treatment: Treatment | None = None

--- a/custom_components/poolman/domain/rules/__init__.py
+++ b/custom_components/poolman/domain/rules/__init__.py
@@ -3,14 +3,14 @@
 Public API::
 
     from custom_components.poolman.domain.rules import (
-        Rule, RuleResult, RuleEngine, ALL_RULES,
+        Rule, RuleEngine, ALL_RULES,
         PhRule, SanitizerRule, FreeChlorineRule, TacRule,
         AlgaeRiskRule, CyaRule, HardnessRule, SaltRule, TdsRule,
         FiltrationRule, CalibrationRule,
     )
 """
 
-from .base import Rule, RuleResult
+from .base import Rule
 from .chemistry.algae import AlgaeRiskRule
 from .chemistry.alkalinity import TacRule
 from .chemistry.chlorine import FreeChlorineRule
@@ -36,7 +36,6 @@ __all__ = [
     "PhRule",
     "Rule",
     "RuleEngine",
-    "RuleResult",
     "SaltRule",
     "SanitizerRule",
     "TacRule",

--- a/custom_components/poolman/domain/rules/base.py
+++ b/custom_components/poolman/domain/rules/base.py
@@ -1,19 +1,22 @@
 """Base types for the pool rule engine.
 
-Defines the :class:`Rule` abstract base class and the :class:`RuleResult`
-dataclass that every rule returns.
+Defines the :class:`Rule` abstract base class.  Each concrete rule evaluates
+one aspect of the pool state and returns a list of :class:`~..problem.Problem`
+objects.
 
 Design constraints
 ------------------
 - Rules are pure functions: stateless, deterministic, no side effects.
 - Rules receive the full :class:`~..model.PoolState` and extract what they need.
+- Rules may attach a pre-computed :class:`~..recommendation.Treatment` to a
+  :class:`~..problem.Problem` so that downstream recommendation generation
+  does not need to re-read sensor or pool data.
 - No Home Assistant dependency.
 """
 
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from ..problem import Problem
@@ -22,22 +25,11 @@ if TYPE_CHECKING:
     from ..model import PoolState
 
 
-@dataclass
-class RuleResult:
-    """Output of a single rule evaluation.
-
-    Attributes:
-        problems: List of detected problems. Empty when the rule finds no issue.
-    """
-
-    problems: list[Problem] = field(default_factory=list)
-
-
 class Rule(ABC):
     """Abstract base class for pool management rules.
 
     Each concrete rule evaluates one aspect of the pool state and returns a
-    :class:`RuleResult` describing any detected issues.
+    list of :class:`~..problem.Problem` describing any detected issues.
 
     Rules must be:
 
@@ -48,13 +40,20 @@ class Rule(ABC):
     Attributes:
         id: Unique machine-readable identifier, e.g. ``"ph"``.
         description: Short human-readable description of what the rule checks.
+        priority: Execution order hint (lower runs first).  Defaults to
+            ``100``.  The :class:`~.engine.RuleEngine` sorts rules by this
+            value before evaluating them; the final list of problems is then
+            re-sorted by :class:`~..problem.Severity`, so ``priority`` is
+            mostly observable for equal-severity problems where the stable
+            sort preserves rule order.
     """
 
     id: str
     description: str
+    priority: int = 100
 
     @abstractmethod
-    def evaluate(self, state: PoolState) -> RuleResult:
+    def evaluate(self, state: PoolState) -> list[Problem]:
         """Evaluate the rule against the current pool state.
 
         Args:
@@ -63,5 +62,8 @@ class Rule(ABC):
                 etc.).
 
         Returns:
-            :class:`RuleResult` with zero or more detected problems.
+            A list of zero or more detected :class:`~..problem.Problem`
+            instances.  Each problem may carry a pre-computed
+            :class:`~..recommendation.Treatment` via
+            :attr:`~..problem.Problem.treatment`.
         """

--- a/custom_components/poolman/domain/rules/chemistry/_helpers.py
+++ b/custom_components/poolman/domain/rules/chemistry/_helpers.py
@@ -1,0 +1,43 @@
+"""Shared helpers for chemistry rules."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ...recommendation import Treatment
+
+if TYPE_CHECKING:
+    from ...model import DosageAdjustment
+
+
+def treatment_from_dosage(
+    code: str, dosage: DosageAdjustment | None, unit: str = "g"
+) -> Treatment | None:
+    """Convert a :class:`~...model.DosageAdjustment` into a :class:`Treatment`.
+
+    Returns ``None`` when no dosage is provided.  When ``quantity_g`` is
+    ``None`` (e.g. when the dosage function only identifies the product but
+    has no quantitative recommendation), the resulting Treatment has
+    ``quantity = 0.0``.
+
+    Args:
+        code: The originating :attr:`~...problem.Problem.code`, used to build
+            a unique treatment id (``f"{code}_{product_id}"``).
+        dosage: The :class:`~...model.DosageAdjustment` produced by a
+            :mod:`...chemistry` ``compute_*_adjustment`` function.
+        unit: HA-compatible unit string (default ``"g"``).
+
+    Returns:
+        A :class:`Treatment` ready to attach to a
+        :class:`~...problem.Problem`, or ``None`` when ``dosage`` is ``None``.
+    """
+    if dosage is None:
+        return None
+    product_id = dosage.product.value
+    return Treatment(
+        id=f"{code}_{product_id}",
+        product_id=product_id,
+        name=product_id.replace("_", " ").title(),
+        quantity=dosage.quantity_g or 0.0,
+        unit=unit,
+    )

--- a/custom_components/poolman/domain/rules/chemistry/algae.py
+++ b/custom_components/poolman/domain/rules/chemistry/algae.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from ...chemistry import ORP_MAX, ORP_MIN_ACCEPTABLE
 from ...model import PoolMode
 from ...problem import MetricName, Problem, Severity
-from ..base import Rule, RuleResult
+from ..base import Rule
 
 if TYPE_CHECKING:
     from ...model import PoolState
@@ -23,36 +23,38 @@ class AlgaeRiskRule(Rule):
     - Water temperature > 28 °C, **and**
     - ORP < minimum acceptable level.
 
+    No specific chemical treatment is attached; the recommendation surfaces
+    as an :attr:`~...recommendation.RecommendationType.ALERT`.
+
     Disabled in :attr:`~...model.PoolMode.WINTER_PASSIVE` and
     :attr:`~...model.PoolMode.WINTER_ACTIVE` modes.
     """
 
     id = "algae_risk"
     description = "Detect algae risk from warm water and low ORP"
+    priority = 90
 
-    def evaluate(self, state: PoolState) -> RuleResult:  # type: ignore[override]
+    def evaluate(self, state: PoolState) -> list[Problem]:
         """Evaluate algae risk and return a critical problem when conditions are met."""
         if state.mode in (PoolMode.WINTER_PASSIVE, PoolMode.WINTER_ACTIVE):
-            return RuleResult()
+            return []
 
         if state.reading.temp_c is None or state.reading.orp is None:
-            return RuleResult()
+            return []
 
         if state.reading.temp_c > _ALGAE_TEMP_THRESHOLD and state.reading.orp < ORP_MIN_ACCEPTABLE:
-            return RuleResult(
-                problems=[
-                    Problem(
-                        code="algae_risk",
-                        message=(
-                            f"High algae risk: water temperature {state.reading.temp_c:.1f} °C"
-                            f" with ORP {state.reading.orp:.0f} mV"
-                        ),
-                        severity=Severity.CRITICAL,
-                        metric=MetricName.ORP,
-                        value=state.reading.orp,
-                        expected_range=(ORP_MIN_ACCEPTABLE, ORP_MAX),
-                    )
-                ]
-            )
+            return [
+                Problem(
+                    code="algae_risk",
+                    message=(
+                        f"High algae risk: water temperature {state.reading.temp_c:.1f} °C"
+                        f" with ORP {state.reading.orp:.0f} mV"
+                    ),
+                    severity=Severity.CRITICAL,
+                    metric=MetricName.ORP,
+                    value=state.reading.orp,
+                    expected_range=(ORP_MIN_ACCEPTABLE, ORP_MAX),
+                )
+            ]
 
-        return RuleResult()
+        return []

--- a/custom_components/poolman/domain/rules/chemistry/alkalinity.py
+++ b/custom_components/poolman/domain/rules/chemistry/alkalinity.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ...chemistry import TAC_MAX, TAC_MIN
+from ...chemistry import TAC_MAX, TAC_MIN, compute_tac_adjustment
 from ...model import PoolMode
 from ...problem import MetricName, Problem, Severity
-from ..base import Rule, RuleResult
+from ..base import Rule
+from ._helpers import treatment_from_dosage
 
 if TYPE_CHECKING:
     from ...model import PoolState
@@ -19,53 +20,59 @@ class TacRule(Rule):
     - Below minimum → :attr:`~...problem.Severity.MEDIUM`
     - Above maximum → :attr:`~...problem.Severity.LOW`
 
+    When :attr:`~...model.PoolState.pool` is set, the rule pre-computes a
+    :class:`~...recommendation.Treatment` (TAC+ for low, pH- for high) and
+    attaches it to the produced :class:`~...problem.Problem`.
+
     Disabled in :attr:`~...model.PoolMode.WINTER_PASSIVE` and
     :attr:`~...model.PoolMode.WINTER_ACTIVE` modes.
     """
 
     id = "alkalinity"
     description = "Evaluate total alkalinity (TAC) level"
+    priority = 30
 
-    def evaluate(self, state: PoolState) -> RuleResult:  # type: ignore[override]
+    def evaluate(self, state: PoolState) -> list[Problem]:
         """Evaluate TAC level and return a problem when out of range."""
         if (
             state.mode in (PoolMode.WINTER_PASSIVE, PoolMode.WINTER_ACTIVE)
             or state.reading.tac is None
         ):
-            return RuleResult()
+            return []
 
         tac = state.reading.tac
+        dosage = (
+            compute_tac_adjustment(state.pool, state.reading) if state.pool is not None else None
+        )
 
         if tac < TAC_MIN:
-            return RuleResult(
-                problems=[
-                    Problem(
-                        code="alkalinity_too_low",
-                        message=(
-                            f"Total alkalinity is too low: {tac:.0f} ppm (minimum {TAC_MIN} ppm)"
-                        ),
-                        severity=Severity.MEDIUM,
-                        metric=MetricName.ALKALINITY,
-                        value=tac,
-                        expected_range=(TAC_MIN, TAC_MAX),
-                    )
-                ]
-            )
+            code = "alkalinity_too_low"
+            return [
+                Problem(
+                    code=code,
+                    message=(f"Total alkalinity is too low: {tac:.0f} ppm (minimum {TAC_MIN} ppm)"),
+                    severity=Severity.MEDIUM,
+                    metric=MetricName.ALKALINITY,
+                    value=tac,
+                    expected_range=(TAC_MIN, TAC_MAX),
+                    treatment=treatment_from_dosage(code, dosage),
+                )
+            ]
 
         if tac > TAC_MAX:
-            return RuleResult(
-                problems=[
-                    Problem(
-                        code="alkalinity_too_high",
-                        message=(
-                            f"Total alkalinity is too high: {tac:.0f} ppm (maximum {TAC_MAX} ppm)"
-                        ),
-                        severity=Severity.LOW,
-                        metric=MetricName.ALKALINITY,
-                        value=tac,
-                        expected_range=(TAC_MIN, TAC_MAX),
-                    )
-                ]
-            )
+            code = "alkalinity_too_high"
+            return [
+                Problem(
+                    code=code,
+                    message=(
+                        f"Total alkalinity is too high: {tac:.0f} ppm (maximum {TAC_MAX} ppm)"
+                    ),
+                    severity=Severity.LOW,
+                    metric=MetricName.ALKALINITY,
+                    value=tac,
+                    expected_range=(TAC_MIN, TAC_MAX),
+                    treatment=treatment_from_dosage(code, dosage),
+                )
+            ]
 
-        return RuleResult()
+        return []

--- a/custom_components/poolman/domain/rules/chemistry/chlorine.py
+++ b/custom_components/poolman/domain/rules/chemistry/chlorine.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ...chemistry import FREE_CHLORINE_MAX, FREE_CHLORINE_MIN
+from ...chemistry import (
+    FREE_CHLORINE_MAX,
+    FREE_CHLORINE_MIN,
+    compute_free_chlorine_adjustment,
+)
 from ...model import PoolMode
 from ...problem import MetricName, Problem, Severity
-from ..base import Rule, RuleResult
+from ..base import Rule
+from ._helpers import treatment_from_dosage
 
 if TYPE_CHECKING:
     from ...model import PoolState
@@ -19,55 +24,61 @@ class FreeChlorineRule(Rule):
     - Below minimum (< 1 ppm) → :attr:`~...problem.Severity.CRITICAL`
     - Above maximum (> 3 ppm) → :attr:`~...problem.Severity.LOW`
 
+    For the low-chlorine case, the rule pre-computes a
+    :class:`~...recommendation.Treatment` (shock chlorine) via
+    :func:`~...chemistry.compute_free_chlorine_adjustment` and attaches it to
+    the produced :class:`~...problem.Problem`.
+
     Disabled in :attr:`~...model.PoolMode.WINTER_PASSIVE` and
     :attr:`~...model.PoolMode.WINTER_ACTIVE` modes.
     """
 
     id = "free_chlorine"
     description = "Evaluate free chlorine concentration"
+    priority = 40
 
-    def evaluate(self, state: PoolState) -> RuleResult:  # type: ignore[override]
+    def evaluate(self, state: PoolState) -> list[Problem]:
         """Evaluate free chlorine level and return a problem when out of range."""
         if (
             state.mode in (PoolMode.WINTER_PASSIVE, PoolMode.WINTER_ACTIVE)
             or state.reading.free_chlorine is None
         ):
-            return RuleResult()
+            return []
 
         fc = state.reading.free_chlorine
 
         if fc < FREE_CHLORINE_MIN:
-            return RuleResult(
-                problems=[
-                    Problem(
-                        code="chlorine_too_low",
-                        message=(
-                            f"Free chlorine is too low: {fc:.1f} ppm"
-                            f" (minimum {FREE_CHLORINE_MIN} ppm)"
-                        ),
-                        severity=Severity.CRITICAL,
-                        metric=MetricName.CHLORINE,
-                        value=fc,
-                        expected_range=(FREE_CHLORINE_MIN, FREE_CHLORINE_MAX),
-                    )
-                ]
-            )
+            code = "chlorine_too_low"
+            dosage = compute_free_chlorine_adjustment(state.reading)
+            return [
+                Problem(
+                    code=code,
+                    message=(
+                        f"Free chlorine is too low: {fc:.1f} ppm (minimum {FREE_CHLORINE_MIN} ppm)"
+                    ),
+                    severity=Severity.CRITICAL,
+                    metric=MetricName.CHLORINE,
+                    value=fc,
+                    expected_range=(FREE_CHLORINE_MIN, FREE_CHLORINE_MAX),
+                    treatment=treatment_from_dosage(code, dosage),
+                )
+            ]
 
         if fc > FREE_CHLORINE_MAX:
-            return RuleResult(
-                problems=[
-                    Problem(
-                        code="chlorine_too_high",
-                        message=(
-                            f"Free chlorine is too high: {fc:.1f} ppm"
-                            f" (maximum {FREE_CHLORINE_MAX} ppm)"
-                        ),
-                        severity=Severity.LOW,
-                        metric=MetricName.CHLORINE,
-                        value=fc,
-                        expected_range=(FREE_CHLORINE_MIN, FREE_CHLORINE_MAX),
-                    )
-                ]
-            )
+            code = "chlorine_too_high"
+            dosage = compute_free_chlorine_adjustment(state.reading)
+            return [
+                Problem(
+                    code=code,
+                    message=(
+                        f"Free chlorine is too high: {fc:.1f} ppm (maximum {FREE_CHLORINE_MAX} ppm)"
+                    ),
+                    severity=Severity.LOW,
+                    metric=MetricName.CHLORINE,
+                    value=fc,
+                    expected_range=(FREE_CHLORINE_MIN, FREE_CHLORINE_MAX),
+                    treatment=treatment_from_dosage(code, dosage),
+                )
+            ]
 
-        return RuleResult()
+        return []

--- a/custom_components/poolman/domain/rules/chemistry/cya.py
+++ b/custom_components/poolman/domain/rules/chemistry/cya.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ...chemistry import CYA_MAX, CYA_MIN
+from ...chemistry import CYA_MAX, CYA_MIN, compute_cya_adjustment
 from ...model import PoolMode
 from ...problem import MetricName, Problem, Severity
-from ..base import Rule, RuleResult
+from ..base import Rule
+from ._helpers import treatment_from_dosage
 
 if TYPE_CHECKING:
     from ...model import PoolState
@@ -19,49 +20,56 @@ class CyaRule(Rule):
     - Below minimum → :attr:`~...problem.Severity.MEDIUM` (add stabilizer)
     - Above maximum → :attr:`~...problem.Severity.LOW` (no chemical fix; drain)
 
+    For the low case, a :class:`~...recommendation.Treatment` is attached
+    when :attr:`~...model.PoolState.pool` is set.
+
     Disabled in :attr:`~...model.PoolMode.WINTER_PASSIVE` and
     :attr:`~...model.PoolMode.WINTER_ACTIVE` modes.
     """
 
     id = "cya"
     description = "Evaluate cyanuric acid (stabilizer) concentration"
+    priority = 50
 
-    def evaluate(self, state: PoolState) -> RuleResult:  # type: ignore[override]
+    def evaluate(self, state: PoolState) -> list[Problem]:
         """Evaluate CYA level and return a problem when out of range."""
         if (
             state.mode in (PoolMode.WINTER_PASSIVE, PoolMode.WINTER_ACTIVE)
             or state.reading.cya is None
         ):
-            return RuleResult()
+            return []
 
         cya = state.reading.cya
 
         if cya < CYA_MIN:
-            return RuleResult(
-                problems=[
-                    Problem(
-                        code="cya_too_low",
-                        message=f"CYA is too low: {cya:.0f} ppm (minimum {CYA_MIN} ppm)",
-                        severity=Severity.MEDIUM,
-                        metric=MetricName.CYA,
-                        value=cya,
-                        expected_range=(CYA_MIN, CYA_MAX),
-                    )
-                ]
+            code = "cya_too_low"
+            dosage = (
+                compute_cya_adjustment(state.pool, state.reading)
+                if state.pool is not None
+                else None
             )
+            return [
+                Problem(
+                    code=code,
+                    message=f"CYA is too low: {cya:.0f} ppm (minimum {CYA_MIN} ppm)",
+                    severity=Severity.MEDIUM,
+                    metric=MetricName.CYA,
+                    value=cya,
+                    expected_range=(CYA_MIN, CYA_MAX),
+                    treatment=treatment_from_dosage(code, dosage),
+                )
+            ]
 
         if cya > CYA_MAX:
-            return RuleResult(
-                problems=[
-                    Problem(
-                        code="cya_too_high",
-                        message=f"CYA is too high: {cya:.0f} ppm (maximum {CYA_MAX} ppm)",
-                        severity=Severity.LOW,
-                        metric=MetricName.CYA,
-                        value=cya,
-                        expected_range=(CYA_MIN, CYA_MAX),
-                    )
-                ]
-            )
+            return [
+                Problem(
+                    code="cya_too_high",
+                    message=f"CYA is too high: {cya:.0f} ppm (maximum {CYA_MAX} ppm)",
+                    severity=Severity.LOW,
+                    metric=MetricName.CYA,
+                    value=cya,
+                    expected_range=(CYA_MIN, CYA_MAX),
+                )
+            ]
 
-        return RuleResult()
+        return []

--- a/custom_components/poolman/domain/rules/chemistry/hardness.py
+++ b/custom_components/poolman/domain/rules/chemistry/hardness.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ...chemistry import HARDNESS_MAX, HARDNESS_MIN
+from ...chemistry import HARDNESS_MAX, HARDNESS_MIN, compute_hardness_adjustment
 from ...model import PoolMode
 from ...problem import MetricName, Problem, Severity
-from ..base import Rule, RuleResult
+from ..base import Rule
+from ._helpers import treatment_from_dosage
 
 if TYPE_CHECKING:
     from ...model import PoolState
@@ -19,55 +20,62 @@ class HardnessRule(Rule):
     - Below minimum → :attr:`~...problem.Severity.MEDIUM` (add hardness increaser)
     - Above maximum → :attr:`~...problem.Severity.LOW` (no chemical fix; drain)
 
+    For the low case, a :class:`~...recommendation.Treatment` is attached
+    when :attr:`~...model.PoolState.pool` is set.
+
     Disabled in :attr:`~...model.PoolMode.WINTER_PASSIVE` and
     :attr:`~...model.PoolMode.WINTER_ACTIVE` modes.
     """
 
     id = "hardness"
     description = "Evaluate calcium hardness"
+    priority = 60
 
-    def evaluate(self, state: PoolState) -> RuleResult:  # type: ignore[override]
+    def evaluate(self, state: PoolState) -> list[Problem]:
         """Evaluate calcium hardness and return a problem when out of range."""
         if (
             state.mode in (PoolMode.WINTER_PASSIVE, PoolMode.WINTER_ACTIVE)
             or state.reading.hardness is None
         ):
-            return RuleResult()
+            return []
 
         hardness = state.reading.hardness
 
         if hardness < HARDNESS_MIN:
-            return RuleResult(
-                problems=[
-                    Problem(
-                        code="hardness_too_low",
-                        message=(
-                            f"Calcium hardness is too low: {hardness:.0f} ppm"
-                            f" (minimum {HARDNESS_MIN} ppm)"
-                        ),
-                        severity=Severity.MEDIUM,
-                        metric=MetricName.HARDNESS,
-                        value=hardness,
-                        expected_range=(HARDNESS_MIN, HARDNESS_MAX),
-                    )
-                ]
+            code = "hardness_too_low"
+            dosage = (
+                compute_hardness_adjustment(state.pool, state.reading)
+                if state.pool is not None
+                else None
             )
+            return [
+                Problem(
+                    code=code,
+                    message=(
+                        f"Calcium hardness is too low: {hardness:.0f} ppm"
+                        f" (minimum {HARDNESS_MIN} ppm)"
+                    ),
+                    severity=Severity.MEDIUM,
+                    metric=MetricName.HARDNESS,
+                    value=hardness,
+                    expected_range=(HARDNESS_MIN, HARDNESS_MAX),
+                    treatment=treatment_from_dosage(code, dosage),
+                )
+            ]
 
         if hardness > HARDNESS_MAX:
-            return RuleResult(
-                problems=[
-                    Problem(
-                        code="hardness_too_high",
-                        message=(
-                            f"Calcium hardness is too high: {hardness:.0f} ppm"
-                            f" (maximum {HARDNESS_MAX} ppm)"
-                        ),
-                        severity=Severity.LOW,
-                        metric=MetricName.HARDNESS,
-                        value=hardness,
-                        expected_range=(HARDNESS_MIN, HARDNESS_MAX),
-                    )
-                ]
-            )
+            return [
+                Problem(
+                    code="hardness_too_high",
+                    message=(
+                        f"Calcium hardness is too high: {hardness:.0f} ppm"
+                        f" (maximum {HARDNESS_MAX} ppm)"
+                    ),
+                    severity=Severity.LOW,
+                    metric=MetricName.HARDNESS,
+                    value=hardness,
+                    expected_range=(HARDNESS_MIN, HARDNESS_MAX),
+                )
+            ]
 
-        return RuleResult()
+        return []

--- a/custom_components/poolman/domain/rules/chemistry/ph.py
+++ b/custom_components/poolman/domain/rules/chemistry/ph.py
@@ -4,10 +4,17 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ...chemistry import PH_MAX, PH_MIN, PH_TARGET, PH_TOLERANCE
+from ...chemistry import (
+    PH_MAX,
+    PH_MIN,
+    PH_TARGET,
+    PH_TOLERANCE,
+    compute_ph_adjustment,
+)
 from ...model import PoolMode
 from ...problem import MetricName, Problem, Severity
-from ..base import Rule, RuleResult
+from ..base import Rule
+from ._helpers import treatment_from_dosage
 
 if TYPE_CHECKING:
     from ...model import PoolState
@@ -22,22 +29,28 @@ class PhRule(Rule):
     - Delta > 3 x tolerance → :attr:`~...problem.Severity.MEDIUM`
     - Delta > tolerance → :attr:`~...problem.Severity.LOW`
 
+    When :attr:`~...model.PoolState.pool` is set, the rule also pre-computes a
+    :class:`~...recommendation.Treatment` (pH+ or pH-) and attaches it to the
+    produced :class:`~...problem.Problem` for downstream recommendation
+    generation.
+
     Disabled in :attr:`~...model.PoolMode.WINTER_PASSIVE` mode.
     """
 
     id = "ph"
     description = "Detect pH deviation from target range"
+    priority = 20
 
-    def evaluate(self, state: PoolState) -> RuleResult:  # type: ignore[override]
+    def evaluate(self, state: PoolState) -> list[Problem]:
         """Evaluate pH level and return a problem when out of range."""
         if state.mode == PoolMode.WINTER_PASSIVE or state.reading.ph is None:
-            return RuleResult()
+            return []
 
         ph = state.reading.ph
         delta = abs(ph - PH_TARGET)
 
         if delta <= PH_TOLERANCE:
-            return RuleResult()
+            return []
 
         direction = "too_high" if ph > PH_TARGET else "too_low"
         code = f"ph_{direction}"
@@ -53,15 +66,20 @@ class PhRule(Rule):
             f"pH is {direction.replace('_', ' ')}: {ph:.2f}"
             f" (expected {PH_MIN}-{PH_MAX}, target {PH_TARGET})"
         )
-        return RuleResult(
-            problems=[
-                Problem(
-                    code=code,
-                    message=message,
-                    severity=severity,
-                    metric=MetricName.PH,
-                    value=ph,
-                    expected_range=(PH_MIN, PH_MAX),
-                )
-            ]
+
+        dosage = (
+            compute_ph_adjustment(state.pool, state.reading) if state.pool is not None else None
         )
+        treatment = treatment_from_dosage(code, dosage)
+
+        return [
+            Problem(
+                code=code,
+                message=message,
+                severity=severity,
+                metric=MetricName.PH,
+                value=ph,
+                expected_range=(PH_MIN, PH_MAX),
+                treatment=treatment,
+            )
+        ]

--- a/custom_components/poolman/domain/rules/chemistry/salt.py
+++ b/custom_components/poolman/domain/rules/chemistry/salt.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ...chemistry import SALT_MAX, SALT_MIN
+from ...chemistry import SALT_MAX, SALT_MIN, compute_salt_adjustment
 from ...model import PoolMode, TreatmentType
 from ...problem import MetricName, Problem, Severity
-from ..base import Rule, RuleResult
+from ..base import Rule
+from ._helpers import treatment_from_dosage
 
 if TYPE_CHECKING:
     from ...model import PoolState
@@ -24,53 +25,55 @@ class SaltRule(Rule):
     - Below minimum → :attr:`~...problem.Severity.MEDIUM` (add salt)
     - Above maximum → :attr:`~...problem.Severity.LOW` (partial drain)
 
+    For the low case, a :class:`~...recommendation.Treatment` is attached.
+
     Disabled in :attr:`~...model.PoolMode.WINTER_PASSIVE` and
     :attr:`~...model.PoolMode.WINTER_ACTIVE` modes.
     """
 
     id = "salt"
     description = "Evaluate salt concentration for salt electrolysis pools"
+    priority = 70
 
-    def evaluate(self, state: PoolState) -> RuleResult:  # type: ignore[override]
+    def evaluate(self, state: PoolState) -> list[Problem]:
         """Evaluate salt level and return a problem when out of range."""
         if state.pool is None:
-            return RuleResult()
+            return []
         if state.pool.treatment != TreatmentType.SALT_ELECTROLYSIS:
-            return RuleResult()
+            return []
         if (
             state.mode in (PoolMode.WINTER_PASSIVE, PoolMode.WINTER_ACTIVE)
             or state.reading.salt is None
         ):
-            return RuleResult()
+            return []
 
         salt = state.reading.salt
 
         if salt < SALT_MIN:
-            return RuleResult(
-                problems=[
-                    Problem(
-                        code="salt_too_low",
-                        message=f"Salt level is too low: {salt:.0f} ppm (minimum {SALT_MIN} ppm)",
-                        severity=Severity.MEDIUM,
-                        metric=MetricName.SALT,
-                        value=salt,
-                        expected_range=(SALT_MIN, SALT_MAX),
-                    )
-                ]
-            )
+            code = "salt_too_low"
+            dosage = compute_salt_adjustment(state.pool, state.reading)
+            return [
+                Problem(
+                    code=code,
+                    message=f"Salt level is too low: {salt:.0f} ppm (minimum {SALT_MIN} ppm)",
+                    severity=Severity.MEDIUM,
+                    metric=MetricName.SALT,
+                    value=salt,
+                    expected_range=(SALT_MIN, SALT_MAX),
+                    treatment=treatment_from_dosage(code, dosage),
+                )
+            ]
 
         if salt > SALT_MAX:
-            return RuleResult(
-                problems=[
-                    Problem(
-                        code="salt_too_high",
-                        message=f"Salt level is too high: {salt:.0f} ppm (maximum {SALT_MAX} ppm)",
-                        severity=Severity.LOW,
-                        metric=MetricName.SALT,
-                        value=salt,
-                        expected_range=(SALT_MIN, SALT_MAX),
-                    )
-                ]
-            )
+            return [
+                Problem(
+                    code="salt_too_high",
+                    message=f"Salt level is too high: {salt:.0f} ppm (maximum {SALT_MAX} ppm)",
+                    severity=Severity.LOW,
+                    metric=MetricName.SALT,
+                    value=salt,
+                    expected_range=(SALT_MIN, SALT_MAX),
+                )
+            ]
 
-        return RuleResult()
+        return []

--- a/custom_components/poolman/domain/rules/chemistry/sanitizer.py
+++ b/custom_components/poolman/domain/rules/chemistry/sanitizer.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ...chemistry import ORP_MAX, ORP_MIN_ACCEPTABLE, compute_sanitizer_status
-from ...model import PoolMode
+from ...model import ChemicalProduct, PoolMode
 from ...problem import MetricName, Problem, Severity
-from ..base import Rule, RuleResult
+from ...recommendation import Treatment
+from ..base import Rule
 
 if TYPE_CHECKING:
     from ...model import PoolState
@@ -20,8 +21,11 @@ class SanitizerRule(Rule):
     acceptable range (ORP_MIN_ACCEPTABLE - ORP_MAX).
 
     Requires :attr:`~...model.PoolState.pool` to determine the treatment
-    type.  Returns an empty :class:`~..base.RuleResult` when ``pool`` is
-    ``None``.
+    type.  Returns an empty list when ``pool`` is ``None``.
+
+    For the high-ORP case, a :class:`~...recommendation.Treatment` with
+    :attr:`~...model.ChemicalProduct.NEUTRALIZER` is attached.  The low-ORP
+    case has no specific product (operator is asked to increase sanitizer).
 
     Disabled in :attr:`~...model.PoolMode.WINTER_PASSIVE` and
     :attr:`~...model.PoolMode.WINTER_ACTIVE` modes.
@@ -29,46 +33,52 @@ class SanitizerRule(Rule):
 
     id = "sanitizer"
     description = "Evaluate sanitizer effectiveness via ORP"
+    priority = 40
 
-    def evaluate(self, state: PoolState) -> RuleResult:  # type: ignore[override]
+    def evaluate(self, state: PoolState) -> list[Problem]:
         """Evaluate sanitizer via ORP and return a problem when out of range."""
         if state.mode in (PoolMode.WINTER_PASSIVE, PoolMode.WINTER_ACTIVE):
-            return RuleResult()
+            return []
         if state.pool is None or state.reading.orp is None:
-            return RuleResult()
+            return []
 
         result = compute_sanitizer_status(state.reading, state.pool.treatment)
         if result is None:
-            return RuleResult()
+            return []
 
         orp = state.reading.orp
 
         if orp > ORP_MAX:
-            return RuleResult(
-                problems=[
-                    Problem(
-                        code="orp_too_high",
-                        message=f"ORP is too high: {orp:.0f} mV (maximum {ORP_MAX} mV)",
-                        severity=Severity.MEDIUM,
-                        metric=MetricName.ORP,
-                        value=orp,
-                        expected_range=(ORP_MIN_ACCEPTABLE, ORP_MAX),
-                    )
-                ]
-            )
-
-        severity = Severity.CRITICAL if result.severity == Severity.CRITICAL else Severity.MEDIUM
-        return RuleResult(
-            problems=[
+            code = "orp_too_high"
+            product_id = ChemicalProduct.NEUTRALIZER.value
+            return [
                 Problem(
-                    code="orp_too_low",
-                    message=(
-                        f"ORP is too low: {orp:.0f} mV (minimum acceptable {ORP_MIN_ACCEPTABLE} mV)"
-                    ),
-                    severity=severity,
+                    code=code,
+                    message=f"ORP is too high: {orp:.0f} mV (maximum {ORP_MAX} mV)",
+                    severity=Severity.MEDIUM,
                     metric=MetricName.ORP,
                     value=orp,
                     expected_range=(ORP_MIN_ACCEPTABLE, ORP_MAX),
+                    treatment=Treatment(
+                        id=f"{code}_{product_id}",
+                        product_id=product_id,
+                        name=product_id.replace("_", " ").title(),
+                        quantity=0.0,
+                        unit="g",
+                    ),
                 )
             ]
-        )
+
+        severity = Severity.CRITICAL if result.severity == Severity.CRITICAL else Severity.MEDIUM
+        return [
+            Problem(
+                code="orp_too_low",
+                message=(
+                    f"ORP is too low: {orp:.0f} mV (minimum acceptable {ORP_MIN_ACCEPTABLE} mV)"
+                ),
+                severity=severity,
+                metric=MetricName.ORP,
+                value=orp,
+                expected_range=(ORP_MIN_ACCEPTABLE, ORP_MAX),
+            )
+        ]

--- a/custom_components/poolman/domain/rules/chemistry/tds.py
+++ b/custom_components/poolman/domain/rules/chemistry/tds.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from ...chemistry import TDS_MAX, TDS_MIN
 from ...model import PoolMode, TreatmentType
 from ...problem import MetricName, Problem, Severity
-from ..base import Rule, RuleResult
+from ..base import Rule
 
 if TYPE_CHECKING:
     from ...model import PoolState
@@ -23,54 +23,53 @@ class TdsRule(Rule):
     - Above maximum → :attr:`~...problem.Severity.MEDIUM` (partial drain)
     - Below minimum → :attr:`~...problem.Severity.LOW` (check EC sensor)
 
+    No chemical treatment is associated with TDS deviations.
+
     Disabled in :attr:`~...model.PoolMode.WINTER_PASSIVE` and
     :attr:`~...model.PoolMode.WINTER_ACTIVE` modes.
     """
 
     id = "tds"
     description = "Evaluate Total Dissolved Solids (TDS) level"
+    priority = 80
 
-    def evaluate(self, state: PoolState) -> RuleResult:  # type: ignore[override]
+    def evaluate(self, state: PoolState) -> list[Problem]:
         """Evaluate TDS level and return a problem when out of range."""
         if state.pool is None:
-            return RuleResult()
+            return []
         # Salt electrolysis pools naturally have high TDS from dissolved salt
         if state.pool.treatment == TreatmentType.SALT_ELECTROLYSIS:
-            return RuleResult()
+            return []
         if (
             state.mode in (PoolMode.WINTER_PASSIVE, PoolMode.WINTER_ACTIVE)
             or state.reading.tds is None
         ):
-            return RuleResult()
+            return []
 
         tds = state.reading.tds
 
         if tds > TDS_MAX:
-            return RuleResult(
-                problems=[
-                    Problem(
-                        code="tds_too_high",
-                        message=f"TDS is too high: {tds:.0f} ppm (maximum {TDS_MAX} ppm)",
-                        severity=Severity.MEDIUM,
-                        metric=MetricName.TDS,
-                        value=tds,
-                        expected_range=(TDS_MIN, TDS_MAX),
-                    )
-                ]
-            )
+            return [
+                Problem(
+                    code="tds_too_high",
+                    message=f"TDS is too high: {tds:.0f} ppm (maximum {TDS_MAX} ppm)",
+                    severity=Severity.MEDIUM,
+                    metric=MetricName.TDS,
+                    value=tds,
+                    expected_range=(TDS_MIN, TDS_MAX),
+                )
+            ]
 
         if tds < TDS_MIN:
-            return RuleResult(
-                problems=[
-                    Problem(
-                        code="tds_too_low",
-                        message=f"TDS is unusually low: {tds:.0f} ppm (minimum {TDS_MIN} ppm)",
-                        severity=Severity.LOW,
-                        metric=MetricName.TDS,
-                        value=tds,
-                        expected_range=(TDS_MIN, TDS_MAX),
-                    )
-                ]
-            )
+            return [
+                Problem(
+                    code="tds_too_low",
+                    message=f"TDS is unusually low: {tds:.0f} ppm (minimum {TDS_MIN} ppm)",
+                    severity=Severity.LOW,
+                    metric=MetricName.TDS,
+                    value=tds,
+                    expected_range=(TDS_MIN, TDS_MAX),
+                )
+            ]
 
-        return RuleResult()
+        return []

--- a/custom_components/poolman/domain/rules/engine.py
+++ b/custom_components/poolman/domain/rules/engine.py
@@ -25,9 +25,10 @@ _SEVERITY_ORDER: dict[Severity, int] = {
 class RuleEngine:
     """Evaluates all registered rules against a pool state snapshot.
 
-    Rules are evaluated in registration order. All detected
-    :class:`~..problem.Problem` objects are collected and returned sorted
-    by severity (critical first).
+    Rules are sorted by :attr:`~.base.Rule.priority` (ascending) at engine
+    construction.  All detected :class:`~..problem.Problem` objects are then
+    collected and the final list is sorted by :class:`~..problem.Severity`
+    (critical first).
 
     Example::
 
@@ -37,16 +38,19 @@ class RuleEngine:
             print(f"[{problem.severity}] {problem.code}: {problem.message}")
 
     Attributes:
-        rules: The list of rules evaluated on each call to :meth:`evaluate`.
+        rules: The list of rules evaluated on each call to :meth:`evaluate`,
+            sorted by :attr:`~.base.Rule.priority`.
     """
 
     def __init__(self, rules: list[Rule]) -> None:
         """Initialize the engine with a list of rules.
 
         Args:
-            rules: Ordered list of :class:`~.base.Rule` instances to run.
+            rules: List of :class:`~.base.Rule` instances to run.  The
+                engine sorts them by :attr:`~.base.Rule.priority` (ascending)
+                so call order is independent of the argument order.
         """
-        self.rules = rules
+        self.rules = sorted(rules, key=lambda r: r.priority)
 
     def evaluate(self, state: PoolState) -> list[Problem]:
         """Run all rules and return detected problems sorted by severity.
@@ -55,10 +59,12 @@ class RuleEngine:
             state: Current pool state snapshot.
 
         Returns:
-            All problems from all rules, sorted critical-first.
+            All problems from all rules, sorted critical-first.  The sort is
+            stable, so equal-severity problems retain the rule-priority
+            order in which they were produced.
         """
         problems: list[Problem] = []
         for rule in self.rules:
-            problems.extend(rule.evaluate(state).problems)
+            problems.extend(rule.evaluate(state))
         problems.sort(key=lambda p: _SEVERITY_ORDER.get(p.severity, 99))
         return problems

--- a/custom_components/poolman/domain/rules/filtration/filtration.py
+++ b/custom_components/poolman/domain/rules/filtration/filtration.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from ...filtration import compute_filtration_duration
 from ...model import PoolMode
 from ...problem import Problem, Severity
-from ..base import Rule, RuleResult
+from ..base import Rule
 
 if TYPE_CHECKING:
     from ...model import PoolState
@@ -29,28 +29,25 @@ class FiltrationRule(Rule):
 
     id = "filtration"
     description = "Signal required filtration duration"
+    priority = 100
 
-    def evaluate(self, state: PoolState) -> RuleResult:  # type: ignore[override]
+    def evaluate(self, state: PoolState) -> list[Problem]:
         """Evaluate filtration needs and return a problem when action is due."""
         if state.mode == PoolMode.WINTER_PASSIVE:
-            return RuleResult()
+            return []
         if state.pool is None:
-            return RuleResult()
+            return []
 
         hours = compute_filtration_duration(state.pool, state.reading, state.mode)
         if hours is None:
-            return RuleResult()
+            return []
 
         severity = Severity.MEDIUM if hours >= 12 else Severity.LOW
-        return RuleResult(
-            problems=[
-                Problem(
-                    code="filtration_required",
-                    message=f"Run filtration for {hours:.1f} hours today",
-                    severity=severity,
-                    metric=None,
-                    value=hours,
-                    expected_range=None,
-                )
-            ]
-        )
+        return [
+            Problem(
+                code="filtration_required",
+                message=f"Run filtration for {hours:.1f} hours today",
+                severity=severity,
+                value=hours,
+            )
+        ]

--- a/custom_components/poolman/domain/rules/maintenance/calibration.py
+++ b/custom_components/poolman/domain/rules/maintenance/calibration.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from ...model import MeasureParameter, PoolMode
 from ...problem import Problem, Severity
-from ..base import Rule, RuleResult
+from ..base import Rule
 
 if TYPE_CHECKING:
     from ...model import PoolState
@@ -73,13 +73,14 @@ class CalibrationRule(Rule):
 
     id = "calibration"
     description = "Detect sensor vs. manual measurement deviation"
+    priority = 10
 
-    def evaluate(self, state: PoolState) -> RuleResult:  # type: ignore[override]
+    def evaluate(self, state: PoolState) -> list[Problem]:
         """Compare sensor readings against manual measures and flag deviations."""
         if state.mode == PoolMode.WINTER_PASSIVE:
-            return RuleResult()
+            return []
         if state.raw_sensor_reading is None or not state.manual_measures:
-            return RuleResult()
+            return []
 
         problems: list[Problem] = []
         for param, measure in state.manual_measures.items():
@@ -108,10 +109,8 @@ class CalibrationRule(Rule):
                             " Consider sensor recalibration or a new manual measurement."
                         ),
                         severity=Severity.LOW,
-                        metric=None,
                         value=sensor_value,
-                        expected_range=None,
                     )
                 )
 
-        return RuleResult(problems=problems)
+        return problems

--- a/tests/domain/rules/chemistry/test_algae.py
+++ b/tests/domain/rules/chemistry/test_algae.py
@@ -13,51 +13,51 @@ class TestAlgaeRiskRule:
     """Tests for algae risk detection."""
 
     def test_warm_and_low_orp_triggers_critical(self, pool: Pool) -> None:
-        result = AlgaeRiskRule().evaluate(make_state(pool, PoolReading(temp_c=30.0, orp=650.0)))
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "algae_risk"
-        assert result.problems[0].severity == Severity.CRITICAL
-        assert result.problems[0].metric == MetricName.ORP
+        problems = AlgaeRiskRule().evaluate(make_state(pool, PoolReading(temp_c=30.0, orp=650.0)))
+        assert len(problems) == 1
+        assert problems[0].code == "algae_risk"
+        assert problems[0].severity == Severity.CRITICAL
+        assert problems[0].metric == MetricName.ORP
 
     def test_cool_water_no_risk(self, pool: Pool) -> None:
-        result = AlgaeRiskRule().evaluate(make_state(pool, PoolReading(temp_c=22.0, orp=650.0)))
-        assert result.problems == []
+        problems = AlgaeRiskRule().evaluate(make_state(pool, PoolReading(temp_c=22.0, orp=650.0)))
+        assert problems == []
 
     def test_warm_but_good_orp_no_risk(self, pool: Pool) -> None:
-        result = AlgaeRiskRule().evaluate(make_state(pool, PoolReading(temp_c=30.0, orp=750.0)))
-        assert result.problems == []
+        problems = AlgaeRiskRule().evaluate(make_state(pool, PoolReading(temp_c=30.0, orp=750.0)))
+        assert problems == []
 
     def test_missing_data_no_risk(self, pool: Pool) -> None:
-        result = AlgaeRiskRule().evaluate(make_state(pool, PoolReading(temp_c=30.0)))
-        assert result.problems == []
+        problems = AlgaeRiskRule().evaluate(make_state(pool, PoolReading(temp_c=30.0)))
+        assert problems == []
 
     def test_winter_passive_skips(self, pool: Pool) -> None:
-        result = AlgaeRiskRule().evaluate(
+        problems = AlgaeRiskRule().evaluate(
             make_state(pool, PoolReading(temp_c=30.0, orp=650.0), PoolMode.WINTER_PASSIVE)
         )
-        assert result.problems == []
+        assert problems == []
 
     def test_winter_active_skips(self, pool: Pool) -> None:
-        result = AlgaeRiskRule().evaluate(
+        problems = AlgaeRiskRule().evaluate(
             make_state(pool, PoolReading(temp_c=30.0, orp=650.0), PoolMode.WINTER_ACTIVE)
         )
-        assert result.problems == []
+        assert problems == []
 
     def test_hibernating_evaluates(self, pool: Pool) -> None:
-        result = AlgaeRiskRule().evaluate(
+        problems = AlgaeRiskRule().evaluate(
             make_state(pool, PoolReading(temp_c=30.0, orp=650.0), PoolMode.HIBERNATING)
         )
-        assert len(result.problems) == 1
-        assert result.problems[0].severity == Severity.CRITICAL
+        assert len(problems) == 1
+        assert problems[0].severity == Severity.CRITICAL
 
     def test_activating_evaluates(self, pool: Pool) -> None:
-        result = AlgaeRiskRule().evaluate(
+        problems = AlgaeRiskRule().evaluate(
             make_state(pool, PoolReading(temp_c=30.0, orp=650.0), PoolMode.ACTIVATING)
         )
-        assert len(result.problems) == 1
-        assert result.problems[0].severity == Severity.CRITICAL
+        assert len(problems) == 1
+        assert problems[0].severity == Severity.CRITICAL
 
     def test_message_includes_temp_and_orp(self, pool: Pool) -> None:
-        result = AlgaeRiskRule().evaluate(make_state(pool, PoolReading(temp_c=30.0, orp=650.0)))
-        assert "30.0" in result.problems[0].message
-        assert "650" in result.problems[0].message
+        problems = AlgaeRiskRule().evaluate(make_state(pool, PoolReading(temp_c=30.0, orp=650.0)))
+        assert "30.0" in problems[0].message
+        assert "650" in problems[0].message

--- a/tests/domain/rules/chemistry/test_alkalinity.py
+++ b/tests/domain/rules/chemistry/test_alkalinity.py
@@ -13,43 +13,45 @@ class TestTacRule:
     """Tests for TAC rule evaluation."""
 
     def test_tac_in_range_no_problem(self, pool: Pool) -> None:
-        result = TacRule().evaluate(make_state(pool, PoolReading(tac=120.0)))
-        assert result.problems == []
+        problems = TacRule().evaluate(make_state(pool, PoolReading(tac=120.0)))
+        assert problems == []
 
     def test_low_tac_returns_problem(self, pool: Pool) -> None:
-        result = TacRule().evaluate(make_state(pool, PoolReading(tac=50.0)))
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "alkalinity_too_low"
-        assert result.problems[0].metric == MetricName.ALKALINITY
-        assert result.problems[0].severity == Severity.MEDIUM
+        problems = TacRule().evaluate(make_state(pool, PoolReading(tac=50.0)))
+        assert len(problems) == 1
+        assert problems[0].code == "alkalinity_too_low"
+        assert problems[0].metric == MetricName.ALKALINITY
+        assert problems[0].severity == Severity.MEDIUM
 
     def test_high_tac_returns_low_severity_problem(self, pool: Pool) -> None:
-        result = TacRule().evaluate(make_state(pool, PoolReading(tac=160.0)))
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "alkalinity_too_high"
-        assert result.problems[0].severity == Severity.LOW
-        assert "too high" in result.problems[0].message.lower()
+        problems = TacRule().evaluate(make_state(pool, PoolReading(tac=160.0)))
+        assert len(problems) == 1
+        assert problems[0].code == "alkalinity_too_high"
+        assert problems[0].severity == Severity.LOW
+        assert "too high" in problems[0].message.lower()
 
     def test_winter_passive_skips(self, pool: Pool) -> None:
-        result = TacRule().evaluate(
+        problems = TacRule().evaluate(
             make_state(pool, PoolReading(tac=50.0), PoolMode.WINTER_PASSIVE)
         )
-        assert result.problems == []
+        assert problems == []
 
     def test_winter_active_skips(self, pool: Pool) -> None:
-        result = TacRule().evaluate(make_state(pool, PoolReading(tac=50.0), PoolMode.WINTER_ACTIVE))
-        assert result.problems == []
+        problems = TacRule().evaluate(
+            make_state(pool, PoolReading(tac=50.0), PoolMode.WINTER_ACTIVE)
+        )
+        assert problems == []
 
     def test_hibernating_evaluates(self, pool: Pool) -> None:
-        result = TacRule().evaluate(make_state(pool, PoolReading(tac=50.0), PoolMode.HIBERNATING))
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "alkalinity_too_low"
+        problems = TacRule().evaluate(make_state(pool, PoolReading(tac=50.0), PoolMode.HIBERNATING))
+        assert len(problems) == 1
+        assert problems[0].code == "alkalinity_too_low"
 
     def test_activating_evaluates(self, pool: Pool) -> None:
-        result = TacRule().evaluate(make_state(pool, PoolReading(tac=50.0), PoolMode.ACTIVATING))
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "alkalinity_too_low"
+        problems = TacRule().evaluate(make_state(pool, PoolReading(tac=50.0), PoolMode.ACTIVATING))
+        assert len(problems) == 1
+        assert problems[0].code == "alkalinity_too_low"
 
     def test_none_tac_skips(self, pool: Pool) -> None:
-        result = TacRule().evaluate(make_state(pool, PoolReading()))
-        assert result.problems == []
+        problems = TacRule().evaluate(make_state(pool, PoolReading()))
+        assert problems == []

--- a/tests/domain/rules/chemistry/test_chlorine.py
+++ b/tests/domain/rules/chemistry/test_chlorine.py
@@ -15,58 +15,58 @@ class TestFreeChlorineRule:
     """Tests for free chlorine rule evaluation."""
 
     def test_in_range_no_problem(self, pool: Pool) -> None:
-        result = FreeChlorineRule().evaluate(make_state(pool, PoolReading(free_chlorine=2.0)))
-        assert result.problems == []
+        problems = FreeChlorineRule().evaluate(make_state(pool, PoolReading(free_chlorine=2.0)))
+        assert problems == []
 
     def test_too_low_returns_critical_problem(self, pool: Pool) -> None:
-        result = FreeChlorineRule().evaluate(make_state(pool, PoolReading(free_chlorine=0.5)))
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "chlorine_too_low"
-        assert result.problems[0].severity == Severity.CRITICAL
-        assert result.problems[0].metric == MetricName.CHLORINE
-        assert result.problems[0].value == pytest.approx(0.5)
+        problems = FreeChlorineRule().evaluate(make_state(pool, PoolReading(free_chlorine=0.5)))
+        assert len(problems) == 1
+        assert problems[0].code == "chlorine_too_low"
+        assert problems[0].severity == Severity.CRITICAL
+        assert problems[0].metric == MetricName.CHLORINE
+        assert problems[0].value == pytest.approx(0.5)
 
     def test_too_high_returns_low_severity_problem(self, pool: Pool) -> None:
-        result = FreeChlorineRule().evaluate(make_state(pool, PoolReading(free_chlorine=4.0)))
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "chlorine_too_high"
-        assert result.problems[0].severity == Severity.LOW
-        assert result.problems[0].metric == MetricName.CHLORINE
+        problems = FreeChlorineRule().evaluate(make_state(pool, PoolReading(free_chlorine=4.0)))
+        assert len(problems) == 1
+        assert problems[0].code == "chlorine_too_high"
+        assert problems[0].severity == Severity.LOW
+        assert problems[0].metric == MetricName.CHLORINE
 
     def test_none_no_problem(self, pool: Pool) -> None:
-        result = FreeChlorineRule().evaluate(make_state(pool, PoolReading(free_chlorine=None)))
-        assert result.problems == []
+        problems = FreeChlorineRule().evaluate(make_state(pool, PoolReading(free_chlorine=None)))
+        assert problems == []
 
     def test_winter_passive_skips(self, pool: Pool) -> None:
-        result = FreeChlorineRule().evaluate(
+        problems = FreeChlorineRule().evaluate(
             make_state(pool, PoolReading(free_chlorine=0.5), PoolMode.WINTER_PASSIVE)
         )
-        assert result.problems == []
+        assert problems == []
 
     def test_winter_active_skips(self, pool: Pool) -> None:
-        result = FreeChlorineRule().evaluate(
+        problems = FreeChlorineRule().evaluate(
             make_state(pool, PoolReading(free_chlorine=0.5), PoolMode.WINTER_ACTIVE)
         )
-        assert result.problems == []
+        assert problems == []
 
     def test_hibernating_evaluates(self, pool: Pool) -> None:
-        result = FreeChlorineRule().evaluate(
+        problems = FreeChlorineRule().evaluate(
             make_state(pool, PoolReading(free_chlorine=0.5), PoolMode.HIBERNATING)
         )
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "chlorine_too_low"
+        assert len(problems) == 1
+        assert problems[0].code == "chlorine_too_low"
 
     def test_activating_evaluates(self, pool: Pool) -> None:
-        result = FreeChlorineRule().evaluate(
+        problems = FreeChlorineRule().evaluate(
             make_state(pool, PoolReading(free_chlorine=0.5), PoolMode.ACTIVATING)
         )
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "chlorine_too_low"
+        assert len(problems) == 1
+        assert problems[0].code == "chlorine_too_low"
 
     def test_at_min_no_problem(self, pool: Pool) -> None:
-        result = FreeChlorineRule().evaluate(make_state(pool, PoolReading(free_chlorine=1.0)))
-        assert result.problems == []
+        problems = FreeChlorineRule().evaluate(make_state(pool, PoolReading(free_chlorine=1.0)))
+        assert problems == []
 
     def test_at_max_no_problem(self, pool: Pool) -> None:
-        result = FreeChlorineRule().evaluate(make_state(pool, PoolReading(free_chlorine=3.0)))
-        assert result.problems == []
+        problems = FreeChlorineRule().evaluate(make_state(pool, PoolReading(free_chlorine=3.0)))
+        assert problems == []

--- a/tests/domain/rules/chemistry/test_cya.py
+++ b/tests/domain/rules/chemistry/test_cya.py
@@ -15,55 +15,54 @@ class TestCyaRule:
     """Tests for CYA (cyanuric acid) rule evaluation."""
 
     def test_cya_in_range_no_problem(self, pool: Pool) -> None:
-        result = CyaRule().evaluate(make_state(pool, PoolReading(cya=40.0)))
-        assert result.problems == []
+        problems = CyaRule().evaluate(make_state(pool, PoolReading(cya=40.0)))
+        assert problems == []
 
     def test_cya_too_low_returns_medium_problem(self, pool: Pool) -> None:
-        result = CyaRule().evaluate(make_state(pool, PoolReading(cya=10.0)))
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "cya_too_low"
-        assert result.problems[0].metric == MetricName.CYA
-        assert result.problems[0].severity == Severity.MEDIUM
-        assert result.problems[0].value == pytest.approx(10.0)
+        problems = CyaRule().evaluate(make_state(pool, PoolReading(cya=10.0)))
+        assert len(problems) == 1
+        assert problems[0].code == "cya_too_low"
+        assert problems[0].metric == MetricName.CYA
+        assert problems[0].severity == Severity.MEDIUM
+        assert problems[0].value == pytest.approx(10.0)
 
     def test_cya_too_high_returns_low_problem(self, pool: Pool) -> None:
-        result = CyaRule().evaluate(make_state(pool, PoolReading(cya=100.0)))
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "cya_too_high"
-        assert result.problems[0].severity == Severity.LOW
-        assert (
-            "drain" in result.problems[0].message.lower()
-            or "too high" in result.problems[0].message.lower()
-        )
+        problems = CyaRule().evaluate(make_state(pool, PoolReading(cya=100.0)))
+        assert len(problems) == 1
+        assert problems[0].code == "cya_too_high"
+        assert problems[0].severity == Severity.LOW
+        assert "drain" in problems[0].message.lower() or "too high" in problems[0].message.lower()
 
     def test_cya_none_no_problem(self, pool: Pool) -> None:
-        result = CyaRule().evaluate(make_state(pool, PoolReading(cya=None)))
-        assert result.problems == []
+        problems = CyaRule().evaluate(make_state(pool, PoolReading(cya=None)))
+        assert problems == []
 
     def test_winter_passive_skips(self, pool: Pool) -> None:
-        result = CyaRule().evaluate(
+        problems = CyaRule().evaluate(
             make_state(pool, PoolReading(cya=10.0), PoolMode.WINTER_PASSIVE)
         )
-        assert result.problems == []
+        assert problems == []
 
     def test_winter_active_skips(self, pool: Pool) -> None:
-        result = CyaRule().evaluate(make_state(pool, PoolReading(cya=10.0), PoolMode.WINTER_ACTIVE))
-        assert result.problems == []
+        problems = CyaRule().evaluate(
+            make_state(pool, PoolReading(cya=10.0), PoolMode.WINTER_ACTIVE)
+        )
+        assert problems == []
 
     def test_hibernating_evaluates(self, pool: Pool) -> None:
-        result = CyaRule().evaluate(make_state(pool, PoolReading(cya=10.0), PoolMode.HIBERNATING))
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "cya_too_low"
+        problems = CyaRule().evaluate(make_state(pool, PoolReading(cya=10.0), PoolMode.HIBERNATING))
+        assert len(problems) == 1
+        assert problems[0].code == "cya_too_low"
 
     def test_activating_evaluates(self, pool: Pool) -> None:
-        result = CyaRule().evaluate(make_state(pool, PoolReading(cya=10.0), PoolMode.ACTIVATING))
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "cya_too_low"
+        problems = CyaRule().evaluate(make_state(pool, PoolReading(cya=10.0), PoolMode.ACTIVATING))
+        assert len(problems) == 1
+        assert problems[0].code == "cya_too_low"
 
     def test_cya_at_min_no_problem(self, pool: Pool) -> None:
-        result = CyaRule().evaluate(make_state(pool, PoolReading(cya=20.0)))
-        assert result.problems == []
+        problems = CyaRule().evaluate(make_state(pool, PoolReading(cya=20.0)))
+        assert problems == []
 
     def test_cya_at_max_no_problem(self, pool: Pool) -> None:
-        result = CyaRule().evaluate(make_state(pool, PoolReading(cya=75.0)))
-        assert result.problems == []
+        problems = CyaRule().evaluate(make_state(pool, PoolReading(cya=75.0)))
+        assert problems == []

--- a/tests/domain/rules/chemistry/test_hardness.py
+++ b/tests/domain/rules/chemistry/test_hardness.py
@@ -15,57 +15,57 @@ class TestHardnessRule:
     """Tests for calcium hardness rule evaluation."""
 
     def test_hardness_in_range_no_problem(self, pool: Pool) -> None:
-        result = HardnessRule().evaluate(make_state(pool, PoolReading(hardness=250.0)))
-        assert result.problems == []
+        problems = HardnessRule().evaluate(make_state(pool, PoolReading(hardness=250.0)))
+        assert problems == []
 
     def test_hardness_too_low_returns_medium_problem(self, pool: Pool) -> None:
-        result = HardnessRule().evaluate(make_state(pool, PoolReading(hardness=100.0)))
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "hardness_too_low"
-        assert result.problems[0].metric == MetricName.HARDNESS
-        assert result.problems[0].severity == Severity.MEDIUM
-        assert result.problems[0].value == pytest.approx(100.0)
+        problems = HardnessRule().evaluate(make_state(pool, PoolReading(hardness=100.0)))
+        assert len(problems) == 1
+        assert problems[0].code == "hardness_too_low"
+        assert problems[0].metric == MetricName.HARDNESS
+        assert problems[0].severity == Severity.MEDIUM
+        assert problems[0].value == pytest.approx(100.0)
 
     def test_hardness_too_high_returns_low_problem(self, pool: Pool) -> None:
-        result = HardnessRule().evaluate(make_state(pool, PoolReading(hardness=500.0)))
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "hardness_too_high"
-        assert result.problems[0].severity == Severity.LOW
+        problems = HardnessRule().evaluate(make_state(pool, PoolReading(hardness=500.0)))
+        assert len(problems) == 1
+        assert problems[0].code == "hardness_too_high"
+        assert problems[0].severity == Severity.LOW
 
     def test_hardness_none_no_problem(self, pool: Pool) -> None:
-        result = HardnessRule().evaluate(make_state(pool, PoolReading(hardness=None)))
-        assert result.problems == []
+        problems = HardnessRule().evaluate(make_state(pool, PoolReading(hardness=None)))
+        assert problems == []
 
     def test_winter_passive_skips(self, pool: Pool) -> None:
-        result = HardnessRule().evaluate(
+        problems = HardnessRule().evaluate(
             make_state(pool, PoolReading(hardness=100.0), PoolMode.WINTER_PASSIVE)
         )
-        assert result.problems == []
+        assert problems == []
 
     def test_winter_active_skips(self, pool: Pool) -> None:
-        result = HardnessRule().evaluate(
+        problems = HardnessRule().evaluate(
             make_state(pool, PoolReading(hardness=100.0), PoolMode.WINTER_ACTIVE)
         )
-        assert result.problems == []
+        assert problems == []
 
     def test_hibernating_evaluates(self, pool: Pool) -> None:
-        result = HardnessRule().evaluate(
+        problems = HardnessRule().evaluate(
             make_state(pool, PoolReading(hardness=100.0), PoolMode.HIBERNATING)
         )
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "hardness_too_low"
+        assert len(problems) == 1
+        assert problems[0].code == "hardness_too_low"
 
     def test_activating_evaluates(self, pool: Pool) -> None:
-        result = HardnessRule().evaluate(
+        problems = HardnessRule().evaluate(
             make_state(pool, PoolReading(hardness=100.0), PoolMode.ACTIVATING)
         )
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "hardness_too_low"
+        assert len(problems) == 1
+        assert problems[0].code == "hardness_too_low"
 
     def test_hardness_at_min_no_problem(self, pool: Pool) -> None:
-        result = HardnessRule().evaluate(make_state(pool, PoolReading(hardness=150.0)))
-        assert result.problems == []
+        problems = HardnessRule().evaluate(make_state(pool, PoolReading(hardness=150.0)))
+        assert problems == []
 
     def test_hardness_at_max_no_problem(self, pool: Pool) -> None:
-        result = HardnessRule().evaluate(make_state(pool, PoolReading(hardness=400.0)))
-        assert result.problems == []
+        problems = HardnessRule().evaluate(make_state(pool, PoolReading(hardness=400.0)))
+        assert problems == []

--- a/tests/domain/rules/chemistry/test_ph.py
+++ b/tests/domain/rules/chemistry/test_ph.py
@@ -15,67 +15,67 @@ class TestPhRule:
     """Tests for pH rule evaluation."""
 
     def test_good_ph_no_problem(self, pool: Pool) -> None:
-        result = PhRule().evaluate(make_state(pool, PoolReading(ph=7.2)))
-        assert result.problems == []
+        problems = PhRule().evaluate(make_state(pool, PoolReading(ph=7.2)))
+        assert problems == []
 
     def test_high_ph_returns_problem(self, pool: Pool) -> None:
-        result = PhRule().evaluate(make_state(pool, PoolReading(ph=7.8)))
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "ph_too_high"
-        assert result.problems[0].metric == MetricName.PH
-        assert result.problems[0].value == pytest.approx(7.8)
+        problems = PhRule().evaluate(make_state(pool, PoolReading(ph=7.8)))
+        assert len(problems) == 1
+        assert problems[0].code == "ph_too_high"
+        assert problems[0].metric == MetricName.PH
+        assert problems[0].value == pytest.approx(7.8)
 
     def test_low_ph_returns_critical_problem(self, pool: Pool) -> None:
-        result = PhRule().evaluate(make_state(pool, PoolReading(ph=6.6)))
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "ph_too_low"
-        assert result.problems[0].severity == Severity.CRITICAL
-        assert result.problems[0].metric == MetricName.PH
+        problems = PhRule().evaluate(make_state(pool, PoolReading(ph=6.6)))
+        assert len(problems) == 1
+        assert problems[0].code == "ph_too_low"
+        assert problems[0].severity == Severity.CRITICAL
+        assert problems[0].metric == MetricName.PH
 
     def test_winter_passive_skips(self, pool: Pool) -> None:
-        result = PhRule().evaluate(make_state(pool, PoolReading(ph=8.5), PoolMode.WINTER_PASSIVE))
-        assert result.problems == []
+        problems = PhRule().evaluate(make_state(pool, PoolReading(ph=8.5), PoolMode.WINTER_PASSIVE))
+        assert problems == []
 
     def test_winter_active_evaluates(self, pool: Pool) -> None:
         """pH rule should still evaluate in active winter mode (equipment protection)."""
-        result = PhRule().evaluate(make_state(pool, PoolReading(ph=7.8), PoolMode.WINTER_ACTIVE))
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "ph_too_high"
+        problems = PhRule().evaluate(make_state(pool, PoolReading(ph=7.8), PoolMode.WINTER_ACTIVE))
+        assert len(problems) == 1
+        assert problems[0].code == "ph_too_high"
 
     def test_hibernating_evaluates(self, pool: Pool) -> None:
-        result = PhRule().evaluate(make_state(pool, PoolReading(ph=7.8), PoolMode.HIBERNATING))
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "ph_too_high"
+        problems = PhRule().evaluate(make_state(pool, PoolReading(ph=7.8), PoolMode.HIBERNATING))
+        assert len(problems) == 1
+        assert problems[0].code == "ph_too_high"
 
     def test_activating_evaluates(self, pool: Pool) -> None:
-        result = PhRule().evaluate(make_state(pool, PoolReading(ph=7.8), PoolMode.ACTIVATING))
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "ph_too_high"
+        problems = PhRule().evaluate(make_state(pool, PoolReading(ph=7.8), PoolMode.ACTIVATING))
+        assert len(problems) == 1
+        assert problems[0].code == "ph_too_high"
 
     def test_slightly_off_ph_returns_low_severity(self, pool: Pool) -> None:
         """pH slightly off target (delta <= tolerance*3) -> LOW severity."""
-        result = PhRule().evaluate(make_state(pool, PoolReading(ph=7.4)))
-        assert len(result.problems) == 1
-        assert result.problems[0].severity == Severity.LOW
+        problems = PhRule().evaluate(make_state(pool, PoolReading(ph=7.4)))
+        assert len(problems) == 1
+        assert problems[0].severity == Severity.LOW
 
     def test_ph_outside_range_returns_critical_severity(self, pool: Pool) -> None:
-        result = PhRule().evaluate(make_state(pool, PoolReading(ph=8.2)))
-        assert len(result.problems) == 1
-        assert result.problems[0].severity == Severity.CRITICAL
+        problems = PhRule().evaluate(make_state(pool, PoolReading(ph=8.2)))
+        assert len(problems) == 1
+        assert problems[0].severity == Severity.CRITICAL
 
     def test_ph_medium_deviation_returns_medium_severity(self, pool: Pool) -> None:
         """pH delta > 3x tolerance but within range -> MEDIUM severity."""
-        result = PhRule().evaluate(make_state(pool, PoolReading(ph=7.6)))
-        assert len(result.problems) == 1
-        assert result.problems[0].severity == Severity.MEDIUM
+        problems = PhRule().evaluate(make_state(pool, PoolReading(ph=7.6)))
+        assert len(problems) == 1
+        assert problems[0].severity == Severity.MEDIUM
 
     def test_none_ph_skips(self, pool: Pool) -> None:
-        result = PhRule().evaluate(make_state(pool, PoolReading()))
-        assert result.problems == []
+        problems = PhRule().evaluate(make_state(pool, PoolReading()))
+        assert problems == []
 
     def test_expected_range_set(self, pool: Pool) -> None:
-        result = PhRule().evaluate(make_state(pool, PoolReading(ph=8.5)))
-        assert result.problems[0].expected_range is not None
-        low, high = result.problems[0].expected_range
+        problems = PhRule().evaluate(make_state(pool, PoolReading(ph=8.5)))
+        assert problems[0].expected_range is not None
+        low, high = problems[0].expected_range
         assert low < 7.0
         assert high > 7.5

--- a/tests/domain/rules/chemistry/test_salt.py
+++ b/tests/domain/rules/chemistry/test_salt.py
@@ -25,71 +25,71 @@ class TestSaltRule:
 
     def test_salt_in_range_no_problem(self) -> None:
         pool = _make_salt_pool()
-        result = SaltRule().evaluate(make_state(pool, PoolReading(salt=3200.0)))
-        assert result.problems == []
+        problems = SaltRule().evaluate(make_state(pool, PoolReading(salt=3200.0)))
+        assert problems == []
 
     def test_salt_too_low_returns_medium_problem(self) -> None:
         pool = _make_salt_pool()
-        result = SaltRule().evaluate(make_state(pool, PoolReading(salt=2000.0)))
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "salt_too_low"
-        assert result.problems[0].metric == MetricName.SALT
-        assert result.problems[0].severity == Severity.MEDIUM
-        assert result.problems[0].value == pytest.approx(2000.0)
+        problems = SaltRule().evaluate(make_state(pool, PoolReading(salt=2000.0)))
+        assert len(problems) == 1
+        assert problems[0].code == "salt_too_low"
+        assert problems[0].metric == MetricName.SALT
+        assert problems[0].severity == Severity.MEDIUM
+        assert problems[0].value == pytest.approx(2000.0)
 
     def test_salt_too_high_returns_low_problem(self) -> None:
         pool = _make_salt_pool()
-        result = SaltRule().evaluate(make_state(pool, PoolReading(salt=4000.0)))
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "salt_too_high"
-        assert result.problems[0].severity == Severity.LOW
+        problems = SaltRule().evaluate(make_state(pool, PoolReading(salt=4000.0)))
+        assert len(problems) == 1
+        assert problems[0].code == "salt_too_high"
+        assert problems[0].severity == Severity.LOW
 
     def test_salt_none_no_problem(self) -> None:
         pool = _make_salt_pool()
-        result = SaltRule().evaluate(make_state(pool, PoolReading(salt=None)))
-        assert result.problems == []
+        problems = SaltRule().evaluate(make_state(pool, PoolReading(salt=None)))
+        assert problems == []
 
     def test_non_salt_treatment_skips(self, pool: Pool) -> None:
         """SaltRule should skip for non-salt-electrolysis treatment types."""
-        result = SaltRule().evaluate(make_state(pool, PoolReading(salt=2000.0)))
-        assert result.problems == []
+        problems = SaltRule().evaluate(make_state(pool, PoolReading(salt=2000.0)))
+        assert problems == []
 
     def test_winter_passive_skips(self) -> None:
         pool = _make_salt_pool()
-        result = SaltRule().evaluate(
+        problems = SaltRule().evaluate(
             make_state(pool, PoolReading(salt=2000.0), PoolMode.WINTER_PASSIVE)
         )
-        assert result.problems == []
+        assert problems == []
 
     def test_winter_active_skips(self) -> None:
         pool = _make_salt_pool()
-        result = SaltRule().evaluate(
+        problems = SaltRule().evaluate(
             make_state(pool, PoolReading(salt=2000.0), PoolMode.WINTER_ACTIVE)
         )
-        assert result.problems == []
+        assert problems == []
 
     def test_hibernating_evaluates(self) -> None:
         pool = _make_salt_pool()
-        result = SaltRule().evaluate(
+        problems = SaltRule().evaluate(
             make_state(pool, PoolReading(salt=2000.0), PoolMode.HIBERNATING)
         )
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "salt_too_low"
+        assert len(problems) == 1
+        assert problems[0].code == "salt_too_low"
 
     def test_activating_evaluates(self) -> None:
         pool = _make_salt_pool()
-        result = SaltRule().evaluate(
+        problems = SaltRule().evaluate(
             make_state(pool, PoolReading(salt=2000.0), PoolMode.ACTIVATING)
         )
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "salt_too_low"
+        assert len(problems) == 1
+        assert problems[0].code == "salt_too_low"
 
     def test_salt_at_min_no_problem(self) -> None:
         pool = _make_salt_pool()
-        result = SaltRule().evaluate(make_state(pool, PoolReading(salt=2700.0)))
-        assert result.problems == []
+        problems = SaltRule().evaluate(make_state(pool, PoolReading(salt=2700.0)))
+        assert problems == []
 
     def test_salt_at_max_no_problem(self) -> None:
         pool = _make_salt_pool()
-        result = SaltRule().evaluate(make_state(pool, PoolReading(salt=3400.0)))
-        assert result.problems == []
+        problems = SaltRule().evaluate(make_state(pool, PoolReading(salt=3400.0)))
+        assert problems == []

--- a/tests/domain/rules/chemistry/test_sanitizer.py
+++ b/tests/domain/rules/chemistry/test_sanitizer.py
@@ -15,27 +15,27 @@ class TestSanitizerRule:
     """Tests for sanitizer rule evaluation across treatment types."""
 
     def test_good_orp_no_problem(self, pool: Pool) -> None:
-        result = SanitizerRule().evaluate(make_state(pool, PoolReading(orp=750.0)))
-        assert result.problems == []
+        problems = SanitizerRule().evaluate(make_state(pool, PoolReading(orp=750.0)))
+        assert problems == []
 
     def test_critical_orp_returns_critical_problem(self, pool: Pool) -> None:
-        result = SanitizerRule().evaluate(make_state(pool, PoolReading(orp=600.0)))
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "orp_too_low"
-        assert result.problems[0].severity == Severity.CRITICAL
-        assert result.problems[0].metric == MetricName.ORP
+        problems = SanitizerRule().evaluate(make_state(pool, PoolReading(orp=600.0)))
+        assert len(problems) == 1
+        assert problems[0].code == "orp_too_low"
+        assert problems[0].severity == Severity.CRITICAL
+        assert problems[0].metric == MetricName.ORP
 
     def test_medium_low_orp_returns_medium_problem(self, pool: Pool) -> None:
-        result = SanitizerRule().evaluate(make_state(pool, PoolReading(orp=700.0)))
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "orp_too_low"
-        assert result.problems[0].severity == Severity.MEDIUM
+        problems = SanitizerRule().evaluate(make_state(pool, PoolReading(orp=700.0)))
+        assert len(problems) == 1
+        assert problems[0].code == "orp_too_low"
+        assert problems[0].severity == Severity.MEDIUM
 
     def test_high_orp_returns_orp_too_high_problem(self, pool: Pool) -> None:
-        result = SanitizerRule().evaluate(make_state(pool, PoolReading(orp=950.0)))
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "orp_too_high"
-        assert result.problems[0].metric == MetricName.ORP
+        problems = SanitizerRule().evaluate(make_state(pool, PoolReading(orp=950.0)))
+        assert len(problems) == 1
+        assert problems[0].code == "orp_too_high"
+        assert problems[0].metric == MetricName.ORP
 
     def test_salt_critical_orp_returns_critical_problem(self) -> None:
         pool = Pool(
@@ -44,17 +44,17 @@ class TestSanitizerRule:
             pump_flow_m3h=10.0,
             treatment=TreatmentType.SALT_ELECTROLYSIS,
         )
-        result = SanitizerRule().evaluate(make_state(pool, PoolReading(orp=600.0)))
-        assert len(result.problems) == 1
-        assert result.problems[0].severity == Severity.CRITICAL
+        problems = SanitizerRule().evaluate(make_state(pool, PoolReading(orp=600.0)))
+        assert len(problems) == 1
+        assert problems[0].severity == Severity.CRITICAL
 
     def test_bromine_critical_orp_returns_critical_problem(self) -> None:
         pool = Pool(
             name="Bromine Pool", volume_m3=50.0, pump_flow_m3h=10.0, treatment=TreatmentType.BROMINE
         )
-        result = SanitizerRule().evaluate(make_state(pool, PoolReading(orp=600.0)))
-        assert len(result.problems) == 1
-        assert result.problems[0].severity == Severity.CRITICAL
+        problems = SanitizerRule().evaluate(make_state(pool, PoolReading(orp=600.0)))
+        assert len(problems) == 1
+        assert problems[0].severity == Severity.CRITICAL
 
     def test_active_oxygen_critical_orp_returns_critical_problem(self) -> None:
         pool = Pool(
@@ -63,45 +63,45 @@ class TestSanitizerRule:
             pump_flow_m3h=10.0,
             treatment=TreatmentType.ACTIVE_OXYGEN,
         )
-        result = SanitizerRule().evaluate(make_state(pool, PoolReading(orp=600.0)))
-        assert len(result.problems) == 1
-        assert result.problems[0].severity == Severity.CRITICAL
+        problems = SanitizerRule().evaluate(make_state(pool, PoolReading(orp=600.0)))
+        assert len(problems) == 1
+        assert problems[0].severity == Severity.CRITICAL
 
     def test_winter_passive_skips(self, pool: Pool) -> None:
-        result = SanitizerRule().evaluate(
+        problems = SanitizerRule().evaluate(
             make_state(pool, PoolReading(orp=600.0), PoolMode.WINTER_PASSIVE)
         )
-        assert result.problems == []
+        assert problems == []
 
     def test_winter_active_skips(self, pool: Pool) -> None:
-        result = SanitizerRule().evaluate(
+        problems = SanitizerRule().evaluate(
             make_state(pool, PoolReading(orp=600.0), PoolMode.WINTER_ACTIVE)
         )
-        assert result.problems == []
+        assert problems == []
 
     def test_hibernating_evaluates(self, pool: Pool) -> None:
-        result = SanitizerRule().evaluate(
+        problems = SanitizerRule().evaluate(
             make_state(pool, PoolReading(orp=600.0), PoolMode.HIBERNATING)
         )
-        assert len(result.problems) == 1
-        assert result.problems[0].severity == Severity.CRITICAL
+        assert len(problems) == 1
+        assert problems[0].severity == Severity.CRITICAL
 
     def test_activating_evaluates(self, pool: Pool) -> None:
-        result = SanitizerRule().evaluate(
+        problems = SanitizerRule().evaluate(
             make_state(pool, PoolReading(orp=600.0), PoolMode.ACTIVATING)
         )
-        assert len(result.problems) == 1
-        assert result.problems[0].severity == Severity.CRITICAL
+        assert len(problems) == 1
+        assert problems[0].severity == Severity.CRITICAL
 
     @pytest.mark.parametrize("treatment", list(TreatmentType))
     def test_high_orp_returns_too_high_code_for_all_treatments(
         self, treatment: TreatmentType
     ) -> None:
         pool = Pool(name="Test Pool", volume_m3=50.0, pump_flow_m3h=10.0, treatment=treatment)
-        result = SanitizerRule().evaluate(make_state(pool, PoolReading(orp=950.0)))
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "orp_too_high"
+        problems = SanitizerRule().evaluate(make_state(pool, PoolReading(orp=950.0)))
+        assert len(problems) == 1
+        assert problems[0].code == "orp_too_high"
 
     def test_none_orp_skips(self, pool: Pool) -> None:
-        result = SanitizerRule().evaluate(make_state(pool, PoolReading()))
-        assert result.problems == []
+        problems = SanitizerRule().evaluate(make_state(pool, PoolReading()))
+        assert problems == []

--- a/tests/domain/rules/chemistry/test_tds.py
+++ b/tests/domain/rules/chemistry/test_tds.py
@@ -13,25 +13,25 @@ class TestTdsRule:
     """Tests for TDS (Total Dissolved Solids) rule evaluation."""
 
     def test_tds_in_range_no_problem(self, pool: Pool) -> None:
-        result = TdsRule().evaluate(make_state(pool, PoolReading(tds=500.0)))
-        assert result.problems == []
+        problems = TdsRule().evaluate(make_state(pool, PoolReading(tds=500.0)))
+        assert problems == []
 
     def test_tds_too_high_returns_medium_problem(self, pool: Pool) -> None:
-        result = TdsRule().evaluate(make_state(pool, PoolReading(tds=2000.0)))
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "tds_too_high"
-        assert result.problems[0].metric == MetricName.TDS
-        assert result.problems[0].severity == Severity.MEDIUM
+        problems = TdsRule().evaluate(make_state(pool, PoolReading(tds=2000.0)))
+        assert len(problems) == 1
+        assert problems[0].code == "tds_too_high"
+        assert problems[0].metric == MetricName.TDS
+        assert problems[0].severity == Severity.MEDIUM
 
     def test_tds_too_low_returns_low_problem(self, pool: Pool) -> None:
-        result = TdsRule().evaluate(make_state(pool, PoolReading(tds=100.0)))
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "tds_too_low"
-        assert result.problems[0].severity == Severity.LOW
+        problems = TdsRule().evaluate(make_state(pool, PoolReading(tds=100.0)))
+        assert len(problems) == 1
+        assert problems[0].code == "tds_too_low"
+        assert problems[0].severity == Severity.LOW
 
     def test_tds_none_no_problem(self, pool: Pool) -> None:
-        result = TdsRule().evaluate(make_state(pool, PoolReading(tds=None)))
-        assert result.problems == []
+        problems = TdsRule().evaluate(make_state(pool, PoolReading(tds=None)))
+        assert problems == []
 
     def test_salt_electrolysis_skips(self) -> None:
         pool = Pool(
@@ -40,35 +40,39 @@ class TestTdsRule:
             pump_flow_m3h=10.0,
             treatment=TreatmentType.SALT_ELECTROLYSIS,
         )
-        result = TdsRule().evaluate(make_state(pool, PoolReading(tds=2000.0)))
-        assert result.problems == []
+        problems = TdsRule().evaluate(make_state(pool, PoolReading(tds=2000.0)))
+        assert problems == []
 
     def test_winter_passive_skips(self, pool: Pool) -> None:
-        result = TdsRule().evaluate(
+        problems = TdsRule().evaluate(
             make_state(pool, PoolReading(tds=2000.0), PoolMode.WINTER_PASSIVE)
         )
-        assert result.problems == []
+        assert problems == []
 
     def test_winter_active_skips(self, pool: Pool) -> None:
-        result = TdsRule().evaluate(
+        problems = TdsRule().evaluate(
             make_state(pool, PoolReading(tds=2000.0), PoolMode.WINTER_ACTIVE)
         )
-        assert result.problems == []
+        assert problems == []
 
     def test_hibernating_evaluates(self, pool: Pool) -> None:
-        result = TdsRule().evaluate(make_state(pool, PoolReading(tds=2000.0), PoolMode.HIBERNATING))
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "tds_too_high"
+        problems = TdsRule().evaluate(
+            make_state(pool, PoolReading(tds=2000.0), PoolMode.HIBERNATING)
+        )
+        assert len(problems) == 1
+        assert problems[0].code == "tds_too_high"
 
     def test_activating_evaluates(self, pool: Pool) -> None:
-        result = TdsRule().evaluate(make_state(pool, PoolReading(tds=2000.0), PoolMode.ACTIVATING))
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "tds_too_high"
+        problems = TdsRule().evaluate(
+            make_state(pool, PoolReading(tds=2000.0), PoolMode.ACTIVATING)
+        )
+        assert len(problems) == 1
+        assert problems[0].code == "tds_too_high"
 
     def test_tds_at_min_no_problem(self, pool: Pool) -> None:
-        result = TdsRule().evaluate(make_state(pool, PoolReading(tds=250.0)))
-        assert result.problems == []
+        problems = TdsRule().evaluate(make_state(pool, PoolReading(tds=250.0)))
+        assert problems == []
 
     def test_tds_at_max_no_problem(self, pool: Pool) -> None:
-        result = TdsRule().evaluate(make_state(pool, PoolReading(tds=1500.0)))
-        assert result.problems == []
+        problems = TdsRule().evaluate(make_state(pool, PoolReading(tds=1500.0)))
+        assert problems == []

--- a/tests/domain/rules/filtration/test_filtration.py
+++ b/tests/domain/rules/filtration/test_filtration.py
@@ -13,51 +13,51 @@ class TestFiltrationRule:
     """Tests for filtration rule evaluation."""
 
     def test_produces_problem(self, pool: Pool) -> None:
-        result = FiltrationRule().evaluate(make_state(pool, PoolReading(temp_c=26.0)))
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "filtration_required"
-        assert result.problems[0].metric is None
-        assert result.problems[0].value is not None
+        problems = FiltrationRule().evaluate(make_state(pool, PoolReading(temp_c=26.0)))
+        assert len(problems) == 1
+        assert problems[0].code == "filtration_required"
+        assert problems[0].metric is None
+        assert problems[0].value is not None
 
     def test_no_temp_no_problem(self, pool: Pool) -> None:
-        result = FiltrationRule().evaluate(make_state(pool, PoolReading()))
-        assert result.problems == []
+        problems = FiltrationRule().evaluate(make_state(pool, PoolReading()))
+        assert problems == []
 
     def test_low_filtration_hours_returns_low_severity(self, pool: Pool) -> None:
         """When filtration hours < 12 in running mode, severity should be LOW."""
-        result = FiltrationRule().evaluate(make_state(pool, PoolReading(temp_c=20.0)))
-        assert len(result.problems) == 1
-        assert result.problems[0].severity == Severity.LOW
+        problems = FiltrationRule().evaluate(make_state(pool, PoolReading(temp_c=20.0)))
+        assert len(problems) == 1
+        assert problems[0].severity == Severity.LOW
 
     def test_high_filtration_hours_returns_medium_severity(self, pool: Pool) -> None:
         """When filtration hours >= 12, severity should be MEDIUM."""
-        result = FiltrationRule().evaluate(make_state(pool, PoolReading(temp_c=26.0)))
-        assert len(result.problems) == 1
-        assert result.problems[0].severity == Severity.MEDIUM
+        problems = FiltrationRule().evaluate(make_state(pool, PoolReading(temp_c=26.0)))
+        assert len(problems) == 1
+        assert problems[0].severity == Severity.MEDIUM
 
     def test_winter_active_evaluates(self, pool: Pool) -> None:
-        result = FiltrationRule().evaluate(
+        problems = FiltrationRule().evaluate(
             make_state(pool, PoolReading(temp_c=15.0), PoolMode.WINTER_ACTIVE)
         )
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "filtration_required"
+        assert len(problems) == 1
+        assert problems[0].code == "filtration_required"
 
     def test_hibernating_produces_problem(self, pool: Pool) -> None:
-        result = FiltrationRule().evaluate(
+        problems = FiltrationRule().evaluate(
             make_state(pool, PoolReading(temp_c=26.0), PoolMode.HIBERNATING)
         )
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "filtration_required"
+        assert len(problems) == 1
+        assert problems[0].code == "filtration_required"
 
     def test_activating_produces_problem(self, pool: Pool) -> None:
-        result = FiltrationRule().evaluate(
+        problems = FiltrationRule().evaluate(
             make_state(pool, PoolReading(temp_c=26.0), PoolMode.ACTIVATING)
         )
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "filtration_required"
+        assert len(problems) == 1
+        assert problems[0].code == "filtration_required"
 
     def test_winter_passive_skips(self, pool: Pool) -> None:
-        result = FiltrationRule().evaluate(
+        problems = FiltrationRule().evaluate(
             make_state(pool, PoolReading(temp_c=26.0), PoolMode.WINTER_PASSIVE)
         )
-        assert result.problems == []
+        assert problems == []

--- a/tests/domain/rules/maintenance/test_calibration.py
+++ b/tests/domain/rules/maintenance/test_calibration.py
@@ -26,8 +26,8 @@ class TestCalibrationRule:
     """Tests for CalibrationRule deviation detection."""
 
     def test_no_manual_measures_no_problem(self, pool: Pool) -> None:
-        result = CalibrationRule().evaluate(make_state(pool, PoolReading(ph=7.2, orp=750.0)))
-        assert result.problems == []
+        problems = CalibrationRule().evaluate(make_state(pool, PoolReading(ph=7.2, orp=750.0)))
+        assert problems == []
 
     def test_no_deviation_no_problem(self, pool: Pool) -> None:
         measures = {
@@ -35,10 +35,10 @@ class TestCalibrationRule:
                 parameter=MeasureParameter.PH, value=7.1, measured_at=_ts()
             ),
         }
-        result = CalibrationRule().evaluate(
+        problems = CalibrationRule().evaluate(
             make_state(pool, PoolReading(ph=7.2), manual_measures=measures)
         )
-        assert result.problems == []
+        assert problems == []
 
     def test_ph_deviation_generates_problem(self, pool: Pool) -> None:
         measures = {
@@ -46,16 +46,16 @@ class TestCalibrationRule:
                 parameter=MeasureParameter.PH, value=7.2, measured_at=_ts()
             ),
         }
-        result = CalibrationRule().evaluate(
+        problems = CalibrationRule().evaluate(
             make_state(pool, PoolReading(ph=7.8), manual_measures=measures)
         )
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "calibration_ph"
-        assert result.problems[0].severity == Severity.LOW
-        assert result.problems[0].metric is None
-        assert "pH" in result.problems[0].message
-        assert "7.8" in result.problems[0].message
-        assert "7.2" in result.problems[0].message
+        assert len(problems) == 1
+        assert problems[0].code == "calibration_ph"
+        assert problems[0].severity == Severity.LOW
+        assert problems[0].metric is None
+        assert "pH" in problems[0].message
+        assert "7.8" in problems[0].message
+        assert "7.2" in problems[0].message
 
     def test_orp_deviation_generates_problem(self, pool: Pool) -> None:
         measures = {
@@ -63,12 +63,12 @@ class TestCalibrationRule:
                 parameter=MeasureParameter.ORP, value=750.0, measured_at=_ts()
             ),
         }
-        result = CalibrationRule().evaluate(
+        problems = CalibrationRule().evaluate(
             make_state(pool, PoolReading(orp=810.0), manual_measures=measures)
         )
-        assert len(result.problems) == 1
-        assert result.problems[0].code == "calibration_orp"
-        assert "ORP" in result.problems[0].message
+        assert len(problems) == 1
+        assert problems[0].code == "calibration_orp"
+        assert "ORP" in problems[0].message
 
     def test_temperature_deviation_generates_problem(self, pool: Pool) -> None:
         measures = {
@@ -76,11 +76,11 @@ class TestCalibrationRule:
                 parameter=MeasureParameter.TEMPERATURE, value=26.0, measured_at=_ts()
             ),
         }
-        result = CalibrationRule().evaluate(
+        problems = CalibrationRule().evaluate(
             make_state(pool, PoolReading(temp_c=28.5), manual_measures=measures)
         )
-        assert len(result.problems) == 1
-        assert "temperature" in result.problems[0].message
+        assert len(problems) == 1
+        assert "temperature" in problems[0].message
 
     def test_sensor_none_skipped(self, pool: Pool) -> None:
         measures = {
@@ -88,10 +88,10 @@ class TestCalibrationRule:
                 parameter=MeasureParameter.PH, value=7.2, measured_at=_ts()
             ),
         }
-        result = CalibrationRule().evaluate(
+        problems = CalibrationRule().evaluate(
             make_state(pool, PoolReading(ph=None), manual_measures=measures)
         )
-        assert result.problems == []
+        assert problems == []
 
     def test_winter_passive_skips(self, pool: Pool) -> None:
         measures = {
@@ -99,10 +99,10 @@ class TestCalibrationRule:
                 parameter=MeasureParameter.PH, value=7.2, measured_at=_ts()
             ),
         }
-        result = CalibrationRule().evaluate(
+        problems = CalibrationRule().evaluate(
             make_state(pool, PoolReading(ph=8.0), PoolMode.WINTER_PASSIVE, manual_measures=measures)
         )
-        assert result.problems == []
+        assert problems == []
 
     def test_multiple_deviations(self, pool: Pool) -> None:
         measures = {
@@ -116,10 +116,10 @@ class TestCalibrationRule:
                 parameter=MeasureParameter.TEMPERATURE, value=26.0, measured_at=_ts()
             ),
         }
-        result = CalibrationRule().evaluate(
+        problems = CalibrationRule().evaluate(
             make_state(pool, PoolReading(ph=7.8, orp=810.0, temp_c=30.0), manual_measures=measures)
         )
-        assert len(result.problems) == 3
+        assert len(problems) == 3
 
     def test_deviation_at_threshold_no_problem(self, pool: Pool) -> None:
         """Deviation exactly at threshold should NOT generate a problem."""
@@ -128,11 +128,11 @@ class TestCalibrationRule:
                 parameter=MeasureParameter.PH, value=7.2, measured_at=_ts()
             ),
         }
-        result = CalibrationRule().evaluate(
+        problems = CalibrationRule().evaluate(
             make_state(pool, PoolReading(ph=7.5), manual_measures=measures)
         )
         # 0.3 == threshold, not > threshold
-        assert result.problems == []
+        assert problems == []
 
     def test_tac_deviation(self, pool: Pool) -> None:
         measures = {
@@ -140,11 +140,11 @@ class TestCalibrationRule:
                 parameter=MeasureParameter.TAC, value=120.0, measured_at=_ts()
             ),
         }
-        result = CalibrationRule().evaluate(
+        problems = CalibrationRule().evaluate(
             make_state(pool, PoolReading(tac=145.0), manual_measures=measures)
         )
-        assert len(result.problems) == 1
-        assert "TAC" in result.problems[0].message
+        assert len(problems) == 1
+        assert "TAC" in problems[0].message
 
     def test_salt_deviation(self, pool: Pool) -> None:
         measures = {
@@ -152,11 +152,11 @@ class TestCalibrationRule:
                 parameter=MeasureParameter.SALT, value=3200.0, measured_at=_ts()
             ),
         }
-        result = CalibrationRule().evaluate(
+        problems = CalibrationRule().evaluate(
             make_state(pool, PoolReading(salt=3400.0), manual_measures=measures)
         )
-        assert len(result.problems) == 1
-        assert "salt" in result.problems[0].message
+        assert len(problems) == 1
+        assert "salt" in problems[0].message
 
     def test_winter_active_evaluates(self, pool: Pool) -> None:
         measures = {
@@ -164,10 +164,10 @@ class TestCalibrationRule:
                 parameter=MeasureParameter.PH, value=7.2, measured_at=_ts()
             ),
         }
-        result = CalibrationRule().evaluate(
+        problems = CalibrationRule().evaluate(
             make_state(pool, PoolReading(ph=7.8), PoolMode.WINTER_ACTIVE, manual_measures=measures)
         )
-        assert len(result.problems) == 1
+        assert len(problems) == 1
 
     def test_hibernating_evaluates(self, pool: Pool) -> None:
         measures = {
@@ -175,7 +175,7 @@ class TestCalibrationRule:
                 parameter=MeasureParameter.PH, value=7.2, measured_at=_ts()
             ),
         }
-        result = CalibrationRule().evaluate(
+        problems = CalibrationRule().evaluate(
             make_state(pool, PoolReading(ph=7.8), PoolMode.HIBERNATING, manual_measures=measures)
         )
-        assert len(result.problems) == 1
+        assert len(problems) == 1

--- a/tests/domain/rules/test_engine.py
+++ b/tests/domain/rules/test_engine.py
@@ -66,3 +66,22 @@ class TestRuleEngine:
         engine = RuleEngine(rules=[PhRule()])
         problems = engine.evaluate(make_state(pool, PoolReading(ph=8.5)))
         assert all(isinstance(p, Problem) for p in problems)
+
+    def test_rules_sorted_by_priority(self) -> None:
+        """RuleEngine must sort rules by their `priority` attribute (ascending)."""
+        engine = RuleEngine(ALL_RULES)
+        priorities = [rule.priority for rule in engine.rules]
+        assert priorities == sorted(priorities)
+
+    def test_custom_priority_overrides_argument_order(self) -> None:
+        """Engine input order is ignored; only `priority` controls iteration order."""
+
+        class LowPriority(PhRule):
+            priority = 999
+
+        class HighPriority(PhRule):
+            priority = 1
+
+        engine = RuleEngine(rules=[LowPriority(), HighPriority()])
+        assert engine.rules[0].priority == 1
+        assert engine.rules[1].priority == 999

--- a/tests/domain/test_analysis.py
+++ b/tests/domain/test_analysis.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import FrozenInstanceError
 from datetime import UTC
-from unittest.mock import patch
 
 import pytest
 
@@ -13,16 +12,9 @@ from custom_components.poolman.domain.analysis import (
     analyze_pool,
     generate_recommendations,
 )
-from custom_components.poolman.domain.model import (
-    ChemistryReport,
-    DosageAdjustment,
-    PoolReading,
-    PoolState,
-)
+from custom_components.poolman.domain.model import PoolReading, PoolState
 from custom_components.poolman.domain.problem import (
-    ChemistryStatus,
     MetricName,
-    ParameterReport,
     Problem,
     Severity,
 )
@@ -30,44 +22,12 @@ from custom_components.poolman.domain.recommendation import (
     ActionKind,
     RecommendationPriority,
     RecommendationType,
+    Treatment,
 )
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _make_report(
-    metric: MetricName,
-    value: float,
-    minimum: float,
-    maximum: float,
-    target: float | None = None,
-    status: ChemistryStatus = ChemistryStatus.GOOD,
-    score: int = 80,
-) -> ParameterReport:
-    """Return a ParameterReport with the given parameters."""
-    return ParameterReport(
-        metric=metric,
-        status=status,
-        value=value,
-        target=target if target is not None else (minimum + maximum) / 2,
-        minimum=minimum,
-        maximum=maximum,
-        score=score,
-    )
-
-
-def _make_state(
-    *,
-    ph: ParameterReport | None = None,
-    orp: ParameterReport | None = None,
-    tac: ParameterReport | None = None,
-) -> PoolState:
-    """Return a PoolState with the given chemistry reports (for legacy tests)."""
-    return PoolState(
-        chemistry_report=ChemistryReport(ph=ph, orp=orp, tac=tac),
-    )
 
 
 def _make_reading_state(
@@ -231,7 +191,31 @@ class TestGenerateRecommendations:
             RecommendationPriority.LOW
         )
 
-    def test_recommendation_has_treatment_when_product_known(self) -> None:
+    def test_recommendation_has_treatment_when_attached(self) -> None:
+        """When a Problem carries a Treatment, it must be included in the rec."""
+        treatment = Treatment(
+            id="ph_too_high_ph_minus",
+            product_id="ph_minus",
+            name="Ph Minus",
+            quantity=120.0,
+            unit="g",
+        )
+        problem = Problem(
+            code="ph_too_high",
+            severity=Severity.MEDIUM,
+            metric=MetricName.PH,
+            value=8.1,
+            message="pH is too high.",
+            expected_range=None,
+            treatment=treatment,
+        )
+        recs = generate_recommendations([problem])
+        assert len(recs[0].treatments) == 1
+        assert recs[0].treatments[0].product_id == "ph_minus"
+        assert recs[0].treatments[0].quantity == 120.0
+
+    def test_recommendation_no_treatment_when_problem_has_none(self) -> None:
+        """Problems without an attached Treatment produce empty treatments."""
         problem = Problem(
             code="ph_too_high",
             severity=Severity.MEDIUM,
@@ -241,8 +225,7 @@ class TestGenerateRecommendations:
             expected_range=None,
         )
         recs = generate_recommendations([problem])
-        assert len(recs[0].treatments) == 1
-        assert recs[0].treatments[0].product_id == "ph_minus"
+        assert recs[0].treatments == []
 
     def test_recommendation_no_treatment_when_no_product(self) -> None:
         """Some problems (e.g., orp_too_low) have no specific product."""
@@ -256,29 +239,6 @@ class TestGenerateRecommendations:
         )
         recs = generate_recommendations([problem])
         assert recs[0].treatments == []
-
-    def test_chlorine_dosage_quantity_populated_from_reading(self) -> None:
-        """chlorine_too_low with a reading that returns a dosage quantity populates it."""
-        from custom_components.poolman.domain.model import ChemicalProduct
-
-        problem = Problem(
-            code="chlorine_too_low",
-            severity=Severity.MEDIUM,
-            metric=MetricName.CHLORINE,
-            value=0.3,
-            message="Free chlorine is too low.",
-            expected_range=None,
-        )
-        reading = PoolReading(free_chlorine=0.3)
-        fake_dosage = DosageAdjustment(product=ChemicalProduct.CHLORE_CHOC, quantity_g=250.0)
-        with patch(
-            "custom_components.poolman.domain.analysis.compute_free_chlorine_adjustment",
-            return_value=fake_dosage,
-        ):
-            recs = generate_recommendations([problem], reading=reading)
-        assert len(recs) == 1
-        assert len(recs[0].treatments) == 1
-        assert recs[0].treatments[0].quantity == 250.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/domain/test_problem.py
+++ b/tests/domain/test_problem.py
@@ -17,6 +17,7 @@ from custom_components.poolman.domain.problem import (
     Problem,
     Severity,
 )
+from custom_components.poolman.domain.recommendation import Treatment
 
 
 class TestProblemDataclass:
@@ -51,18 +52,36 @@ class TestProblemDataclass:
         assert p.expected_range == (6.8, 7.8)
 
     def test_problem_optional_fields(self) -> None:
-        """metric, value, and expected_range are all optional (None)."""
+        """metric, value, expected_range, and treatment are all optional (default None)."""
         p = Problem(
             code="unknown_out_of_range",
             message="unknown is out of range",
             severity=Severity.LOW,
-            metric=None,
-            value=None,
-            expected_range=None,
         )
         assert p.metric is None
         assert p.value is None
         assert p.expected_range is None
+        assert p.treatment is None
+
+    def test_problem_with_treatment(self) -> None:
+        """Problem accepts an optional pre-computed Treatment."""
+        treatment = Treatment(
+            id="ph_too_high_ph_minus",
+            product_id="ph_minus",
+            name="Ph Minus",
+            quantity=120.0,
+            unit="g",
+        )
+        p = Problem(
+            code="ph_too_high",
+            message="pH is too high.",
+            severity=Severity.MEDIUM,
+            metric=MetricName.PH,
+            value=8.1,
+            treatment=treatment,
+        )
+        assert p.treatment is treatment
+        assert p.treatment.product_id == "ph_minus"
 
 
 class TestSeverityEnum:


### PR DESCRIPTION
This refactor finishes the rule engine migration tracked in #17 / #18.

Rules now return `list[Problem]` directly — the intermediate `RuleResult`
container is gone, and dosage information is carried by `Problem.treatment`
rather than reconstructed downstream. A new `priority` field on `Rule`
gives the engine a deterministic evaluation order while preserving
severity-based ordering of the final output.

`generate_recommendations()` is reduced to a pure `Problem → Recommendation`
mapping, removing its dependency on `Pool` and `PoolReading`. The
coordinator's local `sensor_reading` is renamed to `raw_sensor_reading`
to disambiguate it from the fallback `reading` consumed by
`CalibrationRule`.

All 11 rules were migrated; 857 tests pass; linters are clean.

Closes #17
Closes #18