### PR TITLE
feat(inventory): decrement stock when actions are recorded

### DIFF
--- a/custom_components/poolman/coordinator.py
+++ b/custom_components/poolman/coordinator.py
@@ -625,7 +625,12 @@ class PoolmanCoordinator(DataUpdateCoordinator[PoolState]):
         quantity: float,
         unit: str | None = None,
     ) -> None:
-        """Decrement the stock for a product. Used by action recording (#94)."""
+        """Decrement the stock for a product.
+
+        Called by :meth:`async_record_action` when the recorded action
+        carries a ``product_id``. See :meth:`Inventory.consume` for the
+        unit-mismatch / unknown-product / negative-stock contract.
+        """
         self.inventory.consume(product_id, quantity, unit=unit)
         await self._async_persist_inventory()
 
@@ -674,8 +679,13 @@ class PoolmanCoordinator(DataUpdateCoordinator[PoolState]):
         and the ``source``/``recommendation_id`` invariant are enforced
         by :meth:`ActionLog.record`.
 
-        Inventory consumption is intentionally not triggered here; it is
-        tracked separately in #94.
+        When ``action.product_id`` is set, the matching inventory item
+        is debited via :meth:`Inventory.consume` after the action has
+        been persisted. Inventory failures (unknown product, unit
+        mismatch, negative stock) are logged by ``Inventory.consume``
+        itself and MUST NOT block action recording; any unexpected
+        exception is caught and logged so the caller still observes a
+        successfully recorded action.
 
         Args:
             action: The :class:`Action` to record.
@@ -691,6 +701,20 @@ class PoolmanCoordinator(DataUpdateCoordinator[PoolState]):
             )
         self.action_log.record(action)
         await self._async_persist_actions(recorded=action)
+
+        if action.product_id is not None:
+            try:
+                await self.async_inventory_consume(
+                    action.product_id,
+                    action.quantity,
+                    unit=action.unit,
+                )
+            except Exception:  # never block action recording on inventory errors
+                _LOGGER.exception(
+                    "Failed to apply action %s to inventory product %s",
+                    action.id,
+                    action.product_id,
+                )
 
     def get_action_history(self, limit: int = 50) -> list[Action]:
         """Return the most recent actions, newest first (see :meth:`ActionLog.history`)."""

--- a/custom_components/poolman/domain/action.py
+++ b/custom_components/poolman/domain/action.py
@@ -21,7 +21,10 @@ field links back to the originating recommendation.
 This separation enables future features such as:
 
 - Treatment history and audit log (#19, #92).
-- Inventory tracking and product consumption (#94).
+- Inventory tracking and product consumption: recording an action with
+  a ``product_id`` automatically debits the matching inventory item
+  (see :meth:`Inventory.consume` and
+  :meth:`PoolmanCoordinator.async_record_action`).
 - Automatic feedback loop: mark a recommendation as resolved once the
   corresponding action is recorded.
 

--- a/custom_components/poolman/domain/inventory.py
+++ b/custom_components/poolman/domain/inventory.py
@@ -13,7 +13,7 @@ products available for treatment. It is the canonical home for:
 The inventory is **decoupled** from the analysis pipeline: rules and
 recommendations MUST NOT mutate it. Stock is only modified by user input
 (via Home Assistant services) or by recording an :class:`~.action.Action`
-(see #94).
+that carries a ``product_id`` (see :meth:`Inventory.consume`).
 
 Units are plain Home Assistant-compatible strings (``"g"``, ``"mL"``,
 ``"tablet"``), matching the convention used by :class:`~.action.Action`
@@ -119,7 +119,7 @@ class Inventory:
 
     An item is created lazily by :meth:`add_stock` the first time a
     product receives stock. Consumption of an unknown product is logged
-    and silently skipped (matching the contract expected by #94).
+    and silently skipped so action recording is never blocked.
 
     Attributes:
         products: Catalog of known products, keyed by product id.
@@ -222,7 +222,8 @@ class Inventory:
     ) -> None:
         """Decrement the stock for a product.
 
-        Designed to be called from the action-recording pipeline (#94):
+        Called from the action-recording pipeline whenever an
+        :class:`~.action.Action` carries a ``product_id``:
 
         - Unknown products are logged as a warning and skipped, never
           raised, so action recording is not blocked.

--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -24,9 +24,11 @@ persisted to local storage, so it survives Home Assistant restarts.
   stock drops at or below it, a dedicated binary sensor turns on.
 
 The inventory is decoupled from the analysis pipeline: rules and
-recommendations cannot mutate it. Only Home Assistant services
-(documented below) and -- in a future release -- recording an action
-will change stock.
+recommendations cannot mutate it. Stock changes only come from:
+
+- Home Assistant services (documented below), or
+- Recording an action that carries a `product_id` (see
+  [Automatic decrement on action recording](#automatic-decrement-on-action-recording)).
 
 ## Supported units
 
@@ -120,6 +122,27 @@ data:
   low_stock_threshold: 250   # optional
 ```
 
+## Automatic decrement on action recording
+
+When an [action](rules-and-recommendations.md) is recorded with a
+`product_id`, Pool Manager automatically debits the matching product's
+stock by `action.quantity`. The contract is intentionally lenient so an
+inventory issue never prevents the action itself from being logged:
+
+- **Unknown product** -- the action is recorded and a warning is logged
+  (`Unknown product <id> -- action recorded but inventory not updated`).
+  The inventory is left unchanged.
+- **Unit mismatch** -- when the action unit differs from the product
+  unit, the consumption is skipped and an error is logged
+  (`Unit mismatch for product <id>: inventory=<u1> action=<u2> -- skipping
+  inventory update`). No silent unit conversion is performed.
+- **Negative stock** -- the consumption is still applied so the discrepancy
+  remains visible; a warning is logged
+  (`Negative stock for product <id> (<qty>)`).
+
+Actions without a `product_id` (e.g. cleaning or maintenance) never
+touch the inventory.
+
 ## Persistence
 
 The inventory is persisted to Home Assistant's local storage as
@@ -151,8 +174,5 @@ inventory at startup; it never blocks integration setup.
 
 ## Roadmap
 
-- **Automatic decrement on treatment recording** (issue #94) -- recording
-  an action with a `product_id` will consume the corresponding stock,
-  using the product's unit for safety.
 - **Config-flow editor** for products (currently services-only).
 - **External inventory integration** with Vesta (issue #93).

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -26,8 +26,9 @@ from custom_components.poolman.const import (
 from custom_components.poolman.coordinator import PoolmanCoordinator
 from custom_components.poolman.domain.action import Action, ActionSource, ActionType
 from custom_components.poolman.domain.activation import ActivationStep
+from custom_components.poolman.domain.inventory import Product
 from custom_components.poolman.domain.model import ChemicalProduct, MeasureParameter, PoolMode
-from custom_components.poolman.storage import ActionStore
+from custom_components.poolman.storage import ActionStore, InventoryStore
 from tests.conftest import MOCK_CONFIG_DATA, setup_mock_states
 
 
@@ -1261,3 +1262,130 @@ class TestActionTracking:
         unsubscribe()
         await coordinator.async_record_action(self._action("act_2"))
         assert [a.id for a in seen] == ["act_1"]
+
+
+class TestActionInventoryIntegration:
+    """Tests for the action -> inventory glue (issue #94)."""
+
+    @staticmethod
+    def _action(
+        action_id: str = "act_test",
+        *,
+        product_id: str | None = "ph_minus",
+        unit: str = "g",
+        quantity: float = 300.0,
+    ) -> Action:
+        return Action(
+            id=action_id,
+            type=ActionType.CHEMICAL,
+            source=ActionSource.USER,
+            treatment_id="ph_minus_300g",
+            quantity=quantity,
+            unit=unit,
+            timestamp=datetime(2026, 4, 19, 10, 0, tzinfo=UTC),
+            product_id=product_id,
+        )
+
+    @staticmethod
+    async def _prepare_inventory(
+        coordinator: PoolmanCoordinator,
+        *,
+        product_id: str = "ph_minus",
+        unit: str = "g",
+        quantity: float = 1000.0,
+    ) -> None:
+        await coordinator.async_inventory_add_product(
+            Product(id=product_id, name=product_id, unit=unit),
+            initial_quantity=quantity,
+        )
+
+    async def test_action_with_known_product_decrements_stock(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        await self._prepare_inventory(coordinator)
+
+        await coordinator.async_record_action(self._action())
+
+        item = coordinator.inventory.get("ph_minus")
+        assert item is not None
+        assert item.quantity == 700.0
+        assert [a.id for a in coordinator.get_action_history()] == ["act_test"]
+
+    async def test_action_without_product_leaves_inventory_untouched(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        await self._prepare_inventory(coordinator)
+
+        await coordinator.async_record_action(self._action(product_id=None))
+
+        item = coordinator.inventory.get("ph_minus")
+        assert item is not None
+        assert item.quantity == 1000.0
+
+    async def test_unknown_product_logs_warning_and_records_action(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        # No product registered; inventory must stay empty.
+
+        with caplog.at_level("WARNING", logger="custom_components.poolman.domain.inventory"):
+            await coordinator.async_record_action(self._action(product_id="ghost"))
+
+        assert any("Unknown product ghost" in r.message for r in caplog.records)
+        assert coordinator.inventory.get("ghost") is None
+        assert [a.id for a in coordinator.get_action_history()] == ["act_test"]
+
+    async def test_unit_mismatch_logs_error_and_skips_consumption(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        await self._prepare_inventory(coordinator, unit="g", quantity=1000.0)
+
+        with caplog.at_level("ERROR", logger="custom_components.poolman.domain.inventory"):
+            await coordinator.async_record_action(self._action(unit="mL"))
+
+        assert any("Unit mismatch for product ph_minus" in r.message for r in caplog.records)
+        item = coordinator.inventory.get("ph_minus")
+        assert item is not None
+        assert item.quantity == 1000.0
+        assert [a.id for a in coordinator.get_action_history()] == ["act_test"]
+
+    async def test_negative_stock_logs_warning_but_applies(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        await self._prepare_inventory(coordinator, quantity=100.0)
+
+        with caplog.at_level("WARNING", logger="custom_components.poolman.domain.inventory"):
+            await coordinator.async_record_action(self._action(quantity=300.0))
+
+        assert any("Negative stock for product ph_minus" in r.message for r in caplog.records)
+        item = coordinator.inventory.get("ph_minus")
+        assert item is not None
+        assert item.quantity == -200.0
+        assert [a.id for a in coordinator.get_action_history()] == ["act_test"]
+
+    async def test_inventory_decrement_persists_across_restart(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        coordinator = await _setup_coordinator(hass, mock_config_entry)
+        await self._prepare_inventory(coordinator, quantity=1000.0)
+
+        await coordinator.async_record_action(self._action(quantity=400.0))
+
+        store = InventoryStore(hass, mock_config_entry.entry_id)
+        reloaded = await store.async_load()
+        item = reloaded.get("ph_minus")
+        assert item is not None
+        assert item.quantity == 600.0


### PR DESCRIPTION
Closes the loop between user-recorded actions and the product inventory: recording an action with a `product_id` now automatically decrements the matching inventory item by the action's quantity.

The contract is intentionally lenient so action recording is never blocked by an inventory issue:

- Unknown product → warning logged, action still recorded.
- Unit mismatch → error logged, action recorded, stock unchanged (no silent unit conversion).
- Negative stock → warning logged, value applied so the discrepancy stays visible.

Actions without a `product_id` (cleaning, maintenance) do not touch the inventory.

Closes #94