### PR TITLE
feat(actions): track and persist user-recorded pool actions

### DIFF
--- a/custom_components/poolman/coordinator.py
+++ b/custom_components/poolman/coordinator.py
@@ -10,6 +10,7 @@ from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfMass, UnitOfTime, UnitOfVolume
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
@@ -48,6 +49,7 @@ from .const import (
     EVENT_POOLMAN,
     SUBENTRY_ACTIVATION,
 )
+from .domain.action import Action, ActionLog
 from .domain.activation import SHOCK_PRODUCT_VALUES, ActivationChecklist, ActivationStep
 from .domain.analysis import AnalysisResult, analyze_pool
 from .domain.chemistry import (
@@ -78,7 +80,7 @@ from .domain.treatment import (
     compute_swimming_safe,
 )
 from .scheduler import FiltrationScheduler
-from .storage import InventoryStore
+from .storage import ActionStore, InventoryStore
 
 if TYPE_CHECKING:
     from .event import PoolmanMeasureEvent, PoolmanTreatmentEvent
@@ -86,6 +88,19 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 type PoolmanConfigEntry = ConfigEntry[PoolmanCoordinator]
+
+# Set of unit strings accepted by :meth:`PoolmanCoordinator.async_record_action`.
+#
+# The domain :class:`Action` model allows any string for forward compat,
+# but at recording time we enforce HA-compatible units (see #19).  The
+# allowlist combines mass/volume/time units from ``homeassistant.const``
+# with the integration-specific countable units used for tablet products.
+_VALID_ACTION_UNITS: frozenset[str] = frozenset(
+    {u.value for u in UnitOfMass}
+    | {u.value for u in UnitOfVolume}
+    | {u.value for u in UnitOfTime}
+    | {"tablet"}
+)
 
 # Mapping from MeasureParameter to the config key for the corresponding sensor entity
 _MEASURE_SENSOR_KEY: dict[MeasureParameter, str] = {
@@ -134,6 +149,12 @@ class PoolmanCoordinator(DataUpdateCoordinator[PoolState]):
         self.inventory: Inventory = Inventory()
         self._inventory_loaded = False
         self._inventory_listeners: list[Callable[[set[str], set[str]], None]] = []
+
+        # Action log persistence: loaded asynchronously on first refresh.
+        self._action_store = ActionStore(hass, config_entry.entry_id)
+        self.action_log: ActionLog = ActionLog()
+        self._action_log_loaded = False
+        self._action_listeners: list[Callable[[Action], None]] = []
 
         # Filtration scheduler: only created when a pump entity is configured
         pump_entity_id = self._get_config(CONF_PUMP_ENTITY)
@@ -608,6 +629,81 @@ class PoolmanCoordinator(DataUpdateCoordinator[PoolState]):
         self.inventory.consume(product_id, quantity, unit=unit)
         await self._async_persist_inventory()
 
+    # ------------------------------------------------------------------
+    # Action history helpers (issue #19)
+    # ------------------------------------------------------------------
+    def on_action_recorded(
+        self,
+        callback: Callable[[Action], None],
+    ) -> Callable[[], None]:
+        """Register a listener notified when a new action is recorded.
+
+        The listener receives the newly recorded :class:`Action` after it
+        has been appended to :attr:`action_log` and persisted to disk.
+
+        Returns:
+            A callable that removes the listener when invoked.
+        """
+        self._action_listeners.append(callback)
+
+        def _remove() -> None:
+            with contextlib.suppress(ValueError):
+                self._action_listeners.remove(callback)
+
+        return _remove
+
+    def _notify_action_listeners(self, action: Action) -> None:
+        for listener in list(self._action_listeners):
+            try:
+                listener(action)
+            except Exception:
+                _LOGGER.exception("Action listener raised")
+
+    async def _async_persist_actions(self, recorded: Action | None = None) -> None:
+        """Persist the action log and notify listeners + entities."""
+        await self._action_store.async_save(self.action_log)
+        if recorded is not None:
+            self._notify_action_listeners(recorded)
+        self.async_update_listeners()
+
+    async def async_record_action(self, action: Action) -> None:
+        """Record a user-executed action and persist it across restarts.
+
+        Validates that ``action.unit`` is a Home Assistant-compatible
+        unit (see :data:`_VALID_ACTION_UNITS`).  Append-only semantics
+        and the ``source``/``recommendation_id`` invariant are enforced
+        by :meth:`ActionLog.record`.
+
+        Inventory consumption is intentionally not triggered here; it is
+        tracked separately in #94.
+
+        Args:
+            action: The :class:`Action` to record.
+
+        Raises:
+            ValueError: If ``action.unit`` is not in the HA allowlist,
+                or if the action violates :class:`ActionLog` invariants
+                (duplicate id, missing ``recommendation_id``).
+        """
+        if action.unit not in _VALID_ACTION_UNITS:
+            raise ValueError(
+                f"Unit {action.unit!r} is not a Home Assistant-compatible unit",
+            )
+        self.action_log.record(action)
+        await self._async_persist_actions(recorded=action)
+
+    def get_action_history(self, limit: int = 50) -> list[Action]:
+        """Return the most recent actions, newest first (see :meth:`ActionLog.history`)."""
+        return self.action_log.history(limit)
+
+    def get_active_actions(self, now: datetime | None = None) -> list[Action]:
+        """Return actions whose ``duration`` window has not yet elapsed.
+
+        Args:
+            now: Reference instant; defaults to :func:`utcnow`.
+        """
+        return self.action_log.active(now if now is not None else utcnow())
+
     def _read_sensor(self, entity_key: str) -> float | None:
         """Safely read a float value from a HA sensor entity.
 
@@ -778,6 +874,11 @@ class PoolmanCoordinator(DataUpdateCoordinator[PoolState]):
         if not self._inventory_loaded:
             self.inventory = await self._inventory_store.async_load()
             self._inventory_loaded = True
+
+        # Load action log on first refresh as well.
+        if not self._action_log_loaded:
+            self.action_log = await self._action_store.async_load()
+            self._action_log_loaded = True
 
         # Read manual measures from event entities
         manual_measures = self._read_measure_entries()

--- a/custom_components/poolman/domain/action.py
+++ b/custom_components/poolman/domain/action.py
@@ -46,9 +46,14 @@ Example::
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import logging
+
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import StrEnum
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class ActionType(StrEnum):
@@ -127,3 +132,173 @@ class Action:
     recommendation_id: str | None = None
     product_id: str | None = None
     duration: timedelta | None = None
+
+
+@dataclass
+class ActionLog:
+    """Append-only history of :class:`Action` records.
+
+    The log is the in-memory representation of the pool's action timeline.
+    It is intentionally append-only: once recorded, an :class:`Action`
+    cannot be mutated or removed.  The container is JSON-serializable via
+    :meth:`to_dict`/:meth:`from_dict` so that it can be persisted with
+    :class:`homeassistant.helpers.storage.Store` (see
+    :class:`~..storage.ActionStore`).
+
+    Attributes:
+        actions: Recorded actions in insertion order (oldest first).
+    """
+
+    actions: list[Action] = field(default_factory=list)
+
+    # ------------------------------------------------------------------
+    # Mutation (append-only)
+    # ------------------------------------------------------------------
+    def record(self, action: Action) -> None:
+        """Append a new :class:`Action` to the log.
+
+        Enforces the invariants documented in #19:
+
+        - Action ids are unique within the log.
+        - When ``source == ActionSource.RECOMMENDATION`` the
+          ``recommendation_id`` field MUST be set.
+
+        Args:
+            action: The action to record.
+
+        Raises:
+            ValueError: If the id collides with an existing record, or
+                the ``source``/``recommendation_id`` invariant is broken.
+        """
+        if action.source is ActionSource.RECOMMENDATION and not action.recommendation_id:
+            raise ValueError(
+                "recommendation_id is required when source == ActionSource.RECOMMENDATION",
+            )
+        if any(existing.id == action.id for existing in self.actions):
+            raise ValueError(f"Duplicate action id: {action.id}")
+        self.actions.append(action)
+
+    # ------------------------------------------------------------------
+    # Queries
+    # ------------------------------------------------------------------
+    def get(self, action_id: str) -> Action | None:
+        """Return the action with the given id, or ``None`` if absent."""
+        for action in self.actions:
+            if action.id == action_id:
+                return action
+        return None
+
+    def history(self, limit: int = 50) -> list[Action]:
+        """Return the most recent actions, newest first.
+
+        Args:
+            limit: Maximum number of actions to return.
+
+        Returns:
+            Up to ``limit`` actions sorted by ``timestamp`` descending.
+        """
+        ordered = sorted(self.actions, key=lambda a: a.timestamp, reverse=True)
+        return ordered[:limit]
+
+    def active(self, now: datetime) -> list[Action]:
+        """Return actions whose ``duration`` window has not yet elapsed.
+
+        Matches the contract from #19::
+
+            [a for a in actions if a.duration and a.timestamp + a.duration > now]
+
+        Args:
+            now: Reference instant to compare against.
+
+        Returns:
+            Actions still within their active duration window.
+        """
+        return [
+            action
+            for action in self.actions
+            if action.duration is not None and action.timestamp + action.duration > now
+        ]
+
+    def since(self, moment: datetime) -> list[Action]:
+        """Return actions recorded at or after ``moment``, oldest first."""
+        return [action for action in self.actions if action.timestamp >= moment]
+
+    def by_recommendation(self, recommendation_id: str) -> list[Action]:
+        """Return actions linked to the given recommendation id."""
+        return [action for action in self.actions if action.recommendation_id == recommendation_id]
+
+    # ------------------------------------------------------------------
+    # Serialization (used by helpers.storage.Store)
+    # ------------------------------------------------------------------
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation of the log.
+
+        Timestamps are serialized as ISO-8601 strings and durations as
+        their total number of seconds, both natively supported by HA's
+        JSON encoder.
+        """
+        return {
+            "actions": [
+                {
+                    "id": action.id,
+                    "type": action.type.value,
+                    "source": action.source.value,
+                    "treatment_id": action.treatment_id,
+                    "quantity": action.quantity,
+                    "unit": action.unit,
+                    "timestamp": action.timestamp.isoformat(),
+                    "recommendation_id": action.recommendation_id,
+                    "product_id": action.product_id,
+                    "duration": (
+                        action.duration.total_seconds() if action.duration is not None else None
+                    ),
+                }
+                for action in self.actions
+            ],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ActionLog:
+        """Rebuild an :class:`ActionLog` from its JSON representation.
+
+        Entries with an unknown ``type`` or ``source`` value, or missing
+        required fields, are dropped with a warning rather than causing
+        the load to fail.  This keeps history compatible across
+        integration upgrades and downgrades.
+
+        Args:
+            data: A dictionary previously produced by :meth:`to_dict`.
+        """
+        log = cls()
+        if not isinstance(data, dict):
+            raise TypeError(f"ActionLog payload must be a mapping, got {type(data).__name__}")
+        for raw in data.get("actions", []):
+            try:
+                action_type = ActionType(raw["type"])
+                action_source = ActionSource(raw["source"])
+                timestamp = datetime.fromisoformat(raw["timestamp"])
+                raw_duration = raw.get("duration")
+                duration = (
+                    timedelta(seconds=float(raw_duration)) if raw_duration is not None else None
+                )
+                action = Action(
+                    id=raw["id"],
+                    type=action_type,
+                    source=action_source,
+                    treatment_id=raw["treatment_id"],
+                    quantity=float(raw["quantity"]),
+                    unit=raw["unit"],
+                    timestamp=timestamp,
+                    recommendation_id=raw.get("recommendation_id"),
+                    product_id=raw.get("product_id"),
+                    duration=duration,
+                )
+            except (KeyError, TypeError, ValueError):
+                _LOGGER.warning(
+                    "Dropping malformed action entry: %s",
+                    raw,
+                    exc_info=True,
+                )
+                continue
+            log.actions.append(action)
+        return log

--- a/custom_components/poolman/storage.py
+++ b/custom_components/poolman/storage.py
@@ -1,14 +1,16 @@
 """Persistence helpers for Pool Manager.
 
 This module wraps :class:`homeassistant.helpers.storage.Store` to persist
-state that lives outside the config-entry data (currently the user's
-:class:`~.domain.inventory.Inventory`).
+state that lives outside the config-entry data:
+
+- The user's :class:`~.domain.inventory.Inventory`.
+- The append-only :class:`~.domain.action.ActionLog`.
 
 One store file is created per config entry, keyed
-``poolman.inventory.<entry_id>`` so that multi-pool installations remain
+``poolman.<area>.<entry_id>`` so that multi-pool installations remain
 isolated. Loading is fault-tolerant: corrupted or partial payloads cause
-the integration to fall back to an empty inventory and log a warning,
-never crash setup.
+the integration to fall back to an empty domain object and log a
+warning, never crash setup.
 """
 
 from __future__ import annotations
@@ -21,11 +23,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store
 
 from .const import DOMAIN
+from .domain.action import ActionLog
 from .domain.inventory import Inventory
 
 _LOGGER = logging.getLogger(__name__)
 
 INVENTORY_STORAGE_VERSION = 1
+ACTION_STORAGE_VERSION = 1
 
 
 class InventoryStore:
@@ -70,3 +74,47 @@ class InventoryStore:
     async def async_save(self, inventory: Inventory) -> None:
         """Persist the inventory to disk."""
         await self._store.async_save(inventory.to_dict())
+
+
+class ActionStore:
+    """Persistence wrapper for an :class:`ActionLog` per config entry."""
+
+    def __init__(self, hass: HomeAssistant, entry_id: str) -> None:
+        """Initialize the store.
+
+        Args:
+            hass: The Home Assistant instance.
+            entry_id: Config entry identifier; used to namespace the
+                storage key so multiple pools persist independently.
+        """
+        self._store: Store[dict[str, Any]] = Store(
+            hass,
+            ACTION_STORAGE_VERSION,
+            f"{DOMAIN}.actions.{entry_id}",
+        )
+
+    async def async_load(self) -> ActionLog:
+        """Load the action log from disk.
+
+        Returns:
+            The persisted :class:`ActionLog`, or an empty log when no
+            data exists or the stored payload cannot be parsed.
+        """
+        try:
+            data = await self._store.async_load()
+        except Exception:
+            _LOGGER.warning("Failed to load action store; starting empty", exc_info=True)
+            return ActionLog()
+
+        if not data:
+            return ActionLog()
+
+        try:
+            return ActionLog.from_dict(data)
+        except (KeyError, TypeError, ValueError):
+            _LOGGER.warning("Malformed action payload; starting empty", exc_info=True)
+            return ActionLog()
+
+    async def async_save(self, log: ActionLog) -> None:
+        """Persist the action log to disk."""
+        await self._store.async_save(log.to_dict())

--- a/tests/domain/test_action.py
+++ b/tests/domain/test_action.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
+import logging
+
 from dataclasses import FrozenInstanceError
 from datetime import UTC, datetime, timedelta
 
 import pytest
 
-from custom_components.poolman.domain.action import Action, ActionSource, ActionType
+from custom_components.poolman.domain.action import (
+    Action,
+    ActionLog,
+    ActionSource,
+    ActionType,
+)
 
 
 class TestActionType:
@@ -142,3 +149,168 @@ class TestAction:
         )
         assert action.type == ActionType.CLEANING
         assert action.product_id is None
+
+
+class TestActionLog:
+    """Tests for :class:`ActionLog` container."""
+
+    _BASE = datetime(2026, 4, 19, 10, 0, tzinfo=UTC)
+
+    def _action(
+        self,
+        action_id: str,
+        *,
+        offset_minutes: float = 0.0,
+        source: ActionSource = ActionSource.USER,
+        recommendation_id: str | None = None,
+        duration: timedelta | None = None,
+    ) -> Action:
+        return Action(
+            id=action_id,
+            type=ActionType.CHEMICAL,
+            source=source,
+            treatment_id="ph_minus_300g",
+            quantity=300.0,
+            unit="g",
+            timestamp=self._BASE + timedelta(minutes=offset_minutes),
+            recommendation_id=recommendation_id,
+            duration=duration,
+        )
+
+    def test_record_and_get(self) -> None:
+        log = ActionLog()
+        action = self._action("a1")
+        log.record(action)
+        assert log.get("a1") is action
+        assert log.get("missing") is None
+
+    def test_record_rejects_duplicate_id(self) -> None:
+        log = ActionLog()
+        log.record(self._action("a1"))
+        with pytest.raises(ValueError, match="Duplicate action id"):
+            log.record(self._action("a1", offset_minutes=10))
+
+    def test_record_requires_recommendation_id_for_recommendation_source(self) -> None:
+        log = ActionLog()
+        with pytest.raises(ValueError, match="recommendation_id is required"):
+            log.record(self._action("a1", source=ActionSource.RECOMMENDATION))
+
+    def test_record_accepts_recommendation_source_with_id(self) -> None:
+        log = ActionLog()
+        log.record(
+            self._action(
+                "a1",
+                source=ActionSource.RECOMMENDATION,
+                recommendation_id="rec_ph_too_high",
+            )
+        )
+        assert log.actions[0].recommendation_id == "rec_ph_too_high"
+
+    def test_history_newest_first_with_limit(self) -> None:
+        log = ActionLog()
+        for i in range(5):
+            log.record(self._action(f"a{i}", offset_minutes=i))
+        history = log.history(limit=3)
+        assert [a.id for a in history] == ["a4", "a3", "a2"]
+
+    def test_history_default_limit(self) -> None:
+        log = ActionLog()
+        log.record(self._action("a1"))
+        assert log.history() == [log.actions[0]]
+
+    def test_active_filters_by_duration_window(self) -> None:
+        log = ActionLog()
+        log.record(self._action("no_dur"))  # no duration -> not active
+        log.record(
+            self._action("expired", offset_minutes=0, duration=timedelta(minutes=10))
+        )  # ends at +10
+        log.record(
+            self._action("ongoing", offset_minutes=20, duration=timedelta(minutes=30))
+        )  # ends at +50
+
+        now = self._BASE + timedelta(minutes=30)
+        active = log.active(now)
+        assert [a.id for a in active] == ["ongoing"]
+
+    def test_since(self) -> None:
+        log = ActionLog()
+        log.record(self._action("a0", offset_minutes=0))
+        log.record(self._action("a1", offset_minutes=30))
+        log.record(self._action("a2", offset_minutes=60))
+        result = log.since(self._BASE + timedelta(minutes=30))
+        assert [a.id for a in result] == ["a1", "a2"]
+
+    def test_by_recommendation(self) -> None:
+        log = ActionLog()
+        log.record(self._action("a0"))
+        log.record(
+            self._action(
+                "a1",
+                source=ActionSource.RECOMMENDATION,
+                recommendation_id="rec_x",
+            )
+        )
+        log.record(
+            self._action(
+                "a2",
+                offset_minutes=5,
+                source=ActionSource.RECOMMENDATION,
+                recommendation_id="rec_y",
+            )
+        )
+        assert [a.id for a in log.by_recommendation("rec_x")] == ["a1"]
+
+    def test_to_dict_from_dict_round_trip(self) -> None:
+        log = ActionLog()
+        log.record(self._action("a0", duration=timedelta(minutes=30)))
+        log.record(
+            self._action(
+                "a1",
+                offset_minutes=15,
+                source=ActionSource.RECOMMENDATION,
+                recommendation_id="rec_x",
+            )
+        )
+        rebuilt = ActionLog.from_dict(log.to_dict())
+        assert rebuilt.actions == log.actions
+
+    def test_from_dict_drops_malformed_entries(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        payload = {
+            "actions": [
+                # Valid
+                {
+                    "id": "good",
+                    "type": "chemical",
+                    "source": "user",
+                    "treatment_id": "t",
+                    "quantity": 100.0,
+                    "unit": "g",
+                    "timestamp": self._BASE.isoformat(),
+                    "recommendation_id": None,
+                    "product_id": None,
+                    "duration": None,
+                },
+                # Unknown enum value
+                {
+                    "id": "future",
+                    "type": "unknown_type",
+                    "source": "user",
+                    "treatment_id": "t",
+                    "quantity": 1.0,
+                    "unit": "g",
+                    "timestamp": self._BASE.isoformat(),
+                },
+                # Missing required field
+                {"id": "broken"},
+            ],
+        }
+        with caplog.at_level(logging.WARNING):
+            log = ActionLog.from_dict(payload)
+        assert [a.id for a in log.actions] == ["good"]
+        assert sum(1 for r in caplog.records if "malformed action entry" in r.message) >= 2
+
+    def test_from_dict_empty(self) -> None:
+        assert ActionLog.from_dict({}).actions == []

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
+
 import pytest
 
 from homeassistant.core import HomeAssistant
@@ -22,8 +24,10 @@ from custom_components.poolman.const import (
     SUBENTRY_ACTIVATION,
 )
 from custom_components.poolman.coordinator import PoolmanCoordinator
+from custom_components.poolman.domain.action import Action, ActionSource, ActionType
 from custom_components.poolman.domain.activation import ActivationStep
 from custom_components.poolman.domain.model import ChemicalProduct, MeasureParameter, PoolMode
+from custom_components.poolman.storage import ActionStore
 from tests.conftest import MOCK_CONFIG_DATA, setup_mock_states
 
 
@@ -1167,3 +1171,93 @@ class TestAnalysisResult:
         mock_config_entry.add_to_hass(hass)
         coordinator = PoolmanCoordinator(hass, mock_config_entry)
         assert coordinator.analysis_result is None
+
+
+class TestActionTracking:
+    """Tests for coordinator action recording and persistence (issue #19)."""
+
+    @staticmethod
+    def _action(
+        action_id: str = "act_test",
+        *,
+        unit: str = "g",
+        timestamp: datetime | None = None,
+        duration: timedelta | None = None,
+    ) -> Action:
+        return Action(
+            id=action_id,
+            type=ActionType.CHEMICAL,
+            source=ActionSource.USER,
+            treatment_id="ph_minus_300g",
+            quantity=300.0,
+            unit=unit,
+            timestamp=timestamp or datetime(2026, 4, 19, 10, 0, tzinfo=UTC),
+            product_id="ph_minus",
+            duration=duration,
+        )
+
+    async def test_record_action_persists_and_appears_in_history(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        action = self._action()
+        await coordinator.async_record_action(action)
+
+        history = coordinator.get_action_history()
+        assert history == [action]
+
+    async def test_get_active_actions_filters_by_duration(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        base = datetime(2026, 4, 19, 10, 0, tzinfo=UTC)
+        await coordinator.async_record_action(
+            self._action("act_expired", timestamp=base, duration=timedelta(minutes=5))
+        )
+        await coordinator.async_record_action(
+            self._action(
+                "act_ongoing",
+                timestamp=base + timedelta(minutes=30),
+                duration=timedelta(minutes=60),
+            )
+        )
+
+        active = coordinator.get_active_actions(now=base + timedelta(minutes=45))
+        assert [a.id for a in active] == ["act_ongoing"]
+
+    async def test_record_action_rejects_non_ha_unit(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        with pytest.raises(ValueError, match="not a Home Assistant-compatible unit"):
+            await coordinator.async_record_action(self._action(unit="spoon"))
+        assert coordinator.get_action_history() == []
+
+    async def test_record_action_accepts_tablet_unit(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        await coordinator.async_record_action(self._action(unit="tablet"))
+        assert len(coordinator.get_action_history()) == 1
+
+    async def test_history_persists_across_coordinator_restart(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        await coordinator.async_record_action(self._action("act_persist"))
+
+        # Simulate a restart by reloading the store fresh against the same entry id.
+        store = ActionStore(hass, mock_config_entry.entry_id)
+        reloaded = await store.async_load()
+        assert [a.id for a in reloaded.actions] == ["act_persist"]
+
+    async def test_on_action_recorded_listener(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        seen: list[Action] = []
+        unsubscribe = coordinator.on_action_recorded(seen.append)
+        await coordinator.async_record_action(self._action("act_1"))
+        unsubscribe()
+        await coordinator.async_record_action(self._action("act_2"))
+        assert [a.id for a in seen] == ["act_1"]

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -4,13 +4,21 @@ from __future__ import annotations
 
 import logging
 
+from datetime import UTC, datetime, timedelta
+
 import pytest
 
 from homeassistant.core import HomeAssistant
 
+from custom_components.poolman.domain.action import (
+    Action,
+    ActionLog,
+    ActionSource,
+    ActionType,
+)
 from custom_components.poolman.domain.inventory import Inventory, Product
 from custom_components.poolman.domain.model import ChemicalProduct
-from custom_components.poolman.storage import InventoryStore
+from custom_components.poolman.storage import ActionStore, InventoryStore
 
 
 async def test_load_returns_empty_when_no_data(hass: HomeAssistant) -> None:
@@ -63,3 +71,73 @@ async def test_load_malformed_payload_returns_empty(
     assert isinstance(inventory, Inventory)
     assert inventory.products == {}
     assert any("Malformed inventory payload" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# ActionStore (issue #19)
+# ---------------------------------------------------------------------------
+
+
+async def test_action_store_load_returns_empty_when_no_data(hass: HomeAssistant) -> None:
+    store = ActionStore(hass, "entry_empty_actions")
+    log = await store.async_load()
+    assert isinstance(log, ActionLog)
+    assert log.actions == []
+
+
+async def test_action_store_save_then_load_round_trip(hass: HomeAssistant) -> None:
+    store = ActionStore(hass, "entry_actions_round_trip")
+    log = ActionLog()
+    log.record(
+        Action(
+            id="act_1",
+            type=ActionType.CHEMICAL,
+            source=ActionSource.USER,
+            treatment_id="ph_minus_300g",
+            quantity=300.0,
+            unit="g",
+            timestamp=datetime(2026, 4, 19, 10, 0, tzinfo=UTC),
+            product_id="ph_minus",
+            duration=timedelta(minutes=30),
+        )
+    )
+    log.record(
+        Action(
+            id="act_2",
+            type=ActionType.CHEMICAL,
+            source=ActionSource.RECOMMENDATION,
+            treatment_id="chlore_choc_500g",
+            quantity=500.0,
+            unit="g",
+            timestamp=datetime(2026, 4, 19, 11, 0, tzinfo=UTC),
+            recommendation_id="rec_chlorine_low",
+            product_id="chlore_choc",
+        )
+    )
+
+    await store.async_save(log)
+
+    # Reload using a fresh store instance to bypass internal caching.
+    rebuilt_store = ActionStore(hass, "entry_actions_round_trip")
+    rebuilt = await rebuilt_store.async_load()
+    assert rebuilt.actions == log.actions
+
+
+async def test_action_store_load_malformed_payload_returns_empty(
+    hass: HomeAssistant,
+    hass_storage: dict[str, dict],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    # Pre-populate the storage backing with a payload that breaks the
+    # outer container shape (data is not a dict).
+    hass_storage["poolman.actions.entry_bad"] = {
+        "version": 1,
+        "key": "poolman.actions.entry_bad",
+        "data": "not-a-dict",
+    }
+    store = ActionStore(hass, "entry_bad")
+    with caplog.at_level(logging.WARNING):
+        log = await store.async_load()
+    assert isinstance(log, ActionLog)
+    assert log.actions == []
+    assert any("Malformed action payload" in r.message for r in caplog.records)


### PR DESCRIPTION
Introduces a persistent action history for the pool, completing the `Action` domain model with an append-only `ActionLog` container, restart-safe storage via `helpers.storage.Store`, and a coordinator API to record actions, retrieve history, and query the currently active treatments.

Units are validated at recording time against a Home Assistant allowlist (mass, volume, time, plus `tablet`), keeping the domain layer HA-free while enforcing the integration contract on the HA side.

Inventory consumption, HA service exposure, and the action history Lovelace card are intentionally left out of scope and tracked in their respective issues.

Closes #19