### PR TITLE
feat(status): add global pool status sensor

### DIFF
--- a/custom_components/poolman/domain/model.py
+++ b/custom_components/poolman/domain/model.py
@@ -31,6 +31,18 @@ from .recommendation import (
 )
 
 
+class PoolStatus(StrEnum):
+    """Global pool status aggregating worst problem severity.
+
+    Used by ``sensor.pool_<name>_status`` to provide a single,
+    traffic-light-style indicator of overall pool health.
+    """
+
+    OK = "ok"
+    WARNING = "warning"
+    CRITICAL = "critical"
+
+
 class PoolShape(StrEnum):
     """Pool shape types."""
 
@@ -455,6 +467,26 @@ class PoolState(BaseModel):
         safety periods (e.g., recent shock treatment).
         """
         return len(self.critical_recommendations) == 0 and self.swimming_safe
+
+    @property
+    def status(self) -> PoolStatus:
+        """Return the global pool status based on the worst problem severity.
+
+        Maps the latest :attr:`AnalysisResult.problems` to a three-state
+        traffic-light value:
+
+        - :attr:`PoolStatus.CRITICAL` if any problem has
+          :attr:`Severity.CRITICAL`.
+        - :attr:`PoolStatus.WARNING` if any problem has
+          :attr:`Severity.MEDIUM` or :attr:`Severity.LOW`.
+        - :attr:`PoolStatus.OK` if no problems are detected.
+        """
+        problems = self.analysis_result.problems
+        if any(p.severity is Severity.CRITICAL for p in problems):
+            return PoolStatus.CRITICAL
+        if problems:
+            return PoolStatus.WARNING
+        return PoolStatus.OK
 
     @property
     def action_required(self) -> bool:

--- a/custom_components/poolman/icons.json
+++ b/custom_components/poolman/icons.json
@@ -1,0 +1,14 @@
+{
+  "entity": {
+    "sensor": {
+      "status": {
+        "default": "mdi:pool",
+        "state": {
+          "ok": "mdi:check-circle",
+          "warning": "mdi:alert",
+          "critical": "mdi:alert-octagon"
+        }
+      }
+    }
+  }
+}

--- a/custom_components/poolman/sensor.py
+++ b/custom_components/poolman/sensor.py
@@ -27,6 +27,8 @@ from .domain.model import (
     ChemistryStatus,
     ParameterReport,
     PoolState,
+    PoolStatus,
+    Severity,
     format_treatment_spoon,
 )
 from .entity import PoolmanEntity
@@ -98,6 +100,7 @@ def _status_with_source(
 
 
 _CHEMISTRY_STATUS_OPTIONS: list[str] = list(ChemistryStatus)
+_POOL_STATUS_OPTIONS: list[str] = list(PoolStatus)
 
 
 def _chemistry_actions_attrs(state: PoolState) -> dict[str, Any]:
@@ -348,6 +351,24 @@ SENSOR_DESCRIPTIONS: tuple[PoolmanSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.TIMESTAMP,
         icon="mdi:shield-check",
         value_fn=lambda state: state.safe_at,
+    ),
+    PoolmanSensorEntityDescription(
+        key="status",
+        translation_key="status",
+        device_class=SensorDeviceClass.ENUM,
+        options=_POOL_STATUS_OPTIONS,
+        value_fn=lambda state: state.status,
+        extra_attrs_fn=lambda state: {
+            "problem_count": len(state.analysis_result.problems),
+            "critical_count": sum(
+                1 for p in state.analysis_result.problems if p.severity is Severity.CRITICAL
+            ),
+            "worst_severity": (
+                state.analysis_result.problems[0].severity
+                if state.analysis_result.problems
+                else None
+            ),
+        },
     ),
 )
 

--- a/custom_components/poolman/strings.json
+++ b/custom_components/poolman/strings.json
@@ -260,6 +260,14 @@
       "chemistry_actions": {
         "name": "Chemistry actions"
       },
+      "status": {
+        "name": "Status",
+        "state": {
+          "ok": "OK",
+          "warning": "Warning",
+          "critical": "Critical"
+        }
+      },
       "ph_status": {
         "name": "pH status",
         "state": {

--- a/custom_components/poolman/translations/en.json
+++ b/custom_components/poolman/translations/en.json
@@ -260,6 +260,14 @@
       "chemistry_actions": {
         "name": "Chemistry actions"
       },
+      "status": {
+        "name": "Status",
+        "state": {
+          "ok": "OK",
+          "warning": "Warning",
+          "critical": "Critical"
+        }
+      },
       "ph_status": {
         "name": "pH status",
         "state": {

--- a/custom_components/poolman/translations/fr.json
+++ b/custom_components/poolman/translations/fr.json
@@ -260,6 +260,14 @@
       "chemistry_actions": {
         "name": "Actions chimie"
       },
+      "status": {
+        "name": "État",
+        "state": {
+          "ok": "OK",
+          "warning": "Attention",
+          "critical": "Critique"
+        }
+      },
       "ph_status": {
         "name": "Statut pH",
         "state": {

--- a/tests/domain/test_model.py
+++ b/tests/domain/test_model.py
@@ -20,6 +20,7 @@ from custom_components.poolman.domain.model import (
     ParameterReport,
     Pool,
     PoolState,
+    PoolStatus,
     RecommendationPriority,
     RecommendationType,
     SpoonSize,
@@ -29,7 +30,7 @@ from custom_components.poolman.domain.model import (
     format_spoon_text,
     format_treatment_spoon,
 )
-from custom_components.poolman.domain.problem import Severity
+from custom_components.poolman.domain.problem import Problem, Severity
 from custom_components.poolman.domain.recommendation import Recommendation, Treatment
 
 
@@ -310,6 +311,68 @@ class TestActionKind:
     def test_recommendation_kind_requirement(self) -> None:
         rec = _make_rec(kind=ActionKind.REQUIREMENT)
         assert rec.kind == ActionKind.REQUIREMENT
+
+
+def _make_problem(severity: Severity, code: str = "test") -> Problem:
+    """Build a minimal Problem with the given severity."""
+    return Problem(code=code, message=f"{code} problem", severity=severity)
+
+
+class TestPoolStatusEnum:
+    """Tests for the PoolStatus enum used by the global status sensor."""
+
+    def test_values(self) -> None:
+        assert PoolStatus.OK == "ok"
+        assert PoolStatus.WARNING == "warning"
+        assert PoolStatus.CRITICAL == "critical"
+
+    def test_list_order(self) -> None:
+        assert list(PoolStatus) == [PoolStatus.OK, PoolStatus.WARNING, PoolStatus.CRITICAL]
+
+
+class TestPoolStateStatus:
+    """Tests for PoolState.status global rollup property."""
+
+    def test_no_problems_is_ok(self) -> None:
+        state = PoolState()
+        assert state.status is PoolStatus.OK
+
+    def test_only_low_is_warning(self) -> None:
+        state = PoolState(analysis_result=AnalysisResult(problems=[_make_problem(Severity.LOW)]))
+        assert state.status is PoolStatus.WARNING
+
+    def test_only_medium_is_warning(self) -> None:
+        state = PoolState(analysis_result=AnalysisResult(problems=[_make_problem(Severity.MEDIUM)]))
+        assert state.status is PoolStatus.WARNING
+
+    def test_mixed_low_and_medium_is_warning(self) -> None:
+        state = PoolState(
+            analysis_result=AnalysisResult(
+                problems=[
+                    _make_problem(Severity.LOW, "low"),
+                    _make_problem(Severity.MEDIUM, "med"),
+                ]
+            )
+        )
+        assert state.status is PoolStatus.WARNING
+
+    def test_single_critical_is_critical(self) -> None:
+        state = PoolState(
+            analysis_result=AnalysisResult(problems=[_make_problem(Severity.CRITICAL)])
+        )
+        assert state.status is PoolStatus.CRITICAL
+
+    def test_mixed_with_critical_is_critical(self) -> None:
+        state = PoolState(
+            analysis_result=AnalysisResult(
+                problems=[
+                    _make_problem(Severity.LOW, "low"),
+                    _make_problem(Severity.MEDIUM, "med"),
+                    _make_problem(Severity.CRITICAL, "crit"),
+                ]
+            )
+        )
+        assert state.status is PoolStatus.CRITICAL
 
 
 class TestPoolStateChemistryActions:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,4 +1,4 @@
-"""Tests for the Pool Manager sensor platform — recommendations entity."""
+"""Tests for the Pool Manager sensor platform."""
 
 from __future__ import annotations
 
@@ -6,9 +6,12 @@ from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.poolman.coordinator import PoolmanCoordinator
+from custom_components.poolman.domain.model import PoolStatus
+from custom_components.poolman.domain.problem import Severity
 from tests.conftest import setup_mock_states
 
 RECOMMENDATIONS_ENTITY_ID = "sensor.test_pool_recommendations"
+STATUS_ENTITY_ID = "sensor.test_pool_status"
 
 # Keys expected in every serialized recommendation. Aligned with the contract
 # documented in issue #98 (extended to include all domain fields).
@@ -134,3 +137,79 @@ class TestRecommendationsSensor:
         assert updated.attributes["recommendations"] == [
             r.to_dict() for r in coordinator.data.recommendations
         ]
+
+
+class TestPoolStatusSensor:
+    """Tests for ``sensor.<pool>_status`` global status sensor (issue #102)."""
+
+    async def test_entity_registered_with_enum_metadata(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """The status entity exposes ``device_class=enum`` and the three options."""
+        await _setup_integration(hass, mock_config_entry)
+        state = hass.states.get(STATUS_ENTITY_ID)
+        assert state is not None
+        assert state.attributes["device_class"] == "enum"
+        assert state.attributes["options"] == [
+            PoolStatus.OK.value,
+            PoolStatus.WARNING.value,
+            PoolStatus.CRITICAL.value,
+        ]
+
+    async def test_state_matches_pool_state_status(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """The entity state mirrors the computed ``PoolState.status``."""
+        coordinator = await _setup_integration(hass, mock_config_entry)
+        state = hass.states.get(STATUS_ENTITY_ID)
+        assert state is not None
+        assert state.state == coordinator.data.status.value
+
+    async def test_attributes_reflect_problems(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """``problem_count``/``critical_count``/``worst_severity`` reflect analysis output."""
+        coordinator = await _setup_integration(hass, mock_config_entry)
+        problems = coordinator.data.analysis_result.problems
+
+        state = hass.states.get(STATUS_ENTITY_ID)
+        assert state is not None
+        assert state.attributes["problem_count"] == len(problems)
+        assert state.attributes["critical_count"] == sum(
+            1 for p in problems if p.severity is Severity.CRITICAL
+        )
+        if problems:
+            assert state.attributes["worst_severity"] == problems[0].severity
+        else:
+            assert state.attributes["worst_severity"] is None
+
+    async def test_escalates_when_ph_goes_critical(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """A strongly out-of-range pH escalates the global status."""
+        coordinator = await _setup_integration(hass, mock_config_entry)
+        initial = hass.states.get(STATUS_ENTITY_ID)
+        assert initial is not None
+        initial_state = initial.state
+
+        hass.states.async_set("sensor.pool_ph", "5.5")
+        await coordinator.async_request_refresh()
+        await hass.async_block_till_done()
+
+        new_state = hass.states.get(STATUS_ENTITY_ID)
+        assert new_state is not None
+        # State must be at least as severe as the initial one and remain a valid enum value.
+        assert new_state.state in {
+            PoolStatus.OK.value,
+            PoolStatus.WARNING.value,
+            PoolStatus.CRITICAL.value,
+        }
+        # Worst severity present in the problem list.
+        assert new_state.state == coordinator.data.status.value
+        # The bad pH should not lower the severity.
+        order = {
+            PoolStatus.OK.value: 0,
+            PoolStatus.WARNING.value: 1,
+            PoolStatus.CRITICAL.value: 2,
+        }
+        assert order[new_state.state] >= order[initial_state]


### PR DESCRIPTION
Adds a global `sensor.pool_<name>_status` enum entity that summarizes the worst-severity problem from the latest analysis as a single traffic-light value (`ok` / `warning` / `critical`).

The status is exposed as an HA enum sensor with `device_class: enum`, making it usable in automations (e.g. notify on transition to `critical`) and ready to power the upcoming pool overview Lovelace card (#104).

A new `icons.json` provides per-state icons so the entity glyph reflects severity at a glance. The mapping from `Severity` to `PoolStatus` lives on `PoolState.status` to mirror the existing `water_ok` pattern and keep the logic easy to unit-test.

Extra attributes (`problem_count`, `critical_count`, `worst_severity`) expose details for automation conditions and the future card.

Closes #102