### PR TITLE
fix(sensor): remove duplicate Severity import

### DIFF
--- a/custom_components/poolman/sensor.py
+++ b/custom_components/poolman/sensor.py
@@ -31,7 +31,7 @@ from .domain.model import (
     Severity,
     format_treatment_spoon,
 )
-from .domain.problem import Problem, Severity
+from .domain.problem import Problem
 from .entity import PoolmanEntity
 
 


### PR DESCRIPTION
Severity was imported twice in `sensor.py` — once via `.domain.model` (the canonical re-export) and once directly from `.domain.problem`. The second import shadowed the first and tripped ruff F811.

Drop the redundant import; `Problem` continues to be imported from `.domain.problem`.