### PR TITLE
feat(services): make poolman.analyze trigger an immediate, non-debounced refresh

### DIFF
--- a/custom_components/poolman/__init__.py
+++ b/custom_components/poolman/__init__.py
@@ -663,12 +663,12 @@ def _async_register_services(hass: HomeAssistant) -> None:
     async def async_handle_analyze(call: ServiceCall) -> None:
         """Handle the ``analyze`` service call.
 
-        Triggers an immediate coordinator refresh, which re-runs
-        :func:`analyze_pool` (#97) and pushes the updated
+        Triggers an immediate, non-debounced coordinator refresh, which
+        re-runs :func:`analyze_pool` (#97) and pushes the updated
         :class:`AnalysisResult` to all listening entities (#98, #99, #102).
         """
         coordinator = _resolve_device_coordinator(call.data["device_id"])
-        await coordinator.async_request_refresh()
+        await coordinator.async_refresh()
 
     hass.services.async_register(
         DOMAIN,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1173,6 +1173,26 @@ class TestAnalysisResult:
         coordinator = PoolmanCoordinator(hass, mock_config_entry)
         assert coordinator.analysis_result is None
 
+    async def test_analysis_result_populated_with_no_sensors(
+        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
+    ) -> None:
+        """analysis_result must be a valid AnalysisResult even when no sensor states exist.
+
+        Covers issue #101 acceptance criteria: "No crash if analysis returns empty
+        results" and "Analysis runs correctly after HA restart" (first refresh after
+        setup, with sensors not yet available).
+        """
+        from custom_components.poolman.domain.analysis import AnalysisResult
+
+        mock_config_entry.add_to_hass(hass)
+        # Intentionally do NOT call setup_mock_states: simulates a fresh HA
+        # boot where sensor states have not yet been published.
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        coordinator: PoolmanCoordinator = mock_config_entry.runtime_data
+        assert isinstance(coordinator.analysis_result, AnalysisResult)
+
 
 class TestActionTracking:
     """Tests for coordinator action recording and persistence (issue #19)."""

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1275,7 +1275,7 @@ class TestAnalyzeServiceHandler:
     async def test_analyze_triggers_refresh(
         self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
     ) -> None:
-        """The analyze service should call async_request_refresh on the coordinator."""
+        """The analyze service should call async_refresh on the coordinator (non-debounced)."""
         from unittest.mock import AsyncMock, patch
 
         from homeassistant.helpers import device_registry as dr
@@ -1291,7 +1291,7 @@ class TestAnalyzeServiceHandler:
         )
         assert device is not None
 
-        with patch.object(coordinator, "async_request_refresh", new=AsyncMock()) as mock_refresh:
+        with patch.object(coordinator, "async_refresh", new=AsyncMock()) as mock_refresh:
             await hass.services.async_call(
                 DOMAIN,
                 SERVICE_ANALYZE,


### PR DESCRIPTION
Finalizes issue #101 (Trigger and scheduling of pool analysis).

Most of the issue was already covered by #97 (analyze_pool pipeline) and #100 (services): analysis runs on every coordinator cycle and the `poolman.analyze` service is registered. The remaining gap was that the manual trigger used the debounced `async_request_refresh()`, which contradicts the issue requirement that manual triggers must be immediate and non-debounced.

The service now awaits `coordinator.async_refresh()` so callers (automations, Lovelace "Analyze now" button in #107) get a fresh `AnalysisResult` before the service call returns.

A regression test is added to ensure `coordinator.analysis_result` is populated even when no sensor states are available at first refresh.

Closes #101