### PR TITLE
feat(services): add apply_recommendation, record_action, and analyze services

### DIFF
--- a/custom_components/poolman/__init__.py
+++ b/custom_components/poolman/__init__.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import logging
 
+from datetime import UTC, datetime
+
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
@@ -21,20 +23,25 @@ from .const import (
     DEFAULT_FILTRATION_KIND,
     DEFAULT_TREATMENT,
     DOMAIN,
+    EVENT_POOLMAN_ACTION_RECORDED,
     INVENTORY_UNITS,
     PLATFORMS,
     SERVICE_ADD_TREATMENT,
+    SERVICE_ANALYZE,
+    SERVICE_APPLY_RECOMMENDATION,
     SERVICE_BOOST_FILTRATION,
     SERVICE_CONFIRM_ACTIVATION_STEP,
     SERVICE_INVENTORY_ADD_PRODUCT,
     SERVICE_INVENTORY_ADD_STOCK,
     SERVICE_INVENTORY_REMOVE_PRODUCT,
     SERVICE_INVENTORY_SET_STOCK,
+    SERVICE_RECORD_ACTION,
     SERVICE_RECORD_MEASURE,
     SUBENTRY_ACTIVATION,
     SUBENTRY_HIBERNATION,
 )
 from .coordinator import PoolmanCoordinator
+from .domain.action import Action, ActionSource, ActionType
 from .domain.activation import ActivationChecklist, ActivationStep
 from .domain.inventory import Product
 from .domain.model import PRODUCT_DENSITY_G_PER_ML, ChemicalProduct, MeasureParameter, PoolMode
@@ -113,6 +120,30 @@ SERVICE_INVENTORY_SET_STOCK_SCHEMA = vol.Schema(
     }
 )
 
+SERVICE_APPLY_RECOMMENDATION_SCHEMA = vol.Schema(
+    {
+        vol.Required("device_id"): str,
+        vol.Required("recommendation_id"): vol.All(str, vol.Length(min=1)),
+    }
+)
+
+SERVICE_RECORD_ACTION_SCHEMA = vol.Schema(
+    {
+        vol.Required("device_id"): str,
+        vol.Required("type"): vol.In([t.value for t in ActionType]),
+        vol.Optional("product_id"): vol.All(str, vol.Length(min=1)),
+        vol.Optional("quantity"): vol.All(vol.Coerce(float), vol.Range(min=0)),
+        vol.Optional("unit"): vol.All(str, vol.Length(min=1)),
+        vol.Optional("note"): str,
+    }
+)
+
+SERVICE_ANALYZE_SCHEMA = vol.Schema(
+    {
+        vol.Required("device_id"): str,
+    }
+)
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: PoolmanConfigEntry) -> bool:
     """Set up Pool Manager from a config entry."""
@@ -180,6 +211,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: PoolmanConfigEntry) -> 
         hass.services.async_remove(DOMAIN, SERVICE_INVENTORY_REMOVE_PRODUCT)
         hass.services.async_remove(DOMAIN, SERVICE_INVENTORY_ADD_STOCK)
         hass.services.async_remove(DOMAIN, SERVICE_INVENTORY_SET_STOCK)
+        hass.services.async_remove(DOMAIN, SERVICE_APPLY_RECOMMENDATION)
+        hass.services.async_remove(DOMAIN, SERVICE_RECORD_ACTION)
+        hass.services.async_remove(DOMAIN, SERVICE_ANALYZE)
 
     return result
 
@@ -461,4 +495,184 @@ def _async_register_services(hass: HomeAssistant) -> None:
         SERVICE_INVENTORY_SET_STOCK,
         async_handle_inventory_set_stock,
         schema=SERVICE_INVENTORY_SET_STOCK_SCHEMA,
+    )
+
+    def _resolve_device_coordinator(device_id: str) -> PoolmanCoordinator:
+        """Resolve the Pool Manager coordinator owning the given device.
+
+        Raises:
+            ServiceValidationError: If the device id is unknown or does not
+                belong to a Pool Manager config entry.
+        """
+        device_reg = dr.async_get(hass)
+        device = device_reg.async_get(device_id)
+        if device is None:
+            raise ServiceValidationError(f"Unknown device: {device_id}")
+        for entry_id in device.config_entries:
+            entry = hass.config_entries.async_get_entry(entry_id)
+            if entry and entry.domain == DOMAIN:
+                return entry.runtime_data
+        raise ServiceValidationError(
+            f"Device {device_id} is not a Pool Manager device",
+        )
+
+    def _fire_action_recorded(device_id: str, action: Action) -> None:
+        """Fire the ``poolman_action_recorded`` event for ``action``."""
+        hass.bus.async_fire(
+            EVENT_POOLMAN_ACTION_RECORDED,
+            {
+                "device_id": device_id,
+                "action_id": action.id,
+                "type": action.type.value,
+                "source": action.source.value,
+                "recommendation_id": action.recommendation_id,
+                "product_id": action.product_id,
+                "quantity": action.quantity,
+                "unit": action.unit,
+            },
+        )
+
+    async def async_handle_apply_recommendation(call: ServiceCall) -> None:
+        """Handle the ``apply_recommendation`` service call.
+
+        Resolves the recommendation by id in the current
+        :class:`AnalysisResult` and records one :class:`Action` per
+        :class:`Treatment` step (or a single placeholder action when the
+        recommendation has no treatments).  Each recorded action triggers
+        inventory decrement (#94) and fires
+        :data:`EVENT_POOLMAN_ACTION_RECORDED`.
+        """
+        device_id: str = call.data["device_id"]
+        recommendation_id: str = call.data["recommendation_id"]
+        coordinator = _resolve_device_coordinator(device_id)
+
+        result = coordinator.analysis_result
+        if result is None:
+            raise ServiceValidationError(
+                "No pool analysis is available yet. Wait for the first refresh.",
+            )
+
+        rec = next(
+            (r for r in result.recommendations if r.id == recommendation_id),
+            None,
+        )
+        if rec is None:
+            known = ", ".join(r.id for r in result.recommendations) or "(none)"
+            raise ServiceValidationError(
+                f"Unknown recommendation_id {recommendation_id!r}. Known: {known}",
+            )
+
+        now = datetime.now(UTC)
+        ts_token = now.strftime("%Y%m%dT%H%M%S%f")
+        if rec.treatments:
+            actions = [
+                Action(
+                    id=f"act_{ts_token}_{rec.id}_{idx}",
+                    type=ActionType.CHEMICAL,
+                    source=ActionSource.RECOMMENDATION,
+                    treatment_id=treatment.id,
+                    quantity=treatment.quantity,
+                    unit=treatment.unit,
+                    timestamp=now,
+                    recommendation_id=rec.id,
+                    product_id=treatment.product_id,
+                    duration=treatment.duration,
+                )
+                for idx, treatment in enumerate(rec.treatments)
+            ]
+        else:
+            actions = [
+                Action(
+                    id=f"act_{ts_token}_{rec.id}",
+                    type=ActionType.MAINTENANCE,
+                    source=ActionSource.RECOMMENDATION,
+                    treatment_id="",
+                    quantity=0.0,
+                    unit="min",
+                    timestamp=now,
+                    recommendation_id=rec.id,
+                )
+            ]
+
+        for action in actions:
+            try:
+                await coordinator.async_record_action(action)
+            except ValueError as exc:
+                raise ServiceValidationError(str(exc)) from exc
+            _fire_action_recorded(device_id, action)
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_APPLY_RECOMMENDATION,
+        async_handle_apply_recommendation,
+        schema=SERVICE_APPLY_RECOMMENDATION_SCHEMA,
+    )
+
+    async def async_handle_record_action(call: ServiceCall) -> None:
+        """Handle the ``record_action`` service call.
+
+        Records a user-initiated :class:`Action` (treatment, cleaning, or
+        maintenance).  When ``product_id`` is provided, both ``quantity``
+        and ``unit`` are required so that inventory decrement (#94) can be
+        applied unambiguously.  Fires :data:`EVENT_POOLMAN_ACTION_RECORDED`.
+        """
+        device_id: str = call.data["device_id"]
+        coordinator = _resolve_device_coordinator(device_id)
+
+        product_id: str | None = call.data.get("product_id")
+        quantity: float | None = call.data.get("quantity")
+        unit: str | None = call.data.get("unit")
+        note: str | None = call.data.get("note")
+
+        if product_id is not None and (quantity is None or unit is None):
+            raise ServiceValidationError(
+                "quantity and unit are required when product_id is set",
+            )
+
+        now = datetime.now(UTC)
+        ts_token = now.strftime("%Y%m%dT%H%M%S%f")
+        action = Action(
+            id=f"act_{ts_token}_manual",
+            type=ActionType(call.data["type"]),
+            source=ActionSource.USER,
+            treatment_id=f"manual_{ts_token}",
+            quantity=quantity if quantity is not None else 0.0,
+            unit=unit if unit is not None else "min",
+            timestamp=now,
+            product_id=product_id,
+        )
+
+        if note:
+            # Action has no notes field today (#19); log it so context isn't
+            # silently lost. A future PR may extend Action.
+            _LOGGER.debug("record_action note for %s: %s", action.id, note)
+
+        try:
+            await coordinator.async_record_action(action)
+        except ValueError as exc:
+            raise ServiceValidationError(str(exc)) from exc
+        _fire_action_recorded(device_id, action)
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_RECORD_ACTION,
+        async_handle_record_action,
+        schema=SERVICE_RECORD_ACTION_SCHEMA,
+    )
+
+    async def async_handle_analyze(call: ServiceCall) -> None:
+        """Handle the ``analyze`` service call.
+
+        Triggers an immediate coordinator refresh, which re-runs
+        :func:`analyze_pool` (#97) and pushes the updated
+        :class:`AnalysisResult` to all listening entities (#98, #99, #102).
+        """
+        coordinator = _resolve_device_coordinator(call.data["device_id"])
+        await coordinator.async_request_refresh()
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_ANALYZE,
+        async_handle_analyze,
+        schema=SERVICE_ANALYZE_SCHEMA,
     )

--- a/custom_components/poolman/const.py
+++ b/custom_components/poolman/const.py
@@ -5,6 +5,7 @@ from typing import Final
 
 DOMAIN: Final = "poolman"
 EVENT_POOLMAN: Final = "poolman_event"
+EVENT_POOLMAN_ACTION_RECORDED: Final = "poolman_action_recorded"
 
 PLATFORMS: Final = ["sensor", "binary_sensor", "select", "switch", "time", "number", "event"]
 
@@ -163,6 +164,9 @@ SERVICE_INVENTORY_ADD_PRODUCT: Final = "inventory_add_product"
 SERVICE_INVENTORY_REMOVE_PRODUCT: Final = "inventory_remove_product"
 SERVICE_INVENTORY_ADD_STOCK: Final = "inventory_add_stock"
 SERVICE_INVENTORY_SET_STOCK: Final = "inventory_set_stock"
+SERVICE_APPLY_RECOMMENDATION: Final = "apply_recommendation"
+SERVICE_RECORD_ACTION: Final = "record_action"
+SERVICE_ANALYZE: Final = "analyze"
 
 # Inventory units exposed by services
 INVENTORY_UNITS: Final = ["g", "kg", "mL", "L", "tablet"]

--- a/custom_components/poolman/services.yaml
+++ b/custom_components/poolman/services.yaml
@@ -306,3 +306,79 @@ inventory_set_stock:
           min: 0
           step: 0.1
           mode: box
+
+apply_recommendation:
+  name: Apply recommendation
+  description: Apply a recommendation, creating an Action and updating inventory.
+  fields:
+    device_id:
+      name: Pool device
+      description: The Pool Manager device that owns the recommendation.
+      required: true
+      selector:
+        device:
+          integration: poolman
+    recommendation_id:
+      name: Recommendation ID
+      description: Identifier of the recommendation to apply (e.g. ``rec_ph_too_high``).
+      required: true
+      selector:
+        text:
+
+record_action:
+  name: Record action
+  description: Manually record a pool action (treatment, cleaning, maintenance).
+  fields:
+    device_id:
+      name: Pool device
+      description: The Pool Manager device the action applies to.
+      required: true
+      selector:
+        device:
+          integration: poolman
+    type:
+      name: Action type
+      description: Category of action performed.
+      required: true
+      selector:
+        select:
+          translation_key: action_type
+          options:
+            - "chemical"
+            - "cleaning"
+            - "maintenance"
+    product_id:
+      name: Product ID
+      description: Identifier of the inventory product consumed by this action.
+      selector:
+        text:
+    quantity:
+      name: Quantity
+      description: Amount applied (required when product_id is set).
+      selector:
+        number:
+          min: 0
+          step: 0.1
+          mode: box
+    unit:
+      name: Unit
+      description: Unit for the quantity (required when product_id is set, e.g. ``g``, ``mL``, ``tablet``, ``min``).
+      selector:
+        text:
+    note:
+      name: Note
+      description: Optional free-form note describing the action.
+      selector:
+        text:
+
+analyze:
+  name: Analyze pool
+  description: Trigger an immediate pool analysis, refreshing problems and recommendations.
+  fields:
+    device_id:
+      name: Pool device
+      description: The Pool Manager device to analyze.
+      required: true
+      selector:
+        device:
+          integration: poolman

--- a/custom_components/poolman/strings.json
+++ b/custom_components/poolman/strings.json
@@ -784,6 +784,13 @@
         "winter_passive": "Passive wintering",
         "winter_active": "Active wintering"
       }
+    },
+    "action_type": {
+      "options": {
+        "chemical": "Chemical treatment",
+        "cleaning": "Cleaning",
+        "maintenance": "Maintenance"
+      }
     }
   },
   "services": {
@@ -952,6 +959,60 @@
         "low_stock_threshold": {
           "name": "Low-stock threshold",
           "description": "Optional new threshold value."
+        }
+      }
+    },
+    "apply_recommendation": {
+      "name": "Apply recommendation",
+      "description": "Apply a recommendation, creating an Action and updating inventory.",
+      "fields": {
+        "device_id": {
+          "name": "Pool device",
+          "description": "The Pool Manager device that owns the recommendation."
+        },
+        "recommendation_id": {
+          "name": "Recommendation ID",
+          "description": "Identifier of the recommendation to apply (e.g. rec_ph_too_high)."
+        }
+      }
+    },
+    "record_action": {
+      "name": "Record action",
+      "description": "Manually record a pool action (treatment, cleaning, maintenance).",
+      "fields": {
+        "device_id": {
+          "name": "Pool device",
+          "description": "The Pool Manager device the action applies to."
+        },
+        "type": {
+          "name": "Action type",
+          "description": "Category of action performed."
+        },
+        "product_id": {
+          "name": "Product ID",
+          "description": "Identifier of the inventory product consumed by this action."
+        },
+        "quantity": {
+          "name": "Quantity",
+          "description": "Amount applied (required when product_id is set)."
+        },
+        "unit": {
+          "name": "Unit",
+          "description": "Unit for the quantity (required when product_id is set, e.g. g, mL, tablet, min)."
+        },
+        "note": {
+          "name": "Note",
+          "description": "Optional free-form note describing the action."
+        }
+      }
+    },
+    "analyze": {
+      "name": "Analyze pool",
+      "description": "Trigger an immediate pool analysis, refreshing problems and recommendations.",
+      "fields": {
+        "device_id": {
+          "name": "Pool device",
+          "description": "The Pool Manager device to analyze."
         }
       }
     }

--- a/custom_components/poolman/translations/en.json
+++ b/custom_components/poolman/translations/en.json
@@ -784,6 +784,13 @@
         "winter_passive": "Passive wintering",
         "winter_active": "Active wintering"
       }
+    },
+    "action_type": {
+      "options": {
+        "chemical": "Chemical treatment",
+        "cleaning": "Cleaning",
+        "maintenance": "Maintenance"
+      }
     }
   },
   "services": {
@@ -952,6 +959,60 @@
         "low_stock_threshold": {
           "name": "Low-stock threshold",
           "description": "Optional new threshold value."
+        }
+      }
+    },
+    "apply_recommendation": {
+      "name": "Apply recommendation",
+      "description": "Apply a recommendation, creating an Action and updating inventory.",
+      "fields": {
+        "device_id": {
+          "name": "Pool device",
+          "description": "The Pool Manager device that owns the recommendation."
+        },
+        "recommendation_id": {
+          "name": "Recommendation ID",
+          "description": "Identifier of the recommendation to apply (e.g. rec_ph_too_high)."
+        }
+      }
+    },
+    "record_action": {
+      "name": "Record action",
+      "description": "Manually record a pool action (treatment, cleaning, maintenance).",
+      "fields": {
+        "device_id": {
+          "name": "Pool device",
+          "description": "The Pool Manager device the action applies to."
+        },
+        "type": {
+          "name": "Action type",
+          "description": "Category of action performed."
+        },
+        "product_id": {
+          "name": "Product ID",
+          "description": "Identifier of the inventory product consumed by this action."
+        },
+        "quantity": {
+          "name": "Quantity",
+          "description": "Amount applied (required when product_id is set)."
+        },
+        "unit": {
+          "name": "Unit",
+          "description": "Unit for the quantity (required when product_id is set, e.g. g, mL, tablet, min)."
+        },
+        "note": {
+          "name": "Note",
+          "description": "Optional free-form note describing the action."
+        }
+      }
+    },
+    "analyze": {
+      "name": "Analyze pool",
+      "description": "Trigger an immediate pool analysis, refreshing problems and recommendations.",
+      "fields": {
+        "device_id": {
+          "name": "Pool device",
+          "description": "The Pool Manager device to analyze."
         }
       }
     }

--- a/custom_components/poolman/translations/fr.json
+++ b/custom_components/poolman/translations/fr.json
@@ -784,6 +784,13 @@
         "winter_passive": "Hivernage passif",
         "winter_active": "Hivernage actif"
       }
+    },
+    "action_type": {
+      "options": {
+        "chemical": "Traitement chimique",
+        "cleaning": "Nettoyage",
+        "maintenance": "Maintenance"
+      }
     }
   },
   "services": {
@@ -952,6 +959,60 @@
         "low_stock_threshold": {
           "name": "Seuil de stock bas",
           "description": "Nouvelle valeur de seuil optionnelle."
+        }
+      }
+    },
+    "apply_recommendation": {
+      "name": "Appliquer la recommandation",
+      "description": "Appliquer une recommandation, en cr\u00e9ant une action et en mettant \u00e0 jour l'inventaire.",
+      "fields": {
+        "device_id": {
+          "name": "Bassin",
+          "description": "L'appareil Pool Manager qui porte la recommandation."
+        },
+        "recommendation_id": {
+          "name": "Identifiant de la recommandation",
+          "description": "Identifiant de la recommandation \u00e0 appliquer (ex. rec_ph_too_high)."
+        }
+      }
+    },
+    "record_action": {
+      "name": "Enregistrer une action",
+      "description": "Enregistrer manuellement une action sur la piscine (traitement, nettoyage, maintenance).",
+      "fields": {
+        "device_id": {
+          "name": "Bassin",
+          "description": "L'appareil Pool Manager auquel l'action s'applique."
+        },
+        "type": {
+          "name": "Type d'action",
+          "description": "Cat\u00e9gorie d'action r\u00e9alis\u00e9e."
+        },
+        "product_id": {
+          "name": "Identifiant du produit",
+          "description": "Identifiant du produit d'inventaire consomm\u00e9 par cette action."
+        },
+        "quantity": {
+          "name": "Quantit\u00e9",
+          "description": "Quantit\u00e9 appliqu\u00e9e (obligatoire si product_id est renseign\u00e9)."
+        },
+        "unit": {
+          "name": "Unit\u00e9",
+          "description": "Unit\u00e9 de la quantit\u00e9 (obligatoire si product_id est renseign\u00e9, ex. g, mL, tablet, min)."
+        },
+        "note": {
+          "name": "Note",
+          "description": "Note libre optionnelle d\u00e9crivant l'action."
+        }
+      }
+    },
+    "analyze": {
+      "name": "Analyser le bassin",
+      "description": "D\u00e9clencher une analyse imm\u00e9diate du bassin, en rafra\u00eechissant probl\u00e8mes et recommandations.",
+      "fields": {
+        "device_id": {
+          "name": "Bassin",
+          "description": "L'appareil Pool Manager \u00e0 analyser."
         }
       }
     }

--- a/docs/rules-and-recommendations.md
+++ b/docs/rules-and-recommendations.md
@@ -321,3 +321,65 @@ dataclass with:
 
 The coordinator calls `analyze_pool` on every state update and stores the
 result for sensor and binary-sensor entities to consume.
+
+## Services
+
+Three services let users and automations interact with the analysis output
+directly.
+
+### `poolman.analyze`
+
+Trigger an immediate pool analysis. The coordinator re-reads sensors,
+re-runs `analyze_pool()`, and pushes the refreshed problems and
+recommendations to all listening entities.
+
+```yaml
+service: poolman.analyze
+data:
+  device_id: <pool device id>
+```
+
+### `poolman.apply_recommendation`
+
+Apply a recommendation by its id (e.g. `rec_ph_too_high`). One `Action` is
+recorded per `Treatment` step in the recommendation, with
+`source: recommendation` and `recommendation_id` set. When a treatment
+references an inventory `product_id`, the corresponding stock is debited.
+Recommendations without treatments still record a single placeholder
+action so the recommendation is tracked as acknowledged.
+
+```yaml
+service: poolman.apply_recommendation
+data:
+  device_id: <pool device id>
+  recommendation_id: rec_ph_too_high
+```
+
+If the `recommendation_id` is unknown or no analysis has run yet, the
+service raises a `ServiceValidationError` with a friendly message.
+
+### `poolman.record_action`
+
+Manually record a treatment, cleaning, or maintenance action. When
+`product_id` is provided, both `quantity` and `unit` are required so that
+inventory consumption can be applied. When the action is not tied to a
+product, the service stores a placeholder action with `unit: min`.
+
+```yaml
+service: poolman.record_action
+data:
+  device_id: <pool device id>
+  type: chemical
+  product_id: ph_minus
+  quantity: 250
+  unit: g
+  note: Topped up after rain
+```
+
+### `poolman_action_recorded` event
+
+Each call to `apply_recommendation` or `record_action` fires a
+`poolman_action_recorded` event on the Home Assistant bus. The payload
+includes `device_id`, `action_id`, `type`, `source`, `recommendation_id`,
+`product_id`, `quantity`, and `unit`, so automations can react to recorded
+actions (e.g. send a notification or update an external log).

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -16,10 +16,14 @@ from custom_components.poolman.const import (
     DEFAULT_FILTRATION_KIND,
     DEFAULT_TREATMENT,
     DOMAIN,
+    EVENT_POOLMAN_ACTION_RECORDED,
     MODE_WINTER_PASSIVE,
     SERVICE_ADD_TREATMENT,
+    SERVICE_ANALYZE,
+    SERVICE_APPLY_RECOMMENDATION,
     SERVICE_BOOST_FILTRATION,
     SERVICE_CONFIRM_ACTIVATION_STEP,
+    SERVICE_RECORD_ACTION,
     SERVICE_RECORD_MEASURE,
     SUBENTRY_ACTIVATION,
     SUBENTRY_HIBERNATION,
@@ -77,6 +81,19 @@ class TestSetupEntry:
         await hass.async_block_till_done()
 
         assert hass.services.has_service(DOMAIN, SERVICE_CONFIRM_ACTIVATION_STEP)
+
+    async def test_setup_registers_recommendation_services(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Setting up should register the apply/record/analyze services."""
+        mock_config_entry.add_to_hass(hass)
+        setup_mock_states(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert hass.services.has_service(DOMAIN, SERVICE_APPLY_RECOMMENDATION)
+        assert hass.services.has_service(DOMAIN, SERVICE_RECORD_ACTION)
+        assert hass.services.has_service(DOMAIN, SERVICE_ANALYZE)
 
     async def test_service_registration_idempotent(
         self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
@@ -331,6 +348,26 @@ class TestUnloadEntry:
         await hass.async_block_till_done()
 
         assert not hass.services.has_service(DOMAIN, SERVICE_CONFIRM_ACTIVATION_STEP)
+
+    async def test_unload_last_entry_removes_recommendation_services(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Unloading the last entry should remove apply/record/analyze services."""
+        mock_config_entry.add_to_hass(hass)
+        setup_mock_states(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert hass.services.has_service(DOMAIN, SERVICE_APPLY_RECOMMENDATION)
+        assert hass.services.has_service(DOMAIN, SERVICE_RECORD_ACTION)
+        assert hass.services.has_service(DOMAIN, SERVICE_ANALYZE)
+
+        await hass.config_entries.async_unload(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert not hass.services.has_service(DOMAIN, SERVICE_APPLY_RECOMMENDATION)
+        assert not hass.services.has_service(DOMAIN, SERVICE_RECORD_ACTION)
+        assert not hass.services.has_service(DOMAIN, SERVICE_ANALYZE)
 
 
 class TestMigrateEntry:
@@ -894,5 +931,394 @@ class TestConfirmActivationStepServiceHandler:
                     "device_id": device.id,
                     "step": "remove_cover",
                 },
+                blocking=True,
+            )
+
+
+class TestApplyRecommendationServiceHandler:
+    """Tests for the apply_recommendation service handler."""
+
+    @staticmethod
+    def _make_result(treatments: list | None = None):
+        from datetime import UTC, datetime
+
+        from custom_components.poolman.domain.analysis import AnalysisResult
+        from custom_components.poolman.domain.problem import Severity
+        from custom_components.poolman.domain.recommendation import (
+            ActionKind,
+            Recommendation,
+            RecommendationPriority,
+            RecommendationType,
+            Treatment,
+        )
+
+        if treatments is None:
+            treatments = [
+                Treatment(
+                    id="ph_minus_300g",
+                    product_id="ph_minus",
+                    name="pH-",
+                    quantity=300.0,
+                    unit="g",
+                ),
+            ]
+        rec = Recommendation(
+            id="rec_ph_too_high",
+            type=RecommendationType.CHEMISTRY,
+            severity=Severity.MEDIUM,
+            priority=RecommendationPriority.HIGH,
+            kind=ActionKind.REQUIREMENT,
+            title="Lower pH",
+            description="pH is too high.",
+            reason="ph_too_high",
+            treatments=treatments,
+        )
+        return AnalysisResult(problems=[], recommendations=[rec], timestamp=datetime.now(UTC))
+
+    async def _setup(self, hass: HomeAssistant, mock_config_entry: MockConfigEntry):
+        from homeassistant.helpers import device_registry as dr
+
+        mock_config_entry.add_to_hass(hass)
+        setup_mock_states(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        coordinator: PoolmanCoordinator = mock_config_entry.runtime_data
+        device = dr.async_get(hass).async_get_device(
+            identifiers={(DOMAIN, mock_config_entry.entry_id)}
+        )
+        assert device is not None
+        return coordinator, device
+
+    async def test_apply_recommendation_records_action_and_fires_event(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Applying a recommendation should record an Action and fire the event."""
+        from pytest_homeassistant_custom_component.common import async_capture_events
+
+        from custom_components.poolman.domain.action import ActionSource, ActionType
+
+        coordinator, device = await self._setup(hass, mock_config_entry)
+        coordinator._analysis_result = self._make_result()
+
+        events = async_capture_events(hass, EVENT_POOLMAN_ACTION_RECORDED)
+
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_APPLY_RECOMMENDATION,
+            {"device_id": device.id, "recommendation_id": "rec_ph_too_high"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+        actions = coordinator.action_log.actions
+        assert len(actions) == 1
+        action = actions[0]
+        assert action.source is ActionSource.RECOMMENDATION
+        assert action.recommendation_id == "rec_ph_too_high"
+        assert action.product_id == "ph_minus"
+        assert action.quantity == 300.0
+        assert action.unit == "g"
+        assert action.type is ActionType.CHEMICAL
+
+        assert len(events) == 1
+        payload = events[0].data
+        assert payload["device_id"] == device.id
+        assert payload["action_id"] == action.id
+        assert payload["recommendation_id"] == "rec_ph_too_high"
+        assert payload["source"] == "recommendation"
+
+    async def test_apply_recommendation_records_one_action_per_treatment(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """A multi-treatment recommendation should produce one Action per Treatment."""
+        from custom_components.poolman.domain.recommendation import Treatment
+
+        coordinator, device = await self._setup(hass, mock_config_entry)
+        coordinator._analysis_result = self._make_result(
+            treatments=[
+                Treatment(
+                    id="ph_minus_300g",
+                    product_id="ph_minus",
+                    name="pH-",
+                    quantity=300.0,
+                    unit="g",
+                ),
+                Treatment(
+                    id="ph_minus_100g",
+                    product_id="ph_minus",
+                    name="pH-",
+                    quantity=100.0,
+                    unit="g",
+                ),
+            ]
+        )
+
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_APPLY_RECOMMENDATION,
+            {"device_id": device.id, "recommendation_id": "rec_ph_too_high"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+        assert [a.treatment_id for a in coordinator.action_log.actions] == [
+            "ph_minus_300g",
+            "ph_minus_100g",
+        ]
+
+    async def test_apply_recommendation_without_treatments(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """An alert-only recommendation should still produce a placeholder Action."""
+        from custom_components.poolman.domain.action import ActionType
+
+        coordinator, device = await self._setup(hass, mock_config_entry)
+        coordinator._analysis_result = self._make_result(treatments=[])
+
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_APPLY_RECOMMENDATION,
+            {"device_id": device.id, "recommendation_id": "rec_ph_too_high"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+        actions = coordinator.action_log.actions
+        assert len(actions) == 1
+        action = actions[0]
+        assert action.treatment_id == ""
+        assert action.product_id is None
+        assert action.type is ActionType.MAINTENANCE
+
+    async def test_apply_recommendation_unknown_id_raises(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Unknown recommendation_id should raise ServiceValidationError."""
+        import pytest
+
+        from homeassistant.exceptions import ServiceValidationError
+
+        coordinator, device = await self._setup(hass, mock_config_entry)
+        coordinator._analysis_result = self._make_result()
+
+        with pytest.raises(ServiceValidationError, match="Unknown recommendation_id"):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_APPLY_RECOMMENDATION,
+                {"device_id": device.id, "recommendation_id": "rec_does_not_exist"},
+                blocking=True,
+            )
+
+    async def test_apply_recommendation_unknown_device_raises(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Unknown device_id should raise ServiceValidationError."""
+        import pytest
+
+        from homeassistant.exceptions import ServiceValidationError
+
+        await self._setup(hass, mock_config_entry)
+
+        with pytest.raises(ServiceValidationError, match="Unknown device"):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_APPLY_RECOMMENDATION,
+                {"device_id": "nope", "recommendation_id": "rec_ph_too_high"},
+                blocking=True,
+            )
+
+    async def test_apply_recommendation_without_analysis_raises(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Calling before any analysis is available should raise."""
+        import pytest
+
+        from homeassistant.exceptions import ServiceValidationError
+
+        coordinator, device = await self._setup(hass, mock_config_entry)
+        coordinator._analysis_result = None
+
+        with pytest.raises(ServiceValidationError, match="No pool analysis"):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_APPLY_RECOMMENDATION,
+                {"device_id": device.id, "recommendation_id": "rec_ph_too_high"},
+                blocking=True,
+            )
+
+
+class TestRecordActionServiceHandler:
+    """Tests for the record_action service handler."""
+
+    async def _setup(self, hass: HomeAssistant, mock_config_entry: MockConfigEntry):
+        from homeassistant.helpers import device_registry as dr
+
+        mock_config_entry.add_to_hass(hass)
+        setup_mock_states(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        coordinator: PoolmanCoordinator = mock_config_entry.runtime_data
+        device = dr.async_get(hass).async_get_device(
+            identifiers={(DOMAIN, mock_config_entry.entry_id)}
+        )
+        assert device is not None
+        return coordinator, device
+
+    async def test_record_action_with_product_records_and_fires_event(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """A chemical action with product_id should record and fire the event."""
+        from pytest_homeassistant_custom_component.common import async_capture_events
+
+        from custom_components.poolman.domain.action import ActionSource
+        from custom_components.poolman.domain.inventory import Product
+
+        coordinator, device = await self._setup(hass, mock_config_entry)
+        await coordinator.async_inventory_add_product(
+            Product(id="ph_minus", name="pH-", unit="g"),
+            initial_quantity=1000.0,
+        )
+
+        events = async_capture_events(hass, EVENT_POOLMAN_ACTION_RECORDED)
+
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_RECORD_ACTION,
+            {
+                "device_id": device.id,
+                "type": "chemical",
+                "product_id": "ph_minus",
+                "quantity": 250.0,
+                "unit": "g",
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+        actions = coordinator.action_log.actions
+        assert len(actions) == 1
+        action = actions[0]
+        assert action.source is ActionSource.USER
+        assert action.product_id == "ph_minus"
+        assert action.quantity == 250.0
+        assert action.unit == "g"
+        assert len(events) == 1
+        assert events[0].data["source"] == "user"
+
+    async def test_record_action_without_product_succeeds(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """A cleaning action without product_id should record with default unit."""
+        coordinator, device = await self._setup(hass, mock_config_entry)
+
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_RECORD_ACTION,
+            {"device_id": device.id, "type": "cleaning"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+        actions = coordinator.action_log.actions
+        assert len(actions) == 1
+        action = actions[0]
+        assert action.product_id is None
+        assert action.unit == "min"
+        assert action.quantity == 0.0
+
+    async def test_record_action_product_without_quantity_raises(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """product_id without quantity/unit should raise ServiceValidationError."""
+        import pytest
+
+        from homeassistant.exceptions import ServiceValidationError
+
+        _, device = await self._setup(hass, mock_config_entry)
+
+        with pytest.raises(ServiceValidationError, match="quantity and unit"):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_RECORD_ACTION,
+                {
+                    "device_id": device.id,
+                    "type": "chemical",
+                    "product_id": "ph_minus",
+                },
+                blocking=True,
+            )
+
+    async def test_record_action_unknown_device_raises(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Unknown device_id should raise ServiceValidationError."""
+        import pytest
+
+        from homeassistant.exceptions import ServiceValidationError
+
+        await self._setup(hass, mock_config_entry)
+
+        with pytest.raises(ServiceValidationError, match="Unknown device"):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_RECORD_ACTION,
+                {"device_id": "nope", "type": "cleaning"},
+                blocking=True,
+            )
+
+
+class TestAnalyzeServiceHandler:
+    """Tests for the analyze service handler."""
+
+    async def test_analyze_triggers_refresh(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """The analyze service should call async_request_refresh on the coordinator."""
+        from unittest.mock import AsyncMock, patch
+
+        from homeassistant.helpers import device_registry as dr
+
+        mock_config_entry.add_to_hass(hass)
+        setup_mock_states(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        coordinator: PoolmanCoordinator = mock_config_entry.runtime_data
+        device = dr.async_get(hass).async_get_device(
+            identifiers={(DOMAIN, mock_config_entry.entry_id)}
+        )
+        assert device is not None
+
+        with patch.object(coordinator, "async_request_refresh", new=AsyncMock()) as mock_refresh:
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_ANALYZE,
+                {"device_id": device.id},
+                blocking=True,
+            )
+            await hass.async_block_till_done()
+
+        mock_refresh.assert_awaited_once()
+
+    async def test_analyze_unknown_device_raises(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """Unknown device_id should raise ServiceValidationError."""
+        import pytest
+
+        from homeassistant.exceptions import ServiceValidationError
+
+        mock_config_entry.add_to_hass(hass)
+        setup_mock_states(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        with pytest.raises(ServiceValidationError, match="Unknown device"):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_ANALYZE,
+                {"device_id": "nope"},
                 blocking=True,
             )


### PR DESCRIPTION
Adds three Home Assistant services so users, automations, and the upcoming Lovelace cards (#103, #107) can drive the analysis pipeline directly.

- `poolman.apply_recommendation` looks up a recommendation in the current `AnalysisResult` and records one `Action` per `Treatment` step. Each action is tagged with `source=recommendation` and the originating `recommendation_id`, and triggers the inventory decrement wired in #118. Recommendations without treatments still record a single placeholder action so the recommendation is tracked as acknowledged.
- `poolman.record_action` records a manual user action. When a `product_id` is provided, `quantity` and `unit` become required so the inventory debit is unambiguous; otherwise sensible defaults are used.
- `poolman.analyze` delegates to `coordinator.async_request_refresh()`, re-reading sensors, re-running `analyze_pool()`, and pushing the refreshed problems and recommendations to all listening entities.

Each recorded action fires a new `poolman_action_recorded` bus event with the device id, action id, source, product metadata, and quantity/unit so automations can react. Invalid inputs surface as `ServiceValidationError` with friendly messages.

Services, selectors, and translations are added to `services.yaml`, `strings.json`, and the EN/FR translation files. The rules & recommendations doc page has a new Services section documenting the three calls and the event.

Closes #100