### PR TITLE
feat(inventory): add internal product inventory with stock tracking

### DIFF
--- a/custom_components/poolman/__init__.py
+++ b/custom_components/poolman/__init__.py
@@ -8,6 +8,7 @@ import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import device_registry as dr
 
 from .const import (
@@ -20,16 +21,22 @@ from .const import (
     DEFAULT_FILTRATION_KIND,
     DEFAULT_TREATMENT,
     DOMAIN,
+    INVENTORY_UNITS,
     PLATFORMS,
     SERVICE_ADD_TREATMENT,
     SERVICE_BOOST_FILTRATION,
     SERVICE_CONFIRM_ACTIVATION_STEP,
+    SERVICE_INVENTORY_ADD_PRODUCT,
+    SERVICE_INVENTORY_ADD_STOCK,
+    SERVICE_INVENTORY_REMOVE_PRODUCT,
+    SERVICE_INVENTORY_SET_STOCK,
     SERVICE_RECORD_MEASURE,
     SUBENTRY_ACTIVATION,
     SUBENTRY_HIBERNATION,
 )
 from .coordinator import PoolmanCoordinator
 from .domain.activation import ActivationChecklist, ActivationStep
+from .domain.inventory import Product
 from .domain.model import PRODUCT_DENSITY_G_PER_ML, ChemicalProduct, MeasureParameter, PoolMode
 
 _LOGGER = logging.getLogger(__name__)
@@ -67,6 +74,42 @@ SERVICE_CONFIRM_ACTIVATION_STEP_SCHEMA = vol.Schema(
     {
         vol.Required("device_id"): str,
         vol.Required("step"): vol.In([s.value for s in ActivationStep]),
+    }
+)
+
+SERVICE_INVENTORY_ADD_PRODUCT_SCHEMA = vol.Schema(
+    {
+        vol.Required("entry_id"): str,
+        vol.Required("product_id"): vol.All(str, vol.Length(min=1)),
+        vol.Required("name"): vol.All(str, vol.Length(min=1)),
+        vol.Required("unit"): vol.In(INVENTORY_UNITS),
+        vol.Optional("chemical"): vol.In([p.value for p in ChemicalProduct]),
+        vol.Optional("initial_quantity"): vol.All(vol.Coerce(float), vol.Range(min=0)),
+        vol.Optional("low_stock_threshold"): vol.All(vol.Coerce(float), vol.Range(min=0)),
+    }
+)
+
+SERVICE_INVENTORY_REMOVE_PRODUCT_SCHEMA = vol.Schema(
+    {
+        vol.Required("entry_id"): str,
+        vol.Required("product_id"): vol.All(str, vol.Length(min=1)),
+    }
+)
+
+SERVICE_INVENTORY_ADD_STOCK_SCHEMA = vol.Schema(
+    {
+        vol.Required("entry_id"): str,
+        vol.Required("product_id"): vol.All(str, vol.Length(min=1)),
+        vol.Required("quantity"): vol.All(vol.Coerce(float), vol.Range(min=0)),
+    }
+)
+
+SERVICE_INVENTORY_SET_STOCK_SCHEMA = vol.Schema(
+    {
+        vol.Required("entry_id"): str,
+        vol.Required("product_id"): vol.All(str, vol.Length(min=1)),
+        vol.Required("quantity"): vol.All(vol.Coerce(float), vol.Range(min=0)),
+        vol.Optional("low_stock_threshold"): vol.All(vol.Coerce(float), vol.Range(min=0)),
     }
 )
 
@@ -133,6 +176,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: PoolmanConfigEntry) -> 
         hass.services.async_remove(DOMAIN, SERVICE_RECORD_MEASURE)
         hass.services.async_remove(DOMAIN, SERVICE_BOOST_FILTRATION)
         hass.services.async_remove(DOMAIN, SERVICE_CONFIRM_ACTIVATION_STEP)
+        hass.services.async_remove(DOMAIN, SERVICE_INVENTORY_ADD_PRODUCT)
+        hass.services.async_remove(DOMAIN, SERVICE_INVENTORY_REMOVE_PRODUCT)
+        hass.services.async_remove(DOMAIN, SERVICE_INVENTORY_ADD_STOCK)
+        hass.services.async_remove(DOMAIN, SERVICE_INVENTORY_SET_STOCK)
 
     return result
 
@@ -341,4 +388,77 @@ def _async_register_services(hass: HomeAssistant) -> None:
         SERVICE_CONFIRM_ACTIVATION_STEP,
         async_handle_confirm_activation_step,
         schema=SERVICE_CONFIRM_ACTIVATION_STEP_SCHEMA,
+    )
+
+    def _resolve_coordinator(entry_id: str) -> PoolmanCoordinator:
+        entry = hass.config_entries.async_get_entry(entry_id)
+        if entry is None or entry.domain != DOMAIN:
+            raise ServiceValidationError(f"Unknown Pool Manager config entry: {entry_id}")
+        return entry.runtime_data
+
+    async def async_handle_inventory_add_product(call: ServiceCall) -> None:
+        coordinator = _resolve_coordinator(call.data["entry_id"])
+        chemical_raw: str | None = call.data.get("chemical")
+        product = Product(
+            id=call.data["product_id"],
+            name=call.data["name"],
+            unit=call.data["unit"],
+            chemical=ChemicalProduct(chemical_raw) if chemical_raw else None,
+        )
+        await coordinator.async_inventory_add_product(
+            product,
+            initial_quantity=call.data.get("initial_quantity"),
+            low_stock_threshold=call.data.get("low_stock_threshold"),
+        )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_INVENTORY_ADD_PRODUCT,
+        async_handle_inventory_add_product,
+        schema=SERVICE_INVENTORY_ADD_PRODUCT_SCHEMA,
+    )
+
+    async def async_handle_inventory_remove_product(call: ServiceCall) -> None:
+        coordinator = _resolve_coordinator(call.data["entry_id"])
+        await coordinator.async_inventory_remove_product(call.data["product_id"])
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_INVENTORY_REMOVE_PRODUCT,
+        async_handle_inventory_remove_product,
+        schema=SERVICE_INVENTORY_REMOVE_PRODUCT_SCHEMA,
+    )
+
+    async def async_handle_inventory_add_stock(call: ServiceCall) -> None:
+        coordinator = _resolve_coordinator(call.data["entry_id"])
+        product_id = call.data["product_id"]
+        try:
+            await coordinator.async_inventory_add_stock(product_id, call.data["quantity"])
+        except KeyError as exc:
+            raise ServiceValidationError(f"Unknown inventory product: {product_id}") from exc
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_INVENTORY_ADD_STOCK,
+        async_handle_inventory_add_stock,
+        schema=SERVICE_INVENTORY_ADD_STOCK_SCHEMA,
+    )
+
+    async def async_handle_inventory_set_stock(call: ServiceCall) -> None:
+        coordinator = _resolve_coordinator(call.data["entry_id"])
+        product_id = call.data["product_id"]
+        try:
+            await coordinator.async_inventory_set_stock(
+                product_id,
+                call.data["quantity"],
+                low_stock_threshold=call.data.get("low_stock_threshold"),
+            )
+        except KeyError as exc:
+            raise ServiceValidationError(f"Unknown inventory product: {product_id}") from exc
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_INVENTORY_SET_STOCK,
+        async_handle_inventory_set_stock,
+        schema=SERVICE_INVENTORY_SET_STOCK_SCHEMA,
     )

--- a/custom_components/poolman/binary_sensor.py
+++ b/custom_components/poolman/binary_sensor.py
@@ -4,17 +4,19 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Any
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import PoolmanConfigEntry
 from .coordinator import PoolmanCoordinator
+from .domain.inventory import Product
 from .domain.model import PoolState
 from .entity import PoolmanEntity
 
@@ -55,9 +57,35 @@ async def async_setup_entry(
 ) -> None:
     """Set up Pool Manager binary sensors."""
     coordinator: PoolmanCoordinator = entry.runtime_data
-    async_add_entities(
+    entities: list[BinarySensorEntity] = [
         PoolmanBinarySensor(coordinator, description) for description in BINARY_SENSOR_DESCRIPTIONS
-    )
+    ]
+
+    known_inventory_ids: set[str] = set()
+
+    def _add_inventory_entities(product_ids: set[str]) -> None:
+        new_entities: list[BinarySensorEntity] = []
+        for product_id in product_ids:
+            product = coordinator.inventory.products.get(product_id)
+            if product is None or product_id in known_inventory_ids:
+                continue
+            known_inventory_ids.add(product_id)
+            new_entities.append(PoolmanLowStockBinarySensor(coordinator, product))
+        if new_entities:
+            async_add_entities(new_entities)
+
+    for product_id, product in coordinator.inventory.products.items():
+        known_inventory_ids.add(product_id)
+        entities.append(PoolmanLowStockBinarySensor(coordinator, product))
+
+    async_add_entities(entities)
+
+    @callback
+    def _on_inventory_change(added: set[str], _removed: set[str]) -> None:
+        if added:
+            _add_inventory_entities(added)
+
+    entry.async_on_unload(coordinator.on_inventory_change(_on_inventory_change))
 
 
 class PoolmanBinarySensor(PoolmanEntity, BinarySensorEntity):
@@ -79,3 +107,50 @@ class PoolmanBinarySensor(PoolmanEntity, BinarySensorEntity):
     def is_on(self) -> bool | None:
         """Return the binary sensor state."""
         return self.entity_description.is_on_fn(self.pool_state)
+
+
+class PoolmanLowStockBinarySensor(PoolmanEntity, BinarySensorEntity):
+    """Binary sensor flagging when a product's stock falls below threshold."""
+
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_icon = "mdi:package-variant-closed-remove"
+
+    def __init__(self, coordinator: PoolmanCoordinator, product: Product) -> None:
+        """Initialize the low-stock binary sensor."""
+        super().__init__(coordinator)
+        self._product_id = product.id
+        self._attr_unique_id = (
+            f"{coordinator.config_entry.entry_id}_inventory_{product.id}_low_stock"
+        )
+        self._attr_translation_key = "inventory_low_stock"
+        self._attr_translation_placeholders = {"product_name": product.name}
+        self._attr_name = f"{product.name} low stock"
+
+    @property
+    def available(self) -> bool:
+        """Return whether the product is still in the inventory catalog."""
+        return super().available and self._product_id in self.coordinator.inventory.products
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return whether the product's stock is at or below the threshold."""
+        item = self.coordinator.inventory.get(self._product_id)
+        if item is None or item.low_stock_threshold is None:
+            return False
+        return self.coordinator.inventory.is_low(self._product_id)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return product metadata and current stock figures."""
+        product = self.coordinator.inventory.products.get(self._product_id)
+        item = self.coordinator.inventory.get(self._product_id)
+        if product is None:
+            return {}
+        return {
+            "product_id": product.id,
+            "product_name": product.name,
+            "unit": product.unit,
+            "chemical": product.chemical.value if product.chemical else None,
+            "quantity": item.quantity if item is not None else None,
+            "low_stock_threshold": item.low_stock_threshold if item is not None else None,
+        }

--- a/custom_components/poolman/const.py
+++ b/custom_components/poolman/const.py
@@ -159,3 +159,10 @@ SERVICE_ADD_TREATMENT: Final = "add_treatment"
 SERVICE_RECORD_MEASURE: Final = "record_measure"
 SERVICE_BOOST_FILTRATION: Final = "boost_filtration"
 SERVICE_CONFIRM_ACTIVATION_STEP: Final = "confirm_activation_step"
+SERVICE_INVENTORY_ADD_PRODUCT: Final = "inventory_add_product"
+SERVICE_INVENTORY_REMOVE_PRODUCT: Final = "inventory_remove_product"
+SERVICE_INVENTORY_ADD_STOCK: Final = "inventory_add_stock"
+SERVICE_INVENTORY_SET_STOCK: Final = "inventory_set_stock"
+
+# Inventory units exposed by services
+INVENTORY_UNITS: Final = ["g", "kg", "mL", "L", "tablet"]

--- a/custom_components/poolman/coordinator.py
+++ b/custom_components/poolman/coordinator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import logging
 
+from collections.abc import Callable
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
@@ -55,6 +56,7 @@ from .domain.chemistry import (
     compute_water_quality_score,
 )
 from .domain.filtration import compute_filtration_duration
+from .domain.inventory import Inventory, Product
 from .domain.model import (
     ChemicalProduct,
     FiltrationDurationMode,
@@ -76,6 +78,7 @@ from .domain.treatment import (
     compute_swimming_safe,
 )
 from .scheduler import FiltrationScheduler
+from .storage import InventoryStore
 
 if TYPE_CHECKING:
     from .event import PoolmanMeasureEvent, PoolmanTreatmentEvent
@@ -125,6 +128,12 @@ class PoolmanCoordinator(DataUpdateCoordinator[PoolState]):
         self._treatment_entities: dict[ChemicalProduct, PoolmanTreatmentEvent] = {}
         self._measure_entities: dict[MeasureParameter, PoolmanMeasureEvent] = {}
         self._activation: ActivationChecklist | None = None
+
+        # Inventory persistence: loaded asynchronously on first refresh.
+        self._inventory_store = InventoryStore(hass, config_entry.entry_id)
+        self.inventory: Inventory = Inventory()
+        self._inventory_loaded = False
+        self._inventory_listeners: list[Callable[[set[str], set[str]], None]] = []
 
         # Filtration scheduler: only created when a pump entity is configured
         pump_entity_id = self._get_config(CONF_PUMP_ENTITY)
@@ -497,6 +506,108 @@ class PoolmanCoordinator(DataUpdateCoordinator[PoolState]):
         entity.record_measure(value=value, notes=notes)
         await self.async_request_refresh()
 
+    # ------------------------------------------------------------------
+    # Inventory helpers
+    # ------------------------------------------------------------------
+    def on_inventory_change(
+        self,
+        callback: Callable[[set[str], set[str]], None],
+    ) -> Callable[[], None]:
+        """Register a listener notified when products are added or removed.
+
+        The listener receives two sets: ``(added_ids, removed_ids)`` of
+        product identifiers. It is invoked synchronously after the
+        inventory has been mutated and persisted.
+
+        Returns:
+            A callable that removes the listener when invoked.
+        """
+        self._inventory_listeners.append(callback)
+
+        def _remove() -> None:
+            with contextlib.suppress(ValueError):
+                self._inventory_listeners.remove(callback)
+
+        return _remove
+
+    def _notify_inventory_listeners(
+        self,
+        added: set[str],
+        removed: set[str],
+    ) -> None:
+        for listener in list(self._inventory_listeners):
+            try:
+                listener(added, removed)
+            except Exception:
+                _LOGGER.exception("Inventory listener raised")
+
+    async def _async_persist_inventory(
+        self,
+        added: set[str] | None = None,
+        removed: set[str] | None = None,
+    ) -> None:
+        """Persist the inventory and notify listeners + entities."""
+        await self._inventory_store.async_save(self.inventory)
+        self._notify_inventory_listeners(added or set(), removed or set())
+        # Trigger an entity refresh so quantity sensors update immediately.
+        self.async_update_listeners()
+
+    async def async_inventory_add_product(
+        self,
+        product: Product,
+        initial_quantity: float | None = None,
+        low_stock_threshold: float | None = None,
+    ) -> None:
+        """Register a product, optionally seeding its stock and threshold."""
+        is_new = product.id not in self.inventory.products
+        self.inventory.add_product(product)
+        if initial_quantity is not None or low_stock_threshold is not None:
+            self.inventory.set_stock(
+                product.id,
+                initial_quantity if initial_quantity is not None else 0.0,
+                low_stock_threshold=low_stock_threshold,
+            )
+        await self._async_persist_inventory(
+            added={product.id} if is_new else set(),
+        )
+
+    async def async_inventory_remove_product(self, product_id: str) -> None:
+        """Remove a product and its stock from inventory."""
+        existed = product_id in self.inventory.products
+        self.inventory.remove_product(product_id)
+        await self._async_persist_inventory(
+            removed={product_id} if existed else set(),
+        )
+
+    async def async_inventory_add_stock(
+        self,
+        product_id: str,
+        quantity: float,
+    ) -> None:
+        """Increase the stock for a product. Raises KeyError if unknown."""
+        self.inventory.add_stock(product_id, quantity)
+        await self._async_persist_inventory()
+
+    async def async_inventory_set_stock(
+        self,
+        product_id: str,
+        quantity: float,
+        low_stock_threshold: float | None = None,
+    ) -> None:
+        """Set the absolute stock and (optionally) the low-stock threshold."""
+        self.inventory.set_stock(product_id, quantity, low_stock_threshold)
+        await self._async_persist_inventory()
+
+    async def async_inventory_consume(
+        self,
+        product_id: str,
+        quantity: float,
+        unit: str | None = None,
+    ) -> None:
+        """Decrement the stock for a product. Used by action recording (#94)."""
+        self.inventory.consume(product_id, quantity, unit=unit)
+        await self._async_persist_inventory()
+
     def _read_sensor(self, entity_key: str) -> float | None:
         """Safely read a float value from a HA sensor entity.
 
@@ -663,6 +774,11 @@ class PoolmanCoordinator(DataUpdateCoordinator[PoolState]):
         sensors are unavailable. Tracks which source provided each value
         in ``reading_sources``.
         """
+        # Load inventory on first refresh (no async work allowed in __init__).
+        if not self._inventory_loaded:
+            self.inventory = await self._inventory_store.async_load()
+            self._inventory_loaded = True
+
         # Read manual measures from event entities
         manual_measures = self._read_measure_entries()
 

--- a/custom_components/poolman/domain/inventory.py
+++ b/custom_components/poolman/domain/inventory.py
@@ -1,0 +1,359 @@
+"""Inventory model for user-tracked pool products.
+
+This module defines the types used to track the user's stock of chemical
+products available for treatment. It is the canonical home for:
+
+- :class:`Product` -- a user-defined product entry (brand, name, unit,
+  optional tag mapping to a :class:`~.model.ChemicalProduct` kind).
+- :class:`InventoryItem` -- current stock for a product, with an optional
+  low-stock threshold.
+- :class:`Inventory` -- mutable container with the catalog of products and
+  their stock items.
+
+The inventory is **decoupled** from the analysis pipeline: rules and
+recommendations MUST NOT mutate it. Stock is only modified by user input
+(via Home Assistant services) or by recording an :class:`~.action.Action`
+(see #94).
+
+Units are plain Home Assistant-compatible strings (``"g"``, ``"mL"``,
+``"tablet"``), matching the convention used by :class:`~.action.Action`
+and :class:`~.recommendation.Treatment`. No Home Assistant dependency is
+present in this module.
+
+Example::
+
+    from custom_components.poolman.domain.inventory import (
+        Inventory,
+        InventoryItem,
+        Product,
+    )
+    from custom_components.poolman.domain.model import ChemicalProduct
+
+    inventory = Inventory()
+    inventory.add_product(
+        Product(
+            id="brand_x_ph_minus_1_5kg",
+            name="Brand X pH Minus 1.5kg",
+            unit="g",
+            chemical=ChemicalProduct.PH_MINUS,
+        )
+    )
+    inventory.add_stock("brand_x_ph_minus_1_5kg", 1500.0)
+    inventory.consume("brand_x_ph_minus_1_5kg", 300.0, unit="g")
+    assert inventory.get("brand_x_ph_minus_1_5kg").quantity == 1200.0
+"""
+
+from __future__ import annotations
+
+import logging
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .model import ChemicalProduct
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class Product:
+    """A user-defined product available in the inventory.
+
+    Products are user-configured to represent the actual branded items
+    purchased by the user (e.g. *Brand X pH Minus 1.5kg*). The optional
+    :attr:`chemical` tag links the branded product back to one of the
+    well-known :class:`~.model.ChemicalProduct` kinds used by rules and
+    treatments, so that consumption can be correlated with recommended
+    treatments.
+
+    Attributes:
+        id: Stable identifier for the product, used as the key in the
+            inventory and as ``product_id`` reference in actions.
+        name: Human-readable label shown in the UI.
+        unit: Unit for the product's quantity. MUST be a Home
+            Assistant-compatible unit string, e.g. ``"g"``, ``"mL"``,
+            or ``"tablet"``. Must match the unit used by any
+            :class:`~.action.Action` that consumes this product.
+        chemical: Optional tag identifying which
+            :class:`~.model.ChemicalProduct` kind this branded product
+            corresponds to. ``None`` for products outside the known
+            catalog (e.g. custom or proprietary blends).
+    """
+
+    id: str
+    name: str
+    unit: str  # HA-compatible: "g" | "mL" | "tablet"
+    chemical: ChemicalProduct | None = None
+
+
+@dataclass
+class InventoryItem:
+    """Current stock for a product in the inventory.
+
+    Items are mutable: quantity is updated by :meth:`Inventory.add_stock`,
+    :meth:`Inventory.set_stock`, and :meth:`Inventory.consume`. A negative
+    quantity is allowed (and logged as a warning) so over-consumption is
+    visible rather than silently clamped.
+
+    Attributes:
+        product_id: Identifier of the related :class:`Product`.
+        quantity: Current amount in stock, expressed in the product's unit.
+        low_stock_threshold: Optional threshold; when set, ``quantity``
+            falling below this value flags the item as low (see
+            :meth:`Inventory.is_low`).
+    """
+
+    product_id: str
+    quantity: float
+    low_stock_threshold: float | None = None
+
+
+@dataclass
+class Inventory:
+    """Mutable catalog of products and their current stock.
+
+    The inventory holds two maps keyed by ``product_id``:
+
+    - :attr:`products` -- the catalog of known products.
+    - :attr:`items` -- the current stock per product.
+
+    An item is created lazily by :meth:`add_stock` the first time a
+    product receives stock. Consumption of an unknown product is logged
+    and silently skipped (matching the contract expected by #94).
+
+    Attributes:
+        products: Catalog of known products, keyed by product id.
+        items: Current stock items, keyed by product id.
+    """
+
+    products: dict[str, Product] = field(default_factory=dict)
+    items: dict[str, InventoryItem] = field(default_factory=dict)
+
+    # ------------------------------------------------------------------
+    # Catalog
+    # ------------------------------------------------------------------
+    def add_product(self, product: Product) -> None:
+        """Add (or replace) a product in the catalog.
+
+        Existing stock for the same ``product_id`` is preserved.
+
+        Args:
+            product: The product to add or replace.
+        """
+        self.products[product.id] = product
+
+    def remove_product(self, product_id: str) -> None:
+        """Remove a product from the catalog and drop its stock item.
+
+        Args:
+            product_id: Identifier of the product to remove.
+        """
+        self.products.pop(product_id, None)
+        self.items.pop(product_id, None)
+
+    # ------------------------------------------------------------------
+    # Stock access
+    # ------------------------------------------------------------------
+    def get(self, product_id: str) -> InventoryItem | None:
+        """Return the stock item for a product, or ``None`` if absent."""
+        return self.items.get(product_id)
+
+    def add_stock(self, product_id: str, quantity: float) -> None:
+        """Increase the stock for a product.
+
+        Creates the stock item on first call. Raises :class:`KeyError`
+        when the product is not in the catalog so callers can surface a
+        user-facing error.
+
+        Args:
+            product_id: Identifier of the product to credit.
+            quantity: Positive amount to add (in the product's unit).
+
+        Raises:
+            KeyError: If ``product_id`` is not registered in the catalog.
+        """
+        if product_id not in self.products:
+            raise KeyError(product_id)
+        item = self.items.get(product_id)
+        if item is None:
+            self.items[product_id] = InventoryItem(
+                product_id=product_id,
+                quantity=quantity,
+            )
+        else:
+            item.quantity += quantity
+
+    def set_stock(
+        self,
+        product_id: str,
+        quantity: float,
+        low_stock_threshold: float | None = None,
+    ) -> None:
+        """Set the absolute stock and optionally the low-stock threshold.
+
+        Args:
+            product_id: Identifier of the product to update.
+            quantity: New absolute quantity (in the product's unit).
+            low_stock_threshold: Optional new threshold. When ``None``,
+                the existing threshold is preserved.
+
+        Raises:
+            KeyError: If ``product_id`` is not registered in the catalog.
+        """
+        if product_id not in self.products:
+            raise KeyError(product_id)
+        item = self.items.get(product_id)
+        if item is None:
+            self.items[product_id] = InventoryItem(
+                product_id=product_id,
+                quantity=quantity,
+                low_stock_threshold=low_stock_threshold,
+            )
+        else:
+            item.quantity = quantity
+            if low_stock_threshold is not None:
+                item.low_stock_threshold = low_stock_threshold
+
+    def consume(
+        self,
+        product_id: str,
+        quantity: float,
+        unit: str | None = None,
+    ) -> None:
+        """Decrement the stock for a product.
+
+        Designed to be called from the action-recording pipeline (#94):
+
+        - Unknown products are logged as a warning and skipped, never
+          raised, so action recording is not blocked.
+        - When ``unit`` is given and differs from the product's unit, an
+          error is logged and the stock is left unchanged (no silent
+          unit conversion).
+        - Negative resulting stock is allowed but logged as a warning.
+
+        Args:
+            product_id: Identifier of the product to debit.
+            quantity: Positive amount to consume (in the product's unit).
+            unit: Optional unit guard. When provided, MUST match the
+                product's unit, otherwise the consumption is skipped.
+        """
+        product = self.products.get(product_id)
+        item = self.items.get(product_id)
+        if product is None or item is None:
+            _LOGGER.warning(
+                "Unknown product %s — action recorded but inventory not updated",
+                product_id,
+            )
+            return
+
+        if unit is not None and unit != product.unit:
+            _LOGGER.error(
+                "Unit mismatch for product %s: inventory=%s action=%s — skipping inventory update",
+                product_id,
+                product.unit,
+                unit,
+            )
+            return
+
+        item.quantity -= quantity
+        if item.quantity < 0:
+            _LOGGER.warning(
+                "Negative stock for product %s (%.2f)",
+                product_id,
+                item.quantity,
+            )
+
+    def is_low(self, product_id: str) -> bool:
+        """Return ``True`` when the product's stock is at or below threshold.
+
+        Returns ``False`` when the product is unknown, has no stock item,
+        or has no configured threshold.
+
+        Args:
+            product_id: Identifier of the product to check.
+        """
+        item = self.items.get(product_id)
+        if item is None or item.low_stock_threshold is None:
+            return False
+        return item.quantity <= item.low_stock_threshold
+
+    # ------------------------------------------------------------------
+    # Serialization (used by helpers.storage.Store)
+    # ------------------------------------------------------------------
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation of the inventory."""
+        return {
+            "products": [
+                {
+                    "id": product.id,
+                    "name": product.name,
+                    "unit": product.unit,
+                    "chemical": product.chemical.value if product.chemical else None,
+                }
+                for product in self.products.values()
+            ],
+            "items": [
+                {
+                    "product_id": item.product_id,
+                    "quantity": item.quantity,
+                    "low_stock_threshold": item.low_stock_threshold,
+                }
+                for item in self.items.values()
+            ],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Inventory:
+        """Rebuild an :class:`Inventory` from its JSON representation.
+
+        Unknown chemical tags are dropped (set to ``None``) rather than
+        causing the load to fail, so an inventory persisted with a newer
+        version of the integration remains loadable after a downgrade.
+
+        Args:
+            data: A dictionary previously produced by :meth:`to_dict`.
+        """
+        inventory = cls()
+        for raw_product in data.get("products", []):
+            chemical_raw = raw_product.get("chemical")
+            chemical: ChemicalProduct | None
+            if chemical_raw is None:
+                chemical = None
+            else:
+                try:
+                    chemical = ChemicalProduct(chemical_raw)
+                except ValueError:
+                    _LOGGER.warning(
+                        "Dropping unknown chemical tag %s for product %s",
+                        chemical_raw,
+                        raw_product.get("id"),
+                    )
+                    chemical = None
+            product = Product(
+                id=raw_product["id"],
+                name=raw_product["name"],
+                unit=raw_product["unit"],
+                chemical=chemical,
+            )
+            inventory.products[product.id] = product
+
+        for raw_item in data.get("items", []):
+            product_id = raw_item["product_id"]
+            if product_id not in inventory.products:
+                # Drop dangling items without a matching product to keep
+                # the inventory consistent.
+                _LOGGER.warning(
+                    "Dropping inventory item for unknown product %s",
+                    product_id,
+                )
+                continue
+            inventory.items[product_id] = InventoryItem(
+                product_id=product_id,
+                quantity=float(raw_item["quantity"]),
+                low_stock_threshold=(
+                    float(raw_item["low_stock_threshold"])
+                    if raw_item.get("low_stock_threshold") is not None
+                    else None
+                ),
+            )
+        return inventory

--- a/custom_components/poolman/sensor.py
+++ b/custom_components/poolman/sensor.py
@@ -13,14 +13,15 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import UnitOfTemperature, UnitOfTime
-from homeassistant.core import HomeAssistant
+from homeassistant.const import UnitOfMass, UnitOfTemperature, UnitOfTime, UnitOfVolume
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
 from . import PoolmanConfigEntry
 from .coordinator import PoolmanCoordinator
 from .domain.activation import ActivationStep
+from .domain.inventory import Product
 from .domain.model import (
     ActionKind,
     ChemistryStatus,
@@ -379,7 +380,37 @@ async def async_setup_entry(
         PoolmanSensor(coordinator, description) for description in descriptions
     ]
     entities.append(PoolmanActivationStepSensor(coordinator))
+
+    # Inventory: one quantity sensor per configured product, with
+    # dynamic discovery of products added later via services.
+    known_inventory_ids: set[str] = set()
+
+    def _add_inventory_entities(product_ids: set[str]) -> None:
+        new_entities: list[SensorEntity] = []
+        for product_id in product_ids:
+            product = coordinator.inventory.products.get(product_id)
+            if product is None or product_id in known_inventory_ids:
+                continue
+            known_inventory_ids.add(product_id)
+            new_entities.append(PoolmanInventorySensor(coordinator, product))
+        if new_entities:
+            async_add_entities(new_entities)
+
+    initial_ids = set(coordinator.inventory.products.keys())
+    for product_id in initial_ids:
+        known_inventory_ids.add(product_id)
+        entities.append(
+            PoolmanInventorySensor(coordinator, coordinator.inventory.products[product_id])
+        )
+
     async_add_entities(entities)
+
+    @callback
+    def _on_inventory_change(added: set[str], _removed: set[str]) -> None:
+        if added:
+            _add_inventory_entities(added)
+
+    entry.async_on_unload(coordinator.on_inventory_change(_on_inventory_change))
 
 
 class PoolmanSensor(PoolmanEntity, SensorEntity):
@@ -454,4 +485,66 @@ class PoolmanActivationStepSensor(PoolmanEntity, SensorEntity):
             "pending_steps": [s.value for s in activation.pending_steps],
             "progress": f"{completed}/{total}",
             "started_at": activation.started_at.isoformat(),
+        }
+
+
+# Mapping from inventory unit string to (HA unit constant, device class).
+_INVENTORY_UNIT_MAP: dict[str, tuple[str | None, SensorDeviceClass | None]] = {
+    "g": (UnitOfMass.GRAMS, SensorDeviceClass.WEIGHT),
+    "kg": (UnitOfMass.KILOGRAMS, SensorDeviceClass.WEIGHT),
+    "mL": (UnitOfVolume.MILLILITERS, SensorDeviceClass.VOLUME_STORAGE),
+    "L": (UnitOfVolume.LITERS, SensorDeviceClass.VOLUME_STORAGE),
+    "tablet": (None, None),
+}
+
+
+class PoolmanInventorySensor(PoolmanEntity, SensorEntity):
+    """Sensor reporting the current stock for a single inventory product."""
+
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_icon = "mdi:package-variant"
+
+    def __init__(self, coordinator: PoolmanCoordinator, product: Product) -> None:
+        """Initialize the inventory sensor.
+
+        Args:
+            coordinator: The pool coordinator owning the inventory.
+            product: The product this sensor reports stock for.
+        """
+        super().__init__(coordinator)
+        self._product_id = product.id
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}_inventory_{product.id}"
+        self._attr_translation_key = "inventory_product"
+        self._attr_translation_placeholders = {"product_name": product.name}
+        self._attr_name = product.name
+        unit, device_class = _INVENTORY_UNIT_MAP.get(product.unit, (product.unit, None))
+        self._attr_native_unit_of_measurement = unit
+        if device_class is not None:
+            self._attr_device_class = device_class
+
+    @property
+    def available(self) -> bool:
+        """Return whether the product is still in the inventory catalog."""
+        return super().available and self._product_id in self.coordinator.inventory.products
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current quantity in stock, or ``None`` if unknown."""
+        item = self.coordinator.inventory.get(self._product_id)
+        return item.quantity if item is not None else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return product metadata and low-stock state as attributes."""
+        product = self.coordinator.inventory.products.get(self._product_id)
+        item = self.coordinator.inventory.get(self._product_id)
+        if product is None:
+            return {}
+        return {
+            "product_id": product.id,
+            "product_name": product.name,
+            "unit": product.unit,
+            "chemical": product.chemical.value if product.chemical else None,
+            "low_stock_threshold": item.low_stock_threshold if item is not None else None,
+            "is_low": self.coordinator.inventory.is_low(self._product_id),
         }

--- a/custom_components/poolman/services.yaml
+++ b/custom_components/poolman/services.yaml
@@ -149,3 +149,160 @@ confirm_activation_step:
             - "clean_pool_and_filter"
             - "shock_treatment"
             - "intensive_filtration"
+
+inventory_add_product:
+  name: Add inventory product
+  description: Register a product in the pool's inventory catalog.
+  fields:
+    entry_id:
+      name: Config entry
+      description: The Pool Manager config entry that owns the inventory.
+      required: true
+      selector:
+        config_entry:
+          integration: poolman
+    product_id:
+      name: Product ID
+      description: Stable identifier used to reference this product.
+      required: true
+      selector:
+        text:
+    name:
+      name: Display name
+      description: Human-readable label for the product.
+      required: true
+      selector:
+        text:
+    unit:
+      name: Unit
+      description: Unit used to express the product quantity.
+      required: true
+      selector:
+        select:
+          options:
+            - "g"
+            - "kg"
+            - "mL"
+            - "L"
+            - "tablet"
+    chemical:
+      name: Chemical kind
+      description: Optional tag mapping this product to a known chemical kind.
+      selector:
+        select:
+          translation_key: chemical_product
+          options:
+            - "ph_minus"
+            - "ph_plus"
+            - "chlore_choc"
+            - "galet_chlore"
+            - "neutralizer"
+            - "tac_plus"
+            - "salt"
+            - "bromine_tablet"
+            - "bromine_shock"
+            - "active_oxygen_tablet"
+            - "active_oxygen_activator"
+            - "flocculant"
+            - "anti_algae"
+            - "stabilizer"
+            - "clarifier"
+            - "metal_sequestrant"
+            - "calcium_hardness_increaser"
+            - "winterizing_product"
+    initial_quantity:
+      name: Initial quantity
+      description: Optional initial stock to seed the product with.
+      selector:
+        number:
+          min: 0
+          step: 0.1
+          mode: box
+    low_stock_threshold:
+      name: Low-stock threshold
+      description: Optional threshold; the low-stock binary sensor turns on when quantity falls at or below this value.
+      selector:
+        number:
+          min: 0
+          step: 0.1
+          mode: box
+
+inventory_remove_product:
+  name: Remove inventory product
+  description: Remove a product (and its stock) from the inventory catalog.
+  fields:
+    entry_id:
+      name: Config entry
+      description: The Pool Manager config entry that owns the inventory.
+      required: true
+      selector:
+        config_entry:
+          integration: poolman
+    product_id:
+      name: Product ID
+      description: Identifier of the product to remove.
+      required: true
+      selector:
+        text:
+
+inventory_add_stock:
+  name: Add inventory stock
+  description: Add stock to an existing inventory product.
+  fields:
+    entry_id:
+      name: Config entry
+      description: The Pool Manager config entry that owns the inventory.
+      required: true
+      selector:
+        config_entry:
+          integration: poolman
+    product_id:
+      name: Product ID
+      description: Identifier of the product to credit.
+      required: true
+      selector:
+        text:
+    quantity:
+      name: Quantity
+      description: Amount to add, in the product's unit.
+      required: true
+      selector:
+        number:
+          min: 0
+          step: 0.1
+          mode: box
+
+inventory_set_stock:
+  name: Set inventory stock
+  description: Set the absolute stock (and optionally the low-stock threshold) of a product.
+  fields:
+    entry_id:
+      name: Config entry
+      description: The Pool Manager config entry that owns the inventory.
+      required: true
+      selector:
+        config_entry:
+          integration: poolman
+    product_id:
+      name: Product ID
+      description: Identifier of the product to update.
+      required: true
+      selector:
+        text:
+    quantity:
+      name: Quantity
+      description: New absolute quantity, in the product's unit.
+      required: true
+      selector:
+        number:
+          min: 0
+          step: 0.1
+          mode: box
+    low_stock_threshold:
+      name: Low-stock threshold
+      description: Optional new threshold value.
+      selector:
+        number:
+          min: 0
+          step: 0.1
+          mode: box

--- a/custom_components/poolman/storage.py
+++ b/custom_components/poolman/storage.py
@@ -1,0 +1,72 @@
+"""Persistence helpers for Pool Manager.
+
+This module wraps :class:`homeassistant.helpers.storage.Store` to persist
+state that lives outside the config-entry data (currently the user's
+:class:`~.domain.inventory.Inventory`).
+
+One store file is created per config entry, keyed
+``poolman.inventory.<entry_id>`` so that multi-pool installations remain
+isolated. Loading is fault-tolerant: corrupted or partial payloads cause
+the integration to fall back to an empty inventory and log a warning,
+never crash setup.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+
+from .const import DOMAIN
+from .domain.inventory import Inventory
+
+_LOGGER = logging.getLogger(__name__)
+
+INVENTORY_STORAGE_VERSION = 1
+
+
+class InventoryStore:
+    """Persistence wrapper for an :class:`Inventory` per config entry."""
+
+    def __init__(self, hass: HomeAssistant, entry_id: str) -> None:
+        """Initialize the store.
+
+        Args:
+            hass: The Home Assistant instance.
+            entry_id: Config entry identifier; used to namespace the
+                storage key so multiple pools persist independently.
+        """
+        self._store: Store[dict[str, Any]] = Store(
+            hass,
+            INVENTORY_STORAGE_VERSION,
+            f"{DOMAIN}.inventory.{entry_id}",
+        )
+
+    async def async_load(self) -> Inventory:
+        """Load the inventory from disk.
+
+        Returns:
+            The persisted :class:`Inventory`, or an empty inventory when
+            no data exists or the stored payload cannot be parsed.
+        """
+        try:
+            data = await self._store.async_load()
+        except Exception:
+            _LOGGER.warning("Failed to load inventory store; starting empty", exc_info=True)
+            return Inventory()
+
+        if not data:
+            return Inventory()
+
+        try:
+            return Inventory.from_dict(data)
+        except (KeyError, TypeError, ValueError):
+            _LOGGER.warning("Malformed inventory payload; starting empty", exc_info=True)
+            return Inventory()
+
+    async def async_save(self, inventory: Inventory) -> None:
+        """Persist the inventory to disk."""
+        await self._store.async_save(inventory.to_dict())

--- a/custom_components/poolman/strings.json
+++ b/custom_components/poolman/strings.json
@@ -342,6 +342,9 @@
           "shock_treatment": "Shock treatment",
           "intensive_filtration": "Intensive filtration"
         }
+      },
+      "inventory_product": {
+        "name": "{product_name} stock"
       }
     },
     "binary_sensor": {
@@ -353,6 +356,9 @@
       },
       "swimming_safe": {
         "name": "Swimming safe"
+      },
+      "inventory_low_stock": {
+        "name": "{product_name} low stock"
       }
     },
     "event": {
@@ -858,6 +864,94 @@
         "step": {
           "name": "Step",
           "description": "The activation step to confirm as completed."
+        }
+      }
+    },
+    "inventory_add_product": {
+      "name": "Add inventory product",
+      "description": "Register a product in the pool's inventory catalog.",
+      "fields": {
+        "entry_id": {
+          "name": "Config entry",
+          "description": "The Pool Manager config entry that owns the inventory."
+        },
+        "product_id": {
+          "name": "Product ID",
+          "description": "Stable identifier used to reference this product."
+        },
+        "name": {
+          "name": "Display name",
+          "description": "Human-readable label for the product."
+        },
+        "unit": {
+          "name": "Unit",
+          "description": "Unit used to express the product quantity."
+        },
+        "chemical": {
+          "name": "Chemical kind",
+          "description": "Optional tag mapping this product to a known chemical kind."
+        },
+        "initial_quantity": {
+          "name": "Initial quantity",
+          "description": "Optional initial stock to seed the product with."
+        },
+        "low_stock_threshold": {
+          "name": "Low-stock threshold",
+          "description": "Optional threshold; the low-stock binary sensor turns on when quantity falls at or below this value."
+        }
+      }
+    },
+    "inventory_remove_product": {
+      "name": "Remove inventory product",
+      "description": "Remove a product (and its stock) from the inventory catalog.",
+      "fields": {
+        "entry_id": {
+          "name": "Config entry",
+          "description": "The Pool Manager config entry that owns the inventory."
+        },
+        "product_id": {
+          "name": "Product ID",
+          "description": "Identifier of the product to remove."
+        }
+      }
+    },
+    "inventory_add_stock": {
+      "name": "Add inventory stock",
+      "description": "Add stock to an existing inventory product.",
+      "fields": {
+        "entry_id": {
+          "name": "Config entry",
+          "description": "The Pool Manager config entry that owns the inventory."
+        },
+        "product_id": {
+          "name": "Product ID",
+          "description": "Identifier of the product to credit."
+        },
+        "quantity": {
+          "name": "Quantity",
+          "description": "Amount to add, in the product's unit."
+        }
+      }
+    },
+    "inventory_set_stock": {
+      "name": "Set inventory stock",
+      "description": "Set the absolute stock (and optionally the low-stock threshold) of a product.",
+      "fields": {
+        "entry_id": {
+          "name": "Config entry",
+          "description": "The Pool Manager config entry that owns the inventory."
+        },
+        "product_id": {
+          "name": "Product ID",
+          "description": "Identifier of the product to update."
+        },
+        "quantity": {
+          "name": "Quantity",
+          "description": "New absolute quantity, in the product's unit."
+        },
+        "low_stock_threshold": {
+          "name": "Low-stock threshold",
+          "description": "Optional new threshold value."
         }
       }
     }

--- a/custom_components/poolman/translations/en.json
+++ b/custom_components/poolman/translations/en.json
@@ -342,6 +342,9 @@
           "shock_treatment": "Shock treatment",
           "intensive_filtration": "Intensive filtration"
         }
+      },
+      "inventory_product": {
+        "name": "{product_name} stock"
       }
     },
     "binary_sensor": {
@@ -353,6 +356,9 @@
       },
       "swimming_safe": {
         "name": "Swimming safe"
+      },
+      "inventory_low_stock": {
+        "name": "{product_name} low stock"
       }
     },
     "event": {
@@ -858,6 +864,94 @@
         "step": {
           "name": "Step",
           "description": "The activation step to confirm as completed."
+        }
+      }
+    },
+    "inventory_add_product": {
+      "name": "Add inventory product",
+      "description": "Register a product in the pool's inventory catalog.",
+      "fields": {
+        "entry_id": {
+          "name": "Config entry",
+          "description": "The Pool Manager config entry that owns the inventory."
+        },
+        "product_id": {
+          "name": "Product ID",
+          "description": "Stable identifier used to reference this product."
+        },
+        "name": {
+          "name": "Display name",
+          "description": "Human-readable label for the product."
+        },
+        "unit": {
+          "name": "Unit",
+          "description": "Unit used to express the product quantity."
+        },
+        "chemical": {
+          "name": "Chemical kind",
+          "description": "Optional tag mapping this product to a known chemical kind."
+        },
+        "initial_quantity": {
+          "name": "Initial quantity",
+          "description": "Optional initial stock to seed the product with."
+        },
+        "low_stock_threshold": {
+          "name": "Low-stock threshold",
+          "description": "Optional threshold; the low-stock binary sensor turns on when quantity falls at or below this value."
+        }
+      }
+    },
+    "inventory_remove_product": {
+      "name": "Remove inventory product",
+      "description": "Remove a product (and its stock) from the inventory catalog.",
+      "fields": {
+        "entry_id": {
+          "name": "Config entry",
+          "description": "The Pool Manager config entry that owns the inventory."
+        },
+        "product_id": {
+          "name": "Product ID",
+          "description": "Identifier of the product to remove."
+        }
+      }
+    },
+    "inventory_add_stock": {
+      "name": "Add inventory stock",
+      "description": "Add stock to an existing inventory product.",
+      "fields": {
+        "entry_id": {
+          "name": "Config entry",
+          "description": "The Pool Manager config entry that owns the inventory."
+        },
+        "product_id": {
+          "name": "Product ID",
+          "description": "Identifier of the product to credit."
+        },
+        "quantity": {
+          "name": "Quantity",
+          "description": "Amount to add, in the product's unit."
+        }
+      }
+    },
+    "inventory_set_stock": {
+      "name": "Set inventory stock",
+      "description": "Set the absolute stock (and optionally the low-stock threshold) of a product.",
+      "fields": {
+        "entry_id": {
+          "name": "Config entry",
+          "description": "The Pool Manager config entry that owns the inventory."
+        },
+        "product_id": {
+          "name": "Product ID",
+          "description": "Identifier of the product to update."
+        },
+        "quantity": {
+          "name": "Quantity",
+          "description": "New absolute quantity, in the product's unit."
+        },
+        "low_stock_threshold": {
+          "name": "Low-stock threshold",
+          "description": "Optional new threshold value."
         }
       }
     }

--- a/custom_components/poolman/translations/fr.json
+++ b/custom_components/poolman/translations/fr.json
@@ -342,6 +342,9 @@
           "shock_treatment": "Traitement choc",
           "intensive_filtration": "Filtration intensive"
         }
+      },
+      "inventory_product": {
+        "name": "Stock {product_name}"
       }
     },
     "binary_sensor": {
@@ -353,6 +356,9 @@
       },
       "swimming_safe": {
         "name": "Baignade s\u00fbre"
+      },
+      "inventory_low_stock": {
+        "name": "Stock {product_name} bas"
       }
     },
     "event": {
@@ -858,6 +864,94 @@
         "step": {
           "name": "\u00c9tape",
           "description": "L'\u00e9tape de remise en route \u00e0 confirmer."
+        }
+      }
+    },
+    "inventory_add_product": {
+      "name": "Ajouter un produit \u00e0 l'inventaire",
+      "description": "Enregistre un produit dans le catalogue d'inventaire de la piscine.",
+      "fields": {
+        "entry_id": {
+          "name": "Configuration",
+          "description": "La configuration Pool Manager qui poss\u00e8de l'inventaire."
+        },
+        "product_id": {
+          "name": "Identifiant produit",
+          "description": "Identifiant stable utilis\u00e9 pour r\u00e9f\u00e9rencer ce produit."
+        },
+        "name": {
+          "name": "Nom affich\u00e9",
+          "description": "Libell\u00e9 lisible pour le produit."
+        },
+        "unit": {
+          "name": "Unit\u00e9",
+          "description": "Unit\u00e9 utilis\u00e9e pour exprimer la quantit\u00e9 du produit."
+        },
+        "chemical": {
+          "name": "Type chimique",
+          "description": "\u00c9tiquette optionnelle associant ce produit \u00e0 un type chimique connu."
+        },
+        "initial_quantity": {
+          "name": "Quantit\u00e9 initiale",
+          "description": "Stock initial optionnel pour initialiser le produit."
+        },
+        "low_stock_threshold": {
+          "name": "Seuil de stock bas",
+          "description": "Seuil optionnel ; le capteur binaire de stock bas s'active quand la quantit\u00e9 descend au-dessous ou \u00e9gal \u00e0 cette valeur."
+        }
+      }
+    },
+    "inventory_remove_product": {
+      "name": "Retirer un produit de l'inventaire",
+      "description": "Retire un produit (et son stock) du catalogue d'inventaire.",
+      "fields": {
+        "entry_id": {
+          "name": "Configuration",
+          "description": "La configuration Pool Manager qui poss\u00e8de l'inventaire."
+        },
+        "product_id": {
+          "name": "Identifiant produit",
+          "description": "Identifiant du produit \u00e0 retirer."
+        }
+      }
+    },
+    "inventory_add_stock": {
+      "name": "Ajouter du stock",
+      "description": "Ajoute du stock \u00e0 un produit existant de l'inventaire.",
+      "fields": {
+        "entry_id": {
+          "name": "Configuration",
+          "description": "La configuration Pool Manager qui poss\u00e8de l'inventaire."
+        },
+        "product_id": {
+          "name": "Identifiant produit",
+          "description": "Identifiant du produit \u00e0 cr\u00e9diter."
+        },
+        "quantity": {
+          "name": "Quantit\u00e9",
+          "description": "Quantit\u00e9 \u00e0 ajouter, dans l'unit\u00e9 du produit."
+        }
+      }
+    },
+    "inventory_set_stock": {
+      "name": "D\u00e9finir le stock",
+      "description": "D\u00e9finit le stock absolu (et optionnellement le seuil de stock bas) d'un produit.",
+      "fields": {
+        "entry_id": {
+          "name": "Configuration",
+          "description": "La configuration Pool Manager qui poss\u00e8de l'inventaire."
+        },
+        "product_id": {
+          "name": "Identifiant produit",
+          "description": "Identifiant du produit \u00e0 mettre \u00e0 jour."
+        },
+        "quantity": {
+          "name": "Quantit\u00e9",
+          "description": "Nouvelle quantit\u00e9 absolue, dans l'unit\u00e9 du produit."
+        },
+        "low_stock_threshold": {
+          "name": "Seuil de stock bas",
+          "description": "Nouvelle valeur de seuil optionnelle."
         }
       }
     }

--- a/demo/setup.py
+++ b/demo/setup.py
@@ -553,6 +553,63 @@ def seed_dashboards(token: str, yaml_dir: str = "/demo/dashboards") -> None:
 
 
 # ---------------------------------------------------------------------------
+# Inventory seeding
+# ---------------------------------------------------------------------------
+
+# Sample products to seed in the Pool Manager inventory.  Each entry is
+# fed verbatim to the ``poolman.inventory_add_product`` service.  Tweak
+# the demo by editing this list -- duplicates are silently overwritten.
+DEMO_INVENTORY_PRODUCTS: list[dict] = [
+    {
+        "product_id": "demo_ph_minus_1_5kg",
+        "name": "Demo pH Minus 1.5kg",
+        "unit": "g",
+        "chemical": "ph_minus",
+        "initial_quantity": 1500,
+        "low_stock_threshold": 300,
+    },
+    {
+        "product_id": "demo_chlore_choc_400g",
+        "name": "Demo Chlore Choc 400g",
+        "unit": "g",
+        "chemical": "chlore_choc",
+        "initial_quantity": 200,
+        "low_stock_threshold": 250,
+    },
+]
+
+
+def seed_inventory(token: str) -> None:
+    """Seed sample inventory products on the Pool Manager entry.
+
+    Looks up the active ``poolman`` config entry and calls
+    ``poolman.inventory_add_product`` for each entry in
+    :data:`DEMO_INVENTORY_PRODUCTS`. The service is idempotent: calling
+    it again on a known ``product_id`` updates the existing record.
+    """
+    entries = get_config_entries(token)
+    poolman_entry = next((e for e in entries if e["domain"] == "poolman"), None)
+    if poolman_entry is None:
+        log.warning("Pool Manager entry not found, skipping inventory seeding.")
+        return
+
+    entry_id = poolman_entry["entry_id"]
+    log.info("Seeding inventory products on entry %s...", entry_id)
+    for product in DEMO_INVENTORY_PRODUCTS:
+        try:
+            post(
+                f"{HA_URL}/api/services/poolman/inventory_add_product",
+                token=token,
+                json_data={"entry_id": entry_id, **product},
+            )
+            log.info(
+                "  + %s (%s %s)", product["name"], product["initial_quantity"], product["unit"]
+            )
+        except niquests.RequestException as exc:
+            log.warning("Failed to add product %s: %s", product["product_id"], exc)
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -616,6 +673,10 @@ def main() -> None:
                 },
             ],
         )
+
+    # Seed a couple of inventory products so the demo shows stock sensors
+    # and the low-stock binary sensor in action.
+    seed_inventory(token)
 
     # Create storage-mode dashboards (editable from the HA UI)
     log.info("Seeding dashboards...")

--- a/docs/chemistry-tracking.md
+++ b/docs/chemistry-tracking.md
@@ -144,3 +144,11 @@ tap_action:
     product: chlore_choc
     quantity_g: 500
 ```
+
+## Related: Inventory
+
+Treatment recording is currently independent from your product stock.
+The [Inventory](inventory.md) feature lets you track how much of each
+product you have on hand and get warnings when stock is low.
+Automatic stock decrement when a treatment is recorded is tracked in
+issue #94.

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,6 +60,7 @@ All computations happen locally. No cloud API, no account, no internet connectio
 - [Getting Started](getting-started.md) -- Prerequisites, installation, and configuration
 - [Entities](entities.md) -- Sensors, binary sensors, event entities, select, and filtration control entities
 - [Chemistry Tracking](chemistry-tracking.md) -- Treatment recording, safety profiles, and swimming safety
+- [Inventory](inventory.md) -- Track chemical product stock with low-stock warnings
 - [Filtration Control](filtration-control.md) -- Automatic pump scheduling, events, and automation examples
 - [Pool Modes](pool-modes.md) -- Running, Active Wintering, and Passive Wintering explained
 - [Water Chemistry](water-chemistry.md) -- Target ranges, scoring, and parameter details

--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -1,0 +1,158 @@
+---
+icon: lucide/package
+---
+
+# Inventory
+
+Pool Manager can track the stock of chemical products you keep on hand,
+so it can warn you when a product is running low and (in the future)
+automatically decrement your stock as you record treatments.
+
+The inventory is **per pool** (per Home Assistant config entry) and is
+persisted to local storage, so it survives Home Assistant restarts.
+
+## Concepts
+
+- **Product** -- a user-configured entry representing an actual branded
+  item you purchased (e.g. *Brand X pH Minus 1.5kg*). A product is
+  identified by a stable `product_id`, has a display name, a unit, and
+  an optional `chemical` tag mapping it to a known
+  [chemical product kind](rules-and-recommendations.md).
+- **Stock** -- the current quantity available for a product, expressed
+  in the product's unit.
+- **Low-stock threshold** -- an optional value per product; when the
+  stock drops at or below it, a dedicated binary sensor turns on.
+
+The inventory is decoupled from the analysis pipeline: rules and
+recommendations cannot mutate it. Only Home Assistant services
+(documented below) and -- in a future release -- recording an action
+will change stock.
+
+## Supported units
+
+The following unit strings are accepted by the services and exposed as
+Home Assistant-compatible units on the stock sensors:
+
+| Unit string | Sensor unit            | Device class      |
+| ----------- | ---------------------- | ----------------- |
+| `g`         | grams                  | `weight`          |
+| `kg`        | kilograms              | `weight`          |
+| `mL`        | milliliters            | `volume_storage`  |
+| `L`         | liters                 | `volume_storage`  |
+| `tablet`    | none (raw count)       | none              |
+
+The product unit must match the unit used by any treatment that consumes
+it. Mismatched units are logged as an error and the stock is left
+unchanged.
+
+## Entities
+
+For every configured product, Pool Manager creates:
+
+- **`sensor.<pool>_<product_name>`** -- current stock as a measurement.
+  Extra state attributes include `product_id`, `product_name`, `unit`,
+  `chemical`, `low_stock_threshold`, and `is_low`.
+- **`binary_sensor.<pool>_<product_name>_low_stock`** -- `on` when the
+  stock has dropped at or below the configured threshold, `off`
+  otherwise. Device class `problem`. When no threshold is set the
+  binary sensor stays `off`.
+
+Both entities are created dynamically whenever a product is added, and
+become unavailable when the product is removed from the catalog.
+
+## Services
+
+All inventory services target a specific Pool Manager config entry by
+its `entry_id`. Use the **Configuration entry** selector in the UI to
+pick one.
+
+### `poolman.inventory_add_product`
+
+Register a new product, optionally seeding it with stock and a
+low-stock threshold.
+
+```yaml
+service: poolman.inventory_add_product
+data:
+  entry_id: <pool config entry id>
+  product_id: brand_x_ph_minus_1_5kg
+  name: Brand X pH Minus 1.5kg
+  unit: g
+  chemical: ph_minus       # optional tag, must be a ChemicalProduct value
+  initial_quantity: 1500   # optional
+  low_stock_threshold: 300 # optional
+```
+
+### `poolman.inventory_remove_product`
+
+Remove a product and drop its stock entry.
+
+```yaml
+service: poolman.inventory_remove_product
+data:
+  entry_id: <pool config entry id>
+  product_id: brand_x_ph_minus_1_5kg
+```
+
+### `poolman.inventory_add_stock`
+
+Credit the current stock of a product.
+
+```yaml
+service: poolman.inventory_add_stock
+data:
+  entry_id: <pool config entry id>
+  product_id: brand_x_ph_minus_1_5kg
+  quantity: 500
+```
+
+### `poolman.inventory_set_stock`
+
+Set the absolute current stock (e.g. after a manual inventory count).
+Optionally also updates the low-stock threshold.
+
+```yaml
+service: poolman.inventory_set_stock
+data:
+  entry_id: <pool config entry id>
+  product_id: brand_x_ph_minus_1_5kg
+  quantity: 1200
+  low_stock_threshold: 250   # optional
+```
+
+## Persistence
+
+The inventory is persisted to Home Assistant's local storage as
+`.storage/poolman.inventory.<entry_id>`. The payload is JSON and looks
+like:
+
+```json
+{
+  "products": [
+    {
+      "id": "brand_x_ph_minus_1_5kg",
+      "name": "Brand X pH Minus 1.5kg",
+      "unit": "g",
+      "chemical": "ph_minus"
+    }
+  ],
+  "items": [
+    {
+      "product_id": "brand_x_ph_minus_1_5kg",
+      "quantity": 1200.0,
+      "low_stock_threshold": 250.0
+    }
+  ]
+}
+```
+
+A corrupted or partial payload is logged and replaced with an empty
+inventory at startup; it never blocks integration setup.
+
+## Roadmap
+
+- **Automatic decrement on treatment recording** (issue #94) -- recording
+  an action with a `product_id` will consume the corresponding stock,
+  using the product's unit for safety.
+- **Config-flow editor** for products (currently services-only).
+- **External inventory integration** with Vesta (issue #93).

--- a/tests/domain/test_inventory.py
+++ b/tests/domain/test_inventory.py
@@ -1,0 +1,272 @@
+"""Tests for the inventory domain module."""
+
+from __future__ import annotations
+
+import logging
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from custom_components.poolman.domain.inventory import Inventory, InventoryItem, Product
+from custom_components.poolman.domain.model import ChemicalProduct
+
+
+def _item(inventory: Inventory, product_id: str) -> InventoryItem:
+    """Return the stored ``InventoryItem`` or fail the test if missing."""
+    item = inventory.get(product_id)
+    assert item is not None, f"Inventory item {product_id!r} not found"
+    return item
+
+
+class TestProduct:
+    """Tests for the Product frozen dataclass."""
+
+    def test_creation_minimal(self) -> None:
+        product = Product(id="ph_minus", name="pH Minus", unit="g")
+        assert product.id == "ph_minus"
+        assert product.name == "pH Minus"
+        assert product.unit == "g"
+        assert product.chemical is None
+
+    def test_creation_with_chemical_tag(self) -> None:
+        product = Product(
+            id="brand_x_ph_minus",
+            name="Brand X pH Minus 1.5kg",
+            unit="g",
+            chemical=ChemicalProduct.PH_MINUS,
+        )
+        assert product.chemical is ChemicalProduct.PH_MINUS
+
+    def test_frozen(self) -> None:
+        product = Product(id="x", name="X", unit="g")
+        with pytest.raises(FrozenInstanceError):
+            # ``setattr`` keeps the type-checker quiet while still
+            # exercising the runtime FrozenInstanceError guard.
+            setattr(product, "name", "Y")  # noqa: B010
+
+    def test_equality(self) -> None:
+        a = Product(id="x", name="X", unit="g")
+        b = Product(id="x", name="X", unit="g")
+        assert a == b
+
+
+class TestInventoryItem:
+    """Tests for the InventoryItem dataclass."""
+
+    def test_defaults(self) -> None:
+        item = InventoryItem(product_id="x", quantity=10.0)
+        assert item.low_stock_threshold is None
+
+    def test_mutable_quantity(self) -> None:
+        item = InventoryItem(product_id="x", quantity=10.0)
+        item.quantity = 5.0
+        assert item.quantity == 5.0
+
+
+class TestInventoryCatalog:
+    """Tests for catalog mutations on Inventory."""
+
+    def _product(self) -> Product:
+        return Product(id="ph_minus", name="pH Minus", unit="g")
+
+    def test_add_product(self) -> None:
+        inventory = Inventory()
+        product = self._product()
+        inventory.add_product(product)
+        assert inventory.products == {"ph_minus": product}
+
+    def test_remove_product_drops_item(self) -> None:
+        inventory = Inventory()
+        inventory.add_product(self._product())
+        inventory.add_stock("ph_minus", 100.0)
+        inventory.remove_product("ph_minus")
+        assert inventory.products == {}
+        assert inventory.items == {}
+
+    def test_remove_unknown_is_noop(self) -> None:
+        inventory = Inventory()
+        inventory.remove_product("nope")  # no error
+
+
+class TestInventoryStock:
+    """Tests for stock mutation and queries."""
+
+    def _inventory(self, *, threshold: float | None = None) -> Inventory:
+        inventory = Inventory()
+        inventory.add_product(Product(id="ph_minus", name="pH Minus", unit="g"))
+        if threshold is not None:
+            inventory.set_stock("ph_minus", 0.0, low_stock_threshold=threshold)
+        return inventory
+
+    def test_get_unknown_returns_none(self) -> None:
+        inventory = self._inventory()
+        assert inventory.get("nope") is None
+
+    def test_add_stock_creates_item(self) -> None:
+        inventory = self._inventory()
+        inventory.add_stock("ph_minus", 100.0)
+        item = inventory.get("ph_minus")
+        assert item is not None
+        assert item.quantity == 100.0
+
+    def test_add_stock_accumulates(self) -> None:
+        inventory = self._inventory()
+        inventory.add_stock("ph_minus", 100.0)
+        inventory.add_stock("ph_minus", 50.0)
+        assert _item(inventory, "ph_minus").quantity == 150.0
+
+    def test_add_stock_unknown_product_raises(self) -> None:
+        inventory = Inventory()
+        with pytest.raises(KeyError):
+            inventory.add_stock("nope", 10.0)
+
+    def test_set_stock_unknown_product_raises(self) -> None:
+        inventory = Inventory()
+        with pytest.raises(KeyError):
+            inventory.set_stock("nope", 10.0)
+
+    def test_set_stock_overrides_quantity(self) -> None:
+        inventory = self._inventory()
+        inventory.add_stock("ph_minus", 100.0)
+        inventory.set_stock("ph_minus", 42.0)
+        assert _item(inventory, "ph_minus").quantity == 42.0
+
+    def test_set_stock_updates_threshold(self) -> None:
+        inventory = self._inventory(threshold=10.0)
+        inventory.set_stock("ph_minus", 50.0, low_stock_threshold=25.0)
+        assert _item(inventory, "ph_minus").low_stock_threshold == 25.0
+
+    def test_consume_decrements(self) -> None:
+        inventory = self._inventory()
+        inventory.add_stock("ph_minus", 100.0)
+        inventory.consume("ph_minus", 30.0)
+        assert _item(inventory, "ph_minus").quantity == 70.0
+
+    def test_consume_unknown_product_logs_and_skips(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        inventory = self._inventory()
+        with caplog.at_level(logging.WARNING):
+            inventory.consume("unknown", 10.0)
+        assert any("Unknown product" in r.message for r in caplog.records)
+        assert inventory.get("unknown") is None
+
+    def test_consume_unit_mismatch_logs_and_skips(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        inventory = self._inventory()
+        inventory.add_stock("ph_minus", 100.0)
+        with caplog.at_level(logging.ERROR):
+            inventory.consume("ph_minus", 50.0, unit="mL")
+        assert any("Unit mismatch" in r.message for r in caplog.records)
+        assert _item(inventory, "ph_minus").quantity == 100.0
+
+    def test_consume_unit_match_decrements(self) -> None:
+        inventory = self._inventory()
+        inventory.add_stock("ph_minus", 100.0)
+        inventory.consume("ph_minus", 30.0, unit="g")
+        assert _item(inventory, "ph_minus").quantity == 70.0
+
+    def test_consume_below_zero_logs_warning(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        inventory = self._inventory()
+        inventory.add_stock("ph_minus", 10.0)
+        with caplog.at_level(logging.WARNING):
+            inventory.consume("ph_minus", 50.0)
+        assert any("Negative stock" in r.message for r in caplog.records)
+        assert _item(inventory, "ph_minus").quantity == -40.0
+
+
+class TestIsLow:
+    """Tests for the is_low predicate."""
+
+    def _inventory(self) -> Inventory:
+        inventory = Inventory()
+        inventory.add_product(Product(id="ph_minus", name="pH Minus", unit="g"))
+        return inventory
+
+    def test_unknown_product_returns_false(self) -> None:
+        assert Inventory().is_low("nope") is False
+
+    def test_no_threshold_returns_false(self) -> None:
+        inventory = self._inventory()
+        inventory.add_stock("ph_minus", 100.0)
+        assert inventory.is_low("ph_minus") is False
+
+    def test_above_threshold_returns_false(self) -> None:
+        inventory = self._inventory()
+        inventory.set_stock("ph_minus", 100.0, low_stock_threshold=50.0)
+        assert inventory.is_low("ph_minus") is False
+
+    def test_at_or_below_threshold_returns_true(self) -> None:
+        inventory = self._inventory()
+        inventory.set_stock("ph_minus", 50.0, low_stock_threshold=50.0)
+        assert inventory.is_low("ph_minus") is True
+        inventory.set_stock("ph_minus", 25.0)
+        assert inventory.is_low("ph_minus") is True
+
+
+class TestSerialization:
+    """Tests for round-trip JSON serialization via to_dict / from_dict."""
+
+    def test_round_trip_minimal(self) -> None:
+        inventory = Inventory()
+        inventory.add_product(Product(id="ph_minus", name="pH Minus", unit="g"))
+        inventory.add_stock("ph_minus", 1500.0)
+        rebuilt = Inventory.from_dict(inventory.to_dict())
+        assert rebuilt.products == inventory.products
+        assert rebuilt.items["ph_minus"].quantity == 1500.0
+
+    def test_round_trip_with_chemical_and_threshold(self) -> None:
+        inventory = Inventory()
+        inventory.add_product(
+            Product(
+                id="brand_x_ph_minus",
+                name="Brand X pH Minus 1.5kg",
+                unit="g",
+                chemical=ChemicalProduct.PH_MINUS,
+            )
+        )
+        inventory.set_stock("brand_x_ph_minus", 1500.0, low_stock_threshold=300.0)
+        rebuilt = Inventory.from_dict(inventory.to_dict())
+        product = rebuilt.products["brand_x_ph_minus"]
+        assert product.chemical is ChemicalProduct.PH_MINUS
+        assert rebuilt.items["brand_x_ph_minus"].low_stock_threshold == 300.0
+
+    def test_from_dict_drops_unknown_chemical_tag(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        data = {
+            "products": [
+                {"id": "x", "name": "X", "unit": "g", "chemical": "not_a_real_product"},
+            ],
+            "items": [],
+        }
+        with caplog.at_level(logging.WARNING):
+            rebuilt = Inventory.from_dict(data)
+        assert rebuilt.products["x"].chemical is None
+        assert any("unknown chemical tag" in r.message for r in caplog.records)
+
+    def test_from_dict_drops_dangling_items(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        data = {
+            "products": [],
+            "items": [{"product_id": "ghost", "quantity": 1.0, "low_stock_threshold": None}],
+        }
+        with caplog.at_level(logging.WARNING):
+            rebuilt = Inventory.from_dict(data)
+        assert rebuilt.items == {}
+        assert any("unknown product" in r.message for r in caplog.records)
+
+    def test_from_dict_empty(self) -> None:
+        rebuilt = Inventory.from_dict({})
+        assert rebuilt.products == {}
+        assert rebuilt.items == {}

--- a/tests/test_inventory_services.py
+++ b/tests/test_inventory_services.py
@@ -1,0 +1,388 @@
+"""Tests for inventory HA services and dynamic entity discovery."""
+
+from __future__ import annotations
+
+import pytest
+
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.poolman.const import (
+    DOMAIN,
+    SERVICE_INVENTORY_ADD_PRODUCT,
+    SERVICE_INVENTORY_ADD_STOCK,
+    SERVICE_INVENTORY_REMOVE_PRODUCT,
+    SERVICE_INVENTORY_SET_STOCK,
+)
+from custom_components.poolman.coordinator import PoolmanCoordinator
+from custom_components.poolman.domain.model import ChemicalProduct
+from tests.conftest import setup_mock_states
+
+
+@pytest.fixture
+async def setup_entry(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> PoolmanCoordinator:
+    """Set up the integration and return the coordinator."""
+    mock_config_entry.add_to_hass(hass)
+    setup_mock_states(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    return mock_config_entry.runtime_data
+
+
+class TestInventoryServices:
+    """Tests for inventory service handlers."""
+
+    async def test_services_are_registered(
+        self,
+        hass: HomeAssistant,
+        setup_entry: PoolmanCoordinator,
+    ) -> None:
+        assert hass.services.has_service(DOMAIN, SERVICE_INVENTORY_ADD_PRODUCT)
+        assert hass.services.has_service(DOMAIN, SERVICE_INVENTORY_REMOVE_PRODUCT)
+        assert hass.services.has_service(DOMAIN, SERVICE_INVENTORY_ADD_STOCK)
+        assert hass.services.has_service(DOMAIN, SERVICE_INVENTORY_SET_STOCK)
+
+    async def test_add_product_with_initial_stock_and_threshold(
+        self,
+        hass: HomeAssistant,
+        setup_entry: PoolmanCoordinator,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_INVENTORY_ADD_PRODUCT,
+            {
+                "entry_id": mock_config_entry.entry_id,
+                "product_id": "brand_x_ph_minus",
+                "name": "Brand X pH Minus 1.5kg",
+                "unit": "g",
+                "chemical": "ph_minus",
+                "initial_quantity": 1500.0,
+                "low_stock_threshold": 300.0,
+            },
+            blocking=True,
+        )
+
+        product = setup_entry.inventory.products["brand_x_ph_minus"]
+        assert product.chemical is ChemicalProduct.PH_MINUS
+        item = setup_entry.inventory.get("brand_x_ph_minus")
+        assert item is not None
+        assert item.quantity == 1500.0
+        assert item.low_stock_threshold == 300.0
+
+        # Quantity sensor was created dynamically.
+        state = hass.states.get("sensor.test_pool_brand_x_ph_minus_1_5kg")
+        assert state is not None
+        assert float(state.state) == 1500.0
+        assert state.attributes["is_low"] is False
+
+        binary_state = hass.states.get("binary_sensor.test_pool_brand_x_ph_minus_1_5kg_low_stock")
+        assert binary_state is not None
+        assert binary_state.state == "off"
+
+    async def test_add_stock_then_set_stock(
+        self,
+        hass: HomeAssistant,
+        setup_entry: PoolmanCoordinator,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_INVENTORY_ADD_PRODUCT,
+            {
+                "entry_id": mock_config_entry.entry_id,
+                "product_id": "ph_minus",
+                "name": "pH Minus",
+                "unit": "g",
+            },
+            blocking=True,
+        )
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_INVENTORY_ADD_STOCK,
+            {
+                "entry_id": mock_config_entry.entry_id,
+                "product_id": "ph_minus",
+                "quantity": 500.0,
+            },
+            blocking=True,
+        )
+        item = setup_entry.inventory.get("ph_minus")
+        assert item is not None
+        assert item.quantity == 500.0
+
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_INVENTORY_SET_STOCK,
+            {
+                "entry_id": mock_config_entry.entry_id,
+                "product_id": "ph_minus",
+                "quantity": 50.0,
+                "low_stock_threshold": 100.0,
+            },
+            blocking=True,
+        )
+        item = setup_entry.inventory.get("ph_minus")
+        assert item is not None
+        assert item.quantity == 50.0
+        assert item.low_stock_threshold == 100.0
+        assert setup_entry.inventory.is_low("ph_minus") is True
+
+        binary_state = hass.states.get("binary_sensor.test_pool_ph_minus_low_stock")
+        assert binary_state is not None
+        assert binary_state.state == "on"
+
+    async def test_add_stock_unknown_product_raises_validation_error(
+        self,
+        hass: HomeAssistant,
+        setup_entry: PoolmanCoordinator,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        with pytest.raises(ServiceValidationError):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_INVENTORY_ADD_STOCK,
+                {
+                    "entry_id": mock_config_entry.entry_id,
+                    "product_id": "ghost",
+                    "quantity": 1.0,
+                },
+                blocking=True,
+            )
+
+    async def test_remove_product_clears_stock(
+        self,
+        hass: HomeAssistant,
+        setup_entry: PoolmanCoordinator,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_INVENTORY_ADD_PRODUCT,
+            {
+                "entry_id": mock_config_entry.entry_id,
+                "product_id": "ph_minus",
+                "name": "pH Minus",
+                "unit": "g",
+                "initial_quantity": 500.0,
+            },
+            blocking=True,
+        )
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_INVENTORY_REMOVE_PRODUCT,
+            {
+                "entry_id": mock_config_entry.entry_id,
+                "product_id": "ph_minus",
+            },
+            blocking=True,
+        )
+        assert "ph_minus" not in setup_entry.inventory.products
+        assert setup_entry.inventory.get("ph_minus") is None
+
+    async def test_unknown_entry_id_raises_validation_error(
+        self,
+        hass: HomeAssistant,
+        setup_entry: PoolmanCoordinator,
+    ) -> None:
+        with pytest.raises(ServiceValidationError):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_INVENTORY_REMOVE_PRODUCT,
+                {"entry_id": "not_a_real_entry", "product_id": "x"},
+                blocking=True,
+            )
+
+    async def test_set_stock_unknown_product_raises_validation_error(
+        self,
+        hass: HomeAssistant,
+        setup_entry: PoolmanCoordinator,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        with pytest.raises(ServiceValidationError):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_INVENTORY_SET_STOCK,
+                {
+                    "entry_id": mock_config_entry.entry_id,
+                    "product_id": "ghost",
+                    "quantity": 1.0,
+                },
+                blocking=True,
+            )
+
+
+class TestCoordinatorInventoryAPI:
+    """Direct tests for the coordinator's inventory helpers."""
+
+    async def test_consume_decrements_persisted_stock(
+        self,
+        setup_entry: PoolmanCoordinator,
+    ) -> None:
+        from custom_components.poolman.domain.inventory import Product
+
+        await setup_entry.async_inventory_add_product(
+            Product(id="ph_minus", name="pH Minus", unit="g"),
+            initial_quantity=100.0,
+        )
+        await setup_entry.async_inventory_consume("ph_minus", 30.0, unit="g")
+        item = setup_entry.inventory.get("ph_minus")
+        assert item is not None
+        assert item.quantity == 70.0
+
+    async def test_inventory_listener_exception_is_swallowed(
+        self,
+        setup_entry: PoolmanCoordinator,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        from custom_components.poolman.domain.inventory import Product
+
+        def _boom(_added: set[str], _removed: set[str]) -> None:
+            raise RuntimeError("listener exploded")
+
+        unsubscribe = setup_entry.on_inventory_change(_boom)
+        try:
+            with caplog.at_level("ERROR"):
+                await setup_entry.async_inventory_add_product(
+                    Product(id="ph_minus", name="pH Minus", unit="g"),
+                )
+        finally:
+            unsubscribe()
+
+        assert any("Inventory listener raised" in r.message for r in caplog.records)
+
+    async def test_inventory_entities_seeded_from_storage(
+        self,
+        hass: HomeAssistant,
+        hass_storage: dict[str, dict],
+    ) -> None:
+        """Entities are created from inventory persisted before setup."""
+        from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+        from tests.conftest import MOCK_CONFIG_DATA, setup_mock_states
+
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data=MOCK_CONFIG_DATA,
+            entry_id="seeded_entry",
+            title="Seeded Pool",
+        )
+        entry.add_to_hass(hass)
+        # Pre-populate storage with one product BEFORE setup so that
+        # initial entity discovery (sync path in async_setup_entry) runs.
+        hass_storage[f"poolman.inventory.{entry.entry_id}"] = {
+            "version": 1,
+            "key": f"poolman.inventory.{entry.entry_id}",
+            "data": {
+                "products": [
+                    {"id": "ph_minus", "name": "pH Minus", "unit": "g"},
+                ],
+                "items": [
+                    {
+                        "product_id": "ph_minus",
+                        "quantity": 200.0,
+                        "low_stock_threshold": 100.0,
+                    }
+                ],
+            },
+        }
+        setup_mock_states(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        # Both entities were created without a service call.
+        sensor_state = hass.states.get("sensor.seeded_pool_ph_minus")
+        assert sensor_state is not None
+        assert float(sensor_state.state) == 200.0
+
+        binary_state = hass.states.get("binary_sensor.seeded_pool_ph_minus_low_stock")
+        assert binary_state is not None
+        assert binary_state.state == "off"
+
+    async def test_inventory_entities_when_product_removed(
+        self,
+        hass: HomeAssistant,
+        setup_entry: PoolmanCoordinator,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Stock entities return None/empty attrs once product is gone."""
+        from custom_components.poolman.binary_sensor import PoolmanLowStockBinarySensor
+        from custom_components.poolman.domain.inventory import Product
+        from custom_components.poolman.sensor import PoolmanInventorySensor
+
+        product = Product(id="ph_minus", name="pH Minus", unit="g")
+        await setup_entry.async_inventory_add_product(product, initial_quantity=50.0)
+
+        sensor = PoolmanInventorySensor(setup_entry, product)
+        binary = PoolmanLowStockBinarySensor(setup_entry, product)
+        assert sensor.native_value == 50.0
+        assert sensor.extra_state_attributes["product_id"] == "ph_minus"
+        assert binary.is_on is False
+        assert binary.extra_state_attributes["product_id"] == "ph_minus"
+
+        await setup_entry.async_inventory_remove_product("ph_minus")
+
+        # After removal, the underlying entity helpers gracefully degrade.
+        assert sensor.native_value is None
+        assert sensor.extra_state_attributes == {}
+        assert binary.is_on is False
+        assert binary.extra_state_attributes == {}
+
+    async def test_add_product_idempotent_ignores_duplicate_listener_call(
+        self,
+        hass: HomeAssistant,
+        setup_entry: PoolmanCoordinator,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Re-adding a known product does not create a duplicate entity."""
+        for _ in range(2):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_INVENTORY_ADD_PRODUCT,
+                {
+                    "entry_id": mock_config_entry.entry_id,
+                    "product_id": "ph_minus",
+                    "name": "pH Minus",
+                    "unit": "g",
+                    "initial_quantity": 100.0,
+                },
+                blocking=True,
+            )
+        # Exactly one entity each.
+        matches = [s for s in hass.states.async_all() if s.entity_id == "sensor.test_pool_ph_minus"]
+        assert len(matches) == 1
+
+    async def test_listener_notified_with_unknown_id_is_ignored(
+        self,
+        hass: HomeAssistant,
+        setup_entry: PoolmanCoordinator,
+    ) -> None:
+        """A spurious listener notification for a missing product is a no-op."""
+        before = len(hass.states.async_all())
+        # Directly notify listeners with an id absent from the catalog;
+        # the platform callbacks should skip it without creating entities
+        # or raising.
+        setup_entry._notify_inventory_listeners({"phantom_id"}, set())
+        await hass.async_block_till_done()
+        assert len(hass.states.async_all()) == before
+        assert hass.states.get("sensor.test_pool_phantom_id") is None
+        assert hass.states.get("binary_sensor.test_pool_phantom_id_low_stock") is None
+
+    async def test_tablet_unit_has_no_device_class(
+        self,
+        setup_entry: PoolmanCoordinator,
+    ) -> None:
+        """Tablet products carry no Home Assistant device_class."""
+        from custom_components.poolman.domain.inventory import Product
+        from custom_components.poolman.sensor import PoolmanInventorySensor
+
+        product = Product(id="tabs", name="Multi Tabs", unit="tablet")
+        await setup_entry.async_inventory_add_product(product, initial_quantity=10.0)
+        sensor = PoolmanInventorySensor(setup_entry, product)
+        # ``tablet`` intentionally maps to (None, None): a raw count
+        # without a Home Assistant unit-of-measurement or device class.
+        assert sensor._attr_native_unit_of_measurement is None
+        assert getattr(sensor, "_attr_device_class", None) is None

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,65 @@
+"""Tests for inventory persistence via :class:`InventoryStore`."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from homeassistant.core import HomeAssistant
+
+from custom_components.poolman.domain.inventory import Inventory, Product
+from custom_components.poolman.domain.model import ChemicalProduct
+from custom_components.poolman.storage import InventoryStore
+
+
+async def test_load_returns_empty_when_no_data(hass: HomeAssistant) -> None:
+    store = InventoryStore(hass, "entry_empty")
+    inventory = await store.async_load()
+    assert isinstance(inventory, Inventory)
+    assert inventory.products == {}
+    assert inventory.items == {}
+
+
+async def test_save_then_load_round_trip(hass: HomeAssistant) -> None:
+    store = InventoryStore(hass, "entry_round_trip")
+    inventory = Inventory()
+    inventory.add_product(
+        Product(
+            id="brand_x_ph_minus",
+            name="Brand X pH Minus 1.5kg",
+            unit="g",
+            chemical=ChemicalProduct.PH_MINUS,
+        )
+    )
+    inventory.set_stock("brand_x_ph_minus", 1500.0, low_stock_threshold=300.0)
+
+    await store.async_save(inventory)
+
+    # Reload using a fresh store instance to bypass internal caching.
+    rebuilt_store = InventoryStore(hass, "entry_round_trip")
+    rebuilt = await rebuilt_store.async_load()
+    product = rebuilt.products["brand_x_ph_minus"]
+    assert product.chemical is ChemicalProduct.PH_MINUS
+    item = rebuilt.items["brand_x_ph_minus"]
+    assert item.quantity == 1500.0
+    assert item.low_stock_threshold == 300.0
+
+
+async def test_load_malformed_payload_returns_empty(
+    hass: HomeAssistant,
+    hass_storage: dict[str, dict],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Pre-populate the storage backing with a malformed payload.
+    hass_storage["poolman.inventory.entry_bad"] = {
+        "version": 1,
+        "key": "poolman.inventory.entry_bad",
+        "data": {"products": [{"id": "x"}]},  # missing required fields
+    }
+    store = InventoryStore(hass, "entry_bad")
+    with caplog.at_level(logging.WARNING):
+        inventory = await store.async_load()
+    assert isinstance(inventory, Inventory)
+    assert inventory.products == {}
+    assert any("Malformed inventory payload" in r.message for r in caplog.records)


### PR DESCRIPTION
Adds a per-pool inventory of chemical products with stock tracking and low-stock warnings, persisted locally via Home Assistant's storage helper.

Products are user-defined and can be tagged with a known `ChemicalProduct` kind. For every product the integration dynamically creates:

- a stock sensor (g / kg / mL / L / tablet), with an `is_low` attribute
- a `problem`-class binary sensor that turns on when stock drops at or below the configured threshold

The catalog and stock can be managed from automations or the UI through four new services. The inventory is decoupled from the analysis pipeline; only services mutate stock today (automatic decrement on recorded treatments is tracked separately in #94).

Documentation is added under `docs/inventory.md` with cross-links from the index and chemistry-tracking pages, and the dev demo seeds two sample products so the new entities are visible out of the box.

Closes #92