### PR TITLE
feat(sensor): expose detected problems as a sensor entity

### DIFF
--- a/custom_components/poolman/sensor.py
+++ b/custom_components/poolman/sensor.py
@@ -29,6 +29,7 @@ from .domain.model import (
     PoolState,
     format_treatment_spoon,
 )
+from .domain.problem import Problem, Severity
 from .entity import PoolmanEntity
 
 
@@ -122,6 +123,61 @@ def _chemistry_actions_attrs(state: PoolState) -> dict[str, Any]:
         "requirement_count": sum(
             1 for r in state.chemistry_actions if r.kind == ActionKind.REQUIREMENT
         ),
+    }
+
+
+_SEVERITY_ORDER: dict[Severity, int] = {
+    Severity.CRITICAL: 3,
+    Severity.MEDIUM: 2,
+    Severity.LOW: 1,
+}
+
+
+def _problem_to_dict(problem: Problem) -> dict[str, Any]:
+    """Serialize a :class:`Problem` to a JSON-safe dictionary for HA attributes.
+
+    Args:
+        problem: The problem to serialize.
+
+    Returns:
+        Dictionary with primitive types only, suitable for the Home Assistant
+        state machine. Enum values are emitted as plain strings.
+    """
+    return {
+        "code": problem.code,
+        "severity": problem.severity.value,
+        "metric": problem.metric.value if problem.metric is not None else None,
+        "value": problem.value,
+        "expected_range": (
+            list(problem.expected_range) if problem.expected_range is not None else None
+        ),
+        "message": problem.message,
+    }
+
+
+def _problems_attrs(state: PoolState) -> dict[str, Any]:
+    """Build attributes for the ``problems`` sensor.
+
+    Problems are sorted by severity (highest first); ties keep the order
+    produced by the analysis pipeline. ``worst_severity`` is ``"ok"`` when
+    no problems are present, otherwise the severity of the first item.
+
+    Args:
+        state: The current pool state.
+
+    Returns:
+        Dictionary with ``problems`` (list of serialized problems) and
+        ``worst_severity`` (``"ok" | "low" | "medium" | "critical"``).
+    """
+    problems = sorted(
+        state.analysis_result.problems,
+        key=lambda p: _SEVERITY_ORDER.get(p.severity, 0),
+        reverse=True,
+    )
+    worst = problems[0].severity.value if problems else "ok"
+    return {
+        "problems": [_problem_to_dict(p) for p in problems],
+        "worst_severity": worst,
     }
 
 
@@ -221,6 +277,13 @@ SENSOR_DESCRIPTIONS: tuple[PoolmanSensorEntityDescription, ...] = (
             "recommendations": [r.to_dict() for r in state.recommendations],
             "critical_count": len(state.critical_recommendations),
         },
+    ),
+    PoolmanSensorEntityDescription(
+        key="problems",
+        translation_key="problems",
+        icon="mdi:alert-circle-outline",
+        value_fn=lambda state: len(state.analysis_result.problems),
+        extra_attrs_fn=_problems_attrs,
     ),
     PoolmanSensorEntityDescription(
         key="chemistry_actions",

--- a/custom_components/poolman/strings.json
+++ b/custom_components/poolman/strings.json
@@ -257,6 +257,9 @@
       "recommendations": {
         "name": "Recommendations"
       },
+      "problems": {
+        "name": "Problems"
+      },
       "chemistry_actions": {
         "name": "Chemistry actions"
       },

--- a/custom_components/poolman/translations/en.json
+++ b/custom_components/poolman/translations/en.json
@@ -257,6 +257,9 @@
       "recommendations": {
         "name": "Recommendations"
       },
+      "problems": {
+        "name": "Problems"
+      },
       "chemistry_actions": {
         "name": "Chemistry actions"
       },

--- a/custom_components/poolman/translations/fr.json
+++ b/custom_components/poolman/translations/fr.json
@@ -257,6 +257,9 @@
       "recommendations": {
         "name": "Recommandations"
       },
+      "problems": {
+        "name": "Problèmes"
+      },
       "chemistry_actions": {
         "name": "Actions chimie"
       },

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -36,6 +36,7 @@ These sensors are calculated by Pool Manager from your readings.
 | `sensor.{pool}_filtration_duration` | Recommended filtration | h | Recommended daily filtration hours, computed from water temperature, filter type efficiency, outdoor temperature, and pump capacity. See [Pool Modes](pool-modes.md#filtration) for the full algorithm. |
 | `sensor.{pool}_water_quality_score` | Water quality | % | Overall water quality score from 0 (poor) to 100 (perfect). See [Water Chemistry](water-chemistry.md#water-quality-score) for scoring details. |
 | `sensor.{pool}_recommendations` | Recommendations | -- | Number of active recommendations. See details below. |
+| `sensor.{pool}_problems` | Problems | -- | Number of detected water-quality problems. See details below. |
 | `sensor.{pool}_chemistry_actions` | Chemistry actions | -- | Number of chemistry-related actions (excludes filtration). See details below. |
 | `sensor.{pool}_active_treatments` | Active treatments | -- | Number of currently active chemical treatments. See [Chemistry Tracking](chemistry-tracking.md) for details. |
 | `sensor.{pool}_safe_at` | Safe to swim at | -- | Timestamp (`timestamp` device class) indicating when the pool will be safe for swimming after treatments. `None` if already safe. |
@@ -50,6 +51,28 @@ The `recommendations` sensor exposes additional detail through its state attribu
 | `critical_count` | integer | Number of high or critical priority recommendations |
 
 These attributes can be used in automations, templates, or Lovelace cards to display detailed recommendation information.
+
+### Problems sensor attributes
+
+The `problems` sensor exposes the raw, severity-ordered list of detected
+water-quality problems through its state attributes. The state itself is the
+problem count (`0` when the pool is healthy).
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `problems` | list of objects | One entry per detected problem, ordered by severity (most severe first). |
+| `worst_severity` | string | Highest severity present, one of `ok`, `low`, `medium`, `critical`. `ok` when the list is empty. |
+
+Each entry in `problems` has the following shape:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `code` | string | Machine-readable identifier, e.g. `"ph_too_high"`. |
+| `severity` | string | One of `low`, `medium`, `critical`. |
+| `metric` | string or null | The chemistry metric affected (`ph`, `orp`, `chlorine`, ...) or `null`. |
+| `value` | float or null | The measured value that triggered the problem. |
+| `expected_range` | list of two floats or null | `[minimum, maximum]` acceptable range. |
+| `message` | string | Human-readable description of the problem. |
 
 ### Chemistry actions sensor attributes
 

--- a/tests/test_sensor_problems.py
+++ b/tests/test_sensor_problems.py
@@ -1,0 +1,158 @@
+"""Tests for the ``problems`` sensor entity."""
+
+from __future__ import annotations
+
+import pytest
+
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.poolman.coordinator import PoolmanCoordinator
+from custom_components.poolman.domain.analysis import AnalysisResult
+from custom_components.poolman.domain.model import Pool, PoolMode, PoolReading, PoolState
+from custom_components.poolman.domain.problem import MetricName, Problem, Severity
+from custom_components.poolman.sensor import _problem_to_dict, _problems_attrs
+from tests.conftest import setup_mock_states
+
+ENTITY_ID = "sensor.test_pool_problems"
+
+
+@pytest.fixture
+async def setup_entry(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> PoolmanCoordinator:
+    """Set up the integration with good (in-range) sensor states."""
+    mock_config_entry.add_to_hass(hass)
+    setup_mock_states(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    return mock_config_entry.runtime_data
+
+
+def _set_bad_states(hass: HomeAssistant) -> None:
+    """Force chemistry out of range to trigger problem rules."""
+    hass.states.async_set("sensor.pool_ph", "8.4")
+    hass.states.async_set("sensor.pool_orp", "500.0")
+    hass.states.async_set("sensor.pool_temperature", "30.0")
+
+
+class TestProblemsSensorIntegration:
+    """End-to-end coverage through the HA state machine."""
+
+    async def test_entity_registered(
+        self, hass: HomeAssistant, setup_entry: PoolmanCoordinator
+    ) -> None:
+        state = hass.states.get(ENTITY_ID)
+        assert state is not None
+
+    async def test_no_problems_with_good_readings(
+        self, hass: HomeAssistant, setup_entry: PoolmanCoordinator
+    ) -> None:
+        state = hass.states.get(ENTITY_ID)
+        assert state is not None
+        # The state must mirror the analysis pipeline's problem count exactly.
+        expected = len(setup_entry.data.analysis_result.problems)
+        assert int(state.state) == expected
+        assert len(state.attributes["problems"]) == expected
+        if expected == 0:
+            assert state.attributes["worst_severity"] == "ok"
+        else:
+            assert state.attributes["worst_severity"] in {"low", "medium", "critical"}
+
+    async def test_problems_exposed_with_bad_readings(
+        self, hass: HomeAssistant, setup_entry: PoolmanCoordinator
+    ) -> None:
+        _set_bad_states(hass)
+        await setup_entry.async_refresh()
+        await hass.async_block_till_done()
+
+        state = hass.states.get(ENTITY_ID)
+        assert state is not None
+        count = int(state.state)
+        assert count > 0
+
+        problems = state.attributes["problems"]
+        assert len(problems) == count
+        # Every entry exposes the documented schema with primitive types.
+        for entry in problems:
+            assert set(entry) == {
+                "code",
+                "severity",
+                "metric",
+                "value",
+                "expected_range",
+                "message",
+            }
+            assert isinstance(entry["code"], str)
+            assert isinstance(entry["severity"], str)
+            assert entry["severity"] in {"low", "medium", "critical"}
+            assert entry["metric"] is None or isinstance(entry["metric"], str)
+            assert entry["expected_range"] is None or isinstance(entry["expected_range"], list)
+
+        # Severity descending order: CRITICAL > MEDIUM > LOW.
+        order = {"critical": 3, "medium": 2, "low": 1}
+        ranks = [order[p["severity"]] for p in problems]
+        assert ranks == sorted(ranks, reverse=True)
+        assert state.attributes["worst_severity"] == problems[0]["severity"]
+
+
+class TestProblemsAttrsHelper:
+    """Direct coverage of the pure helper for deterministic ordering."""
+
+    def _state(self, *problems: Problem) -> PoolState:
+        return PoolState(
+            mode=PoolMode.ACTIVE,
+            pool=Pool(name="t", volume_m3=10.0, pump_flow_m3h=5.0),
+            reading=PoolReading(),
+            analysis_result=AnalysisResult(problems=list(problems)),
+        )
+
+    def test_empty_problems_yields_ok(self) -> None:
+        attrs = _problems_attrs(self._state())
+        assert attrs == {"problems": [], "worst_severity": "ok"}
+
+    def test_orders_by_severity_descending(self) -> None:
+        low = Problem(code="a_low", message="m", severity=Severity.LOW)
+        medium = Problem(code="b_med", message="m", severity=Severity.MEDIUM)
+        critical = Problem(code="c_crit", message="m", severity=Severity.CRITICAL)
+
+        attrs = _problems_attrs(self._state(low, critical, medium))
+        codes = [p["code"] for p in attrs["problems"]]
+        assert codes == ["c_crit", "b_med", "a_low"]
+        assert attrs["worst_severity"] == "critical"
+
+    def test_worst_severity_reflects_highest(self) -> None:
+        low = Problem(code="a", message="m", severity=Severity.LOW)
+        medium = Problem(code="b", message="m", severity=Severity.MEDIUM)
+
+        assert _problems_attrs(self._state(low))["worst_severity"] == "low"
+        assert _problems_attrs(self._state(low, medium))["worst_severity"] == "medium"
+
+    def test_problem_to_dict_serializes_primitives(self) -> None:
+        problem = Problem(
+            code="ph_too_high",
+            message="pH too high",
+            severity=Severity.MEDIUM,
+            metric=MetricName.PH,
+            value=8.4,
+            expected_range=(7.0, 7.6),
+        )
+        assert _problem_to_dict(problem) == {
+            "code": "ph_too_high",
+            "severity": "medium",
+            "metric": "ph",
+            "value": 8.4,
+            "expected_range": [7.0, 7.6],
+            "message": "pH too high",
+        }
+
+    def test_problem_to_dict_handles_optional_fields(self) -> None:
+        problem = Problem(
+            code="generic",
+            message="m",
+            severity=Severity.LOW,
+        )
+        result = _problem_to_dict(problem)
+        assert result["metric"] is None
+        assert result["value"] is None
+        assert result["expected_range"] is None


### PR DESCRIPTION
Exposes the problems detected by `analyze_pool()` as a dedicated Home Assistant sensor so automations, templates, and dashboards can react to water-quality issues without diving into developer tools.

The new `sensor.{pool}_problems` entity reports:

- **state**: number of detected problems (`0` when healthy)
- **`problems`**: list of problems ordered by severity (most severe first), each carrying `code`, `severity`, `metric`, `value`, `expected_range`, and `message` as primitive JSON-safe values
- **`worst_severity`**: `"ok" | "low" | "medium" | "critical"`

Translations added in English and French, and the entity is documented in `docs/entities.md`.

Note: severity values follow the existing `Severity` StrEnum (`low` / `medium` / `critical`) merged in #109, not the wording in the original issue (`info` / `warning`).

Closes #99